### PR TITLE
Support cherry-pick changelogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ The `--sloppy` option defaults to false. When set, it allows `pr-log` to generat
 
 When enabled this option outputs the stacktrace of an error additionally to the error message to `stderr`.
 
+#### --cherry-pick
+
+When enabled this option lists out cherry-picks to the log instead of PR merges. This can be useful for publishing flows where you are simultaneously maintaining stable and pre-release branches and want to generate changelogs of cherry picks in one direction or another.
+
 ### Correct usage makes a clean and complete changelog
 
 If you want your changelog to be complete and clean you have to follow these rules:

--- a/bin/pr-log.js
+++ b/bin/pr-log.js
@@ -23,7 +23,7 @@ program
     .parse(process.argv);
 
 const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
-const { sloppy, cherryPick } = program
+const { sloppy, cherryPick } = program;
 const options = { sloppy, cherryPick, changelogPath };
 const findRemoteAlias = findRemoteAliasFactory({ git });
 const githubClient = createGithubClient();

--- a/bin/pr-log.js
+++ b/bin/pr-log.js
@@ -18,11 +18,13 @@ program
     .version(config.version)
     .option('--sloppy', 'Skip ensuring clean local git state.')
     .option('--trace', 'Show stack traces for any error.')
+    .option('--cherry-pick', 'Use cherry-picks instead of PR merges.')
     .usage('<version-number>')
     .parse(process.argv);
 
 const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
-const options = { sloppy: program.sloppy, changelogPath };
+const { sloppy, cherryPick } = program
+const options = { sloppy, cherryPick, changelogPath };
 const findRemoteAlias = findRemoteAliasFactory({ git });
 const githubClient = createGithubClient();
 const getMergedPullRequests = getMergedPullRequestsFactory({ githubClient, git, getPullRequestLabel });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,7 +41,7 @@ export default function createCliAgent(dependencies) {
             await ensureCleanLocalGitState(githubRepo);
         }
 
-        const pullRequests = await getMergedPullRequests(githubRepo, validLabels);
+        const pullRequests = await getMergedPullRequests(githubRepo, validLabels, options.cherryPick);
         const changelog = createChangelog(newVersionNumber, validLabels, pullRequests, githubRepo);
 
         return stripTrailingEmptyLine(changelog);

--- a/lib/getMergedPullRequests.js
+++ b/lib/getMergedPullRequests.js
@@ -17,8 +17,9 @@ export default (dependencies) => {
             });
     }
 
-    function getPullRequests(fromTag) {
-        return git(`log --no-color --pretty=format:"%s (%b)" --merges ${fromTag}..HEAD`)
+    function getPullRequests(fromTag, cherryPick) {
+        const mergeType = cherryPick ? 'cherry-pick' : 'merges';
+        return git(`log --no-color --pretty=format:"%s (%b)" --${mergeType} ${fromTag}..HEAD`)
             .then((result) => {
                 const mergeCommits = result.replace(/[\r\n]+\)/g, ')').split('\n');
 
@@ -43,9 +44,9 @@ export default (dependencies) => {
         return Promise.all(promises);
     }
 
-    return async function getMergedPullRequests(githubRepo, validLabels) {
+    return async function getMergedPullRequests(githubRepo, validLabels, cherryPick) {
         const latestVersionTag = await getLatestVersionTag();
-        const pullRequests = await getPullRequests(latestVersionTag);
+        const pullRequests = await getPullRequests(latestVersionTag, cherryPick);
         const pullRequestsWithLabels = await extendWithLabel(githubRepo, validLabels, pullRequests);
 
         return pullRequestsWithLabels;


### PR DESCRIPTION
In storybook we use a [workflow](https://gist.github.com/shilman/0b5a4011f8a105a36b657a79736733df) where:
 - `next` is the default branch and we merge into there and release alphas on it every week
 - `master` is the stable branch and we cherry-pick changes from `next` and release patches every week

This flag allows us to generate alpha changelogs (merges) or stable changelogs (cherry-picked merges).