### PR TITLE
Remove "Unreleased" title when version was not released

### DIFF
--- a/source/lib/create-changelog.test.ts
+++ b/source/lib/create-changelog.test.ts
@@ -14,7 +14,7 @@ const changelogOptionsFactory = Factory.define<ChangelogOptions>(() => {
     };
 });
 
-test('contains "Unreleased" with no version number and the formatted date when version was released', (t) => {
+test('contains no title when version was not released', (t) => {
     const createChangelog = createChangelogFactory({
         getCurrentDate: () => {
             return new Date(0);
@@ -25,10 +25,11 @@ test('contains "Unreleased" with no version number and the formatted date when v
         unreleased: true,
         versionNumber: Maybe.nothing()
     });
-    const changelog = createChangelog(options);
-    const expectedTitle = '## Unreleased (January 1, 1970)';
 
-    t.true(changelog.includes(expectedTitle));
+    const changelog = createChangelog(options);
+    const expected = '';
+
+    t.is(changelog, expected);
 });
 
 test('contains a title with the version number and the formatted date when version was released', (t) => {

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -89,13 +89,24 @@ export function createChangelogFactory(dependencies: Dependencies): CreateChange
     const { getCurrentDate, packageInfo } = dependencies;
     const dateFormat = getConfigValueFromPackageInfo(packageInfo, 'dateFormat', defaultDateFormat);
 
-    return function createChangelog(options) {
-        const { validLabels, mergedPullRequests, githubRepo, unreleased } = options;
-        const groupedPullRequests = groupByLabel(mergedPullRequests);
-        const date = formatDate(getCurrentDate(), dateFormat, { locale: enLocale });
-        const title = unreleased ? `## Unreleased (${date})` : `## ${options.versionNumber.value} (${date})`;
+    function createChangelogTitle(options: ChangelogOptions): string {
+        const { unreleased } = options;
 
-        let changelog = `${title}\n\n`;
+        if (unreleased) {
+            return '';
+        }
+
+        const date = formatDate(getCurrentDate(), dateFormat, { locale: enLocale });
+        const title = `## ${options.versionNumber.value} (${date})`;
+
+        return `${title}\n\n`;
+    }
+
+    return function createChangelog(options) {
+        const { validLabels, mergedPullRequests, githubRepo } = options;
+        const groupedPullRequests = groupByLabel(mergedPullRequests);
+
+        let changelog = createChangelogTitle(options);
 
         for (const [label, displayLabel] of validLabels) {
             const pullRequests = groupedPullRequests[label];


### PR DESCRIPTION
When using [release-it](https://github.com/release-it/release-it) for managing the release and `pr-log` for generating the changelog the title `Unreleased` should not be included because the whole changelog will be used for generating the changelog on GitHub for example. Instead only the merged pull request titles should be used.

Right now it would look like this:

---

![2024-01-14 15 45 55 github com 40f04672d14b](https://github.com/lo1tuma/pr-log/assets/149248/e2ac3d1a-1e91-4cdf-b7e2-935130b42b43)

But it should look like this:

---

![2024-01-14 15 42 27 github com 325b67859f78](https://github.com/lo1tuma/pr-log/assets/149248/52f122c9-c95f-4a86-a541-64b8ecc1bfee)
