### PR TITLE
Added --sloppy option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build
 dist
 node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The main features:
 
-* Writes in a `CHANGELOG.md` from merged GitHub pull requests since the last tag. This works by 
+* Writes in a `CHANGELOG.md` from merged GitHub pull requests since the last tag. This works by
     * first getting a list of all tags
     * than removing all tags that are not compatible to [semver versioning](http://semver.org/)
     * sort the tags
@@ -70,9 +70,9 @@ As `pr-log` reads repository information from your project you have to add the `
 
 ## Usage
 
-To create or update your changelog run 
+To create or update your changelog run
 
-```pr-log <version-number>``` where `version-number` is the name of this release
+```pr-log [options] <version-number>``` where `version-number` is the name of this release
 
 Example:
 
@@ -95,6 +95,12 @@ Given the following setup:
 
 * Fix some spelling mistakes in documentation. (#22)
 ```
+
+### Options
+
+#### --sloppy
+
+The `--sloppy` option defaults to false. When set, it allows `pr-log` to generate a changelog even when you are not on the `master` branch. This should not be used in production!
 
 ### Correct usage makes a clean and complete changelog
 

--- a/bin/pr-log.js
+++ b/bin/pr-log.js
@@ -6,7 +6,11 @@ import cli from '../cli';
 
 program
     .version(config.version)
+    .option('--sloppy', 'Skip ensuring clean local git state.')
     .usage('<version-number>')
     .parse(process.argv);
 
-cli.run(program.args[0], program.args[1]).done();
+const options = { sloppy: program.sloppy };
+cli
+    .run(program.args[0], options)
+    .done();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,7 +17,7 @@ function stripTrailingEmptyLine(text) {
 }
 
 export default {
-    run: (newVersionNumber) => {
+    run: (newVersionNumber, options) => {
         const packageConfig = require(path.join(process.cwd(), 'package.json'));
         const githubRepo = getGithubRepo(packageConfig.repository.url);
         const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
@@ -26,7 +26,11 @@ export default {
             throw new Error('version-number not specified');
         }
 
-        return Promise.try(ensureCleanLocalGitState.bind(null, githubRepo))
+        const preconditions = options.sloppy ?
+            Promise.resolve(true) :
+            Promise.try(ensureCleanLocalGitState.bind(null, githubRepo));
+
+        return preconditions
             .then(getMergedPullRequests.bind(null, githubRepo))
             .then(createChangelog.bind(null, newVersionNumber))
             .then(stripTrailingEmptyLine)

--- a/test/unit/lib/cliSpec.js
+++ b/test/unit/lib/cliSpec.js
@@ -23,6 +23,7 @@ describe('CLI', function () {
         },
         prepend: prependFile
     };
+    const options = { sloppy: false };
 
     const cli = proxyquire('../../../lib/cli', requireStubs).default;
 
@@ -31,6 +32,7 @@ describe('CLI', function () {
     });
 
     afterEach(function () {
+        ensureCleanLocalGitState.resolves();
         ensureCleanLocalGitState.reset();
         getMergedPullRequests.reset();
         createChangelog.reset();
@@ -42,12 +44,27 @@ describe('CLI', function () {
         expect(cli.run).to.throw('version-number not specified');
     });
 
+    it('should throw if the repository is dirty', function () {
+        ensureCleanLocalGitState.rejects('Local copy is not clean');
+        expect(cli.run('1.0 ', options)).to.be.rejectedWith('Local copy is not clean');
+    });
+
+    it('should not throw if the repository is dirty', function () {
+        ensureCleanLocalGitState.rejects('Local copy is not clean');
+        createChangelog.returns('sloppy changelog');
+        return cli.run('1.0 ', { sloppy: true })
+          .then(function () {
+              expect(prependFile).to.have.been.calledOnce;
+              expect(prependFile).to.have.been.calledWith('/foo/CHANGELOG.md', 'sloppy changelog');
+          });
+    });
+
     it('should report the generated changelog', function () {
         const expectedGithubRepo = 'foo/bar';
 
         createChangelog.returns('generated changelog');
 
-        return cli.run('1.0.0')
+        return cli.run('1.0.0', options)
             .then(function () {
                 expect(ensureCleanLocalGitState).to.have.been.calledOnce;
                 expect(ensureCleanLocalGitState).to.have.been.calledWith(expectedGithubRepo);
@@ -66,7 +83,7 @@ describe('CLI', function () {
     it('should strip trailing empty lines from the generated changelog', function () {
         createChangelog.returns('generated\nchangelog\nwith\n\na\nlot\n\nof\nempty\nlines\n\n');
 
-        return cli.run('1.0.0')
+        return cli.run('1.0.0', options)
             .then(function () {
                 expect(prependFile).to.have.been
                     .calledWith('/foo/CHANGELOG.md', 'generated\nchangelog\nwith\n\na\nlot\n\nof\nempty\nlines\n');


### PR DESCRIPTION
The `--sloppy` option allows you to create a CHANGELOG without checking your local state. This is useful for the first-time user experience when, for example, you might be editing your CHANGELOG in a non-master branch for feedback (e.g. https://github.com/storybooks/storybook/pull/1047)

NOTE: I couldn't get the code coverage to work properly. The test runner says I am at 100% coverage, but the coverage test still fails. Any help would be much appreciated here!