### PR TITLE
Skip prerelease tags and upgrade semver

### DIFF
--- a/lib/getMergedPullRequests.js
+++ b/lib/getMergedPullRequests.js
@@ -7,7 +7,7 @@ function getLatestVersionTag() {
     return git('tag --list')
         .then(function (result) {
             const tags = result.split('\n');
-            const versionTags = tags.filter(semver.valid);
+            const versionTags = tags.filter((tag) => semver.valid(tag) && !semver.prerelease(tag));
             const orderedVersionTags = versionTags.sort(semver.compare);
 
             return orderedVersionTags[orderedVersionTags.length - 1];

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
         "bluebird": "3.4.0",
         "commander": "2.9.0",
         "git-promise": "0.3.0",
-        "ramda": "0.21.0",
-        "moment": "2.13.0",
         "git-url-parse": "6.0.3",
+        "moment": "2.13.0",
         "parse-github-repo-url": "1.3.0",
         "prepend": "1.0.2",
-        "semver": "5.1.0",
-        "restling": "0.9.1"
+        "ramda": "0.21.0",
+        "restling": "0.9.1",
+        "semver": "^5.3.0"
     },
     "devDependencies": {
         "babel-cli": "6.9.0",

--- a/test/unit/lib/getMergedPullRequestsSpec.js
+++ b/test/unit/lib/getMergedPullRequestsSpec.js
@@ -64,6 +64,17 @@ describe('getMergedPullRequests', function () {
                     expect(git).to.have.been.calledWith(expectedGitLogCommand);
                 });
         });
+
+        it('should ignore prerelease versions', function () {
+            const expectedGitLogCommand = 'log --no-color --pretty=format:"%s (%b)" --merges 2.0.0..HEAD';
+
+            gitTag.resolves('1.0.0\n0.0.0\n0.7.5\n2.0.0\n0.2.5\n3.0.0-alpha.1');
+
+            return getMergedPullRequests(anyRepo)
+                .then(function () {
+                    expect(git).to.have.been.calledWith(expectedGitLogCommand);
+                });
+        });
     });
 
     it('should extract id, title and label for merged pull requests', function () {


### PR DESCRIPTION
It’s convention not to include release notes for prerelease tags (e.g.
alpha, rc, etc.), so we should ignore them when computing the previous
release tag. This also requires an upgrade of the semver library.