### PR TITLE
Introduce "--stdout" option to print the changelog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "ava": "5.3.1",
                 "c8": "8.0.1",
                 "eslint": "8.56.0",
+                "loglevel": "1.8.1",
                 "prettier": "3.1.1",
                 "sinon": "17.0.1",
                 "typescript": "5.3.3"
@@ -4678,6 +4679,19 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz",
             "integrity": "sha512-A9SzX4hMKWS25MyalwcOnNoplyHbkNVsjidhTp8ru0Sj23wY9GWBKS8gAIGDSAqeWjIjvE4KBEl24XXAs+v4wQ=="
+        },
+        "node_modules/loglevel": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+            "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
+            }
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "ava": "5.3.1",
         "c8": "8.0.1",
         "eslint": "8.56.0",
+        "loglevel": "1.8.1",
         "prettier": "3.1.1",
         "sinon": "17.0.1",
         "typescript": "5.3.3"


### PR DESCRIPTION
I'm planning to integrate `pr-log` into [release-it](https://github.com/release-it/release-it). For that to work `release-it` has a setting `git.changelog` that requires to [write a changelog to `stdout`](https://github.com/release-it/release-it/blob/main/docs/changelog.md).

Therefore we should have a `--stdout` option in `pr-log` that prints to `stdout` instead of writing to a `CHANGELOG.md` file.