### PR TITLE
Don’t write stacktraces to stderr per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Given the following setup:
 
 The `--sloppy` option defaults to false. When set, it allows `pr-log` to generate a changelog even when you are not on the `master` branch. This should not be used in production!
 
+#### --trace
+
+When enabled this option outputs the stacktrace of an error additionally to the error message to `stderr`.
+
 ### Correct usage makes a clean and complete changelog
 
 If you want your changelog to be complete and clean you have to follow these rules:

--- a/bin/pr-log.js
+++ b/bin/pr-log.js
@@ -17,6 +17,7 @@ import getPullRequestLabel from '../getPullRequestLabel';
 program
     .version(config.version)
     .option('--sloppy', 'Skip ensuring clean local git state.')
+    .option('--trace', 'Show stack traces for any error.')
     .usage('<version-number>')
     .parse(process.argv);
 
@@ -39,7 +40,13 @@ const cliAgent = createCliAgent(dependencies);
 cliAgent
     .run(program.args[0], options, dependencies)
     .catch((error) => {
+        let message = `Error: ${error.message}`;
+
+        if (program.trace) {
+            message = error.stack;
+        }
+
         // eslint-disable-next-line no-console, no-warning-comments
-        console.error(error);
+        console.error(message);
         process.exitCode = 1;
     });


### PR DESCRIPTION
There is a new option `--trace` which makes to old behavior available.