### PR TITLE
Remove bluebird dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "license": "MIT",
     "dependencies": {
         "@octokit/rest": "^15.1.7",
-        "bluebird": "3.5.1",
         "commander": "2.15.0",
         "git-promise": "0.3.1",
         "git-url-parse": "8.1.0",


### PR DESCRIPTION
Bluebird wasn’t used anymore but was still listed as a dependency.