### PR TITLE
Add auto-version release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ To create or update your changelog run
 
 `pr-log [options] <version-number>` where `version-number` is the name of this release
 
+You can also run `pr-log --auto-version` to derive the next version number from the labels of merged pull requests since the latest stable semver tag.
+The default bump precedence is:
+
+-   `breaking` -> major
+-   `feature` -> minor
+-   any other valid label -> patch
+
 Example:
 
 Given the following setup:
@@ -140,6 +147,25 @@ When enabled this option outputs the stacktrace of an error additionally to the 
 #### --stdout
 
 This option disables writing the changelog into the file `CHANGELOG.md`. Instead it prints the changelog to `stdout`.
+
+#### --auto-version
+
+This option derives the release version from merged pull request labels since the latest stable semver tag.
+It must not be combined with `--unreleased` or an explicit `version-number`.
+
+You can customize the label-to-version mapping in `package.json`:
+
+```json
+{
+    "pr-log": {
+        "versionBumps": {
+            "major": ["breaking"],
+            "minor": ["feature"],
+            "patch": ["bug", "documentation", "upgrade"]
+        }
+    }
+}
+```
 
 ### Correct usage makes a clean and complete changelog
 

--- a/source/bin/pr-log.ts
+++ b/source/bin/pr-log.ts
@@ -16,6 +16,7 @@ import { createChangelogFactory } from '../lib/create-changelog.ts';
 import { findRemoteAliasFactory } from '../lib/find-remote-alias.ts';
 import { getPullRequestLabel } from '../lib/get-pull-request-label.ts';
 import { createGitCommandRunner } from '../lib/git-command-runner.ts';
+import { determineLatestVersionTag } from '../lib/latest-version-tag.ts';
 
 loglevel.enableAll();
 
@@ -40,6 +41,9 @@ const getMergedPullRequests = getMergedPullRequestsFactory({
     gitCommandRunner,
     getPullRequestLabel
 });
+const getLatestVersionTag = async (): Promise<string> => {
+    return determineLatestVersionTag(await gitCommandRunner.listTags());
+};
 const getCurrentDate = (): Readonly<Date> => {
     return new Date();
 };
@@ -54,6 +58,7 @@ program
     .option('--trace', 'show stack traces for any error', false)
     .option('--default-branch <name>', 'set custom default branch', 'main')
     .option('--stdout', 'output the changelog to stdout instead of writing to CHANGELOG.md', false)
+    .option('--auto-version', 'derive the release version from merged pull request labels', false)
     .option('--unreleased', 'include section for unreleased changes', false)
     .action(async (versionNumber: string | undefined, options: Record<string, unknown>) => {
         isTracingEnabled = options.trace === true;
@@ -75,6 +80,7 @@ program
                         { gitCommandRunner, findRemoteAlias },
                         { defaultBranch }
                     ),
+                    getLatestVersionTag,
                     getMergedPullRequests,
                     createChangelog: createChangelogFactory({ getCurrentDate, packageInfo })
                 };

--- a/source/lib/cli-run-options.test.ts
+++ b/source/lib/cli-run-options.test.ts
@@ -28,6 +28,7 @@ const createCliRunOptionsTestCases = [
         optionsOverrides: { commandOptions: { unreleased: true }, versionNumber: undefined },
         expectedResult: Result.ok<CliRunOptions, InvalidArgumentError>({
             unreleased: true,
+            autoVersion: false,
             versionNumber: Maybe.nothing<string>(),
             sloppy: false,
             changelogPath: '',
@@ -56,6 +57,7 @@ const createCliRunOptionsTestCases = [
         optionsOverrides: { commandOptions: { unreleased: false }, versionNumber: '1.2.3' },
         expectedResult: Result.ok<CliRunOptions, InvalidArgumentError>({
             unreleased: false,
+            autoVersion: false,
             versionNumber: Maybe.just('1.2.3') as Just<string>,
             sloppy: false,
             changelogPath: '',
@@ -68,6 +70,7 @@ const createCliRunOptionsTestCases = [
         optionsOverrides: { commandOptions: { unreleased: false, sloppy: true }, versionNumber: '1.2.3' },
         expectedResult: Result.ok<CliRunOptions, InvalidArgumentError>({
             unreleased: false,
+            autoVersion: false,
             versionNumber: Maybe.just('1.2.3') as Just<string>,
             sloppy: true,
             changelogPath: '',
@@ -80,11 +83,41 @@ const createCliRunOptionsTestCases = [
         optionsOverrides: { commandOptions: { unreleased: false, stdout: true }, versionNumber: '1.2.3' },
         expectedResult: Result.ok<CliRunOptions, InvalidArgumentError>({
             unreleased: false,
+            autoVersion: false,
             versionNumber: Maybe.just('1.2.3') as Just<string>,
             sloppy: false,
             changelogPath: '',
             stdout: true
         })
+    },
+    {
+        testName:
+            'createCliRunOptions() returns a Result Ok when "autoVersion" command option is true and no version number was provided',
+        optionsOverrides: { commandOptions: { autoVersion: true }, versionNumber: undefined },
+        expectedResult: Result.ok<CliRunOptions, InvalidArgumentError>({
+            unreleased: false,
+            autoVersion: true,
+            versionNumber: Maybe.nothing<string>(),
+            sloppy: false,
+            changelogPath: '',
+            stdout: false
+        })
+    },
+    {
+        testName:
+            'createCliRunOptions() returns a Result Error when "autoVersion" command option is true and a version number was provided',
+        optionsOverrides: { commandOptions: { autoVersion: true }, versionNumber: '1.2.3' },
+        expectedResult: Result.err<CliRunOptions, InvalidArgumentError>(
+            new InvalidArgumentError('A version number is not allowed when --auto-version was provided')
+        )
+    },
+    {
+        testName:
+            'createCliRunOptions() returns a Result Error when "autoVersion" and "unreleased" command options are both true',
+        optionsOverrides: { commandOptions: { autoVersion: true, unreleased: true }, versionNumber: undefined },
+        expectedResult: Result.err<CliRunOptions, InvalidArgumentError>(
+            new InvalidArgumentError('A version number must not be auto-derived when --unreleased was provided')
+        )
     }
 ] as const;
 

--- a/source/lib/cli-run-options.ts
+++ b/source/lib/cli-run-options.ts
@@ -5,21 +5,32 @@ import { InvalidArgumentError } from 'commander';
 
 type CliRunOptionsUnreleased = {
     readonly unreleased: true;
+    readonly autoVersion: false;
     readonly versionNumber: Nothing<string>;
     readonly changelogPath: string;
     readonly sloppy: boolean;
     readonly stdout: boolean;
 };
 
-type CliRunOptionsReleased = {
+type CliRunOptionsReleasedExplicit = {
     readonly unreleased: false;
+    readonly autoVersion: false;
     readonly versionNumber: Just<string>;
     readonly changelogPath: string;
     readonly sloppy: boolean;
     readonly stdout: boolean;
 };
 
-export type CliRunOptions = CliRunOptionsReleased | CliRunOptionsUnreleased;
+type CliRunOptionsReleasedAuto = {
+    readonly unreleased: false;
+    readonly autoVersion: true;
+    readonly versionNumber: Nothing<string>;
+    readonly changelogPath: string;
+    readonly sloppy: boolean;
+    readonly stdout: boolean;
+};
+
+export type CliRunOptions = CliRunOptionsReleasedExplicit | CliRunOptionsReleasedAuto | CliRunOptionsUnreleased;
 
 export type CreateCliRunOptions = {
     readonly versionNumber: string | undefined;
@@ -30,15 +41,21 @@ export type CreateCliRunOptions = {
 export function createCliRunOptions(options: CreateCliRunOptions): Result<CliRunOptions, InvalidArgumentError> {
     const { versionNumber, commandOptions, changelogPath } = options;
     const unreleased = commandOptions.unreleased === true;
+    const autoVersion = commandOptions.autoVersion === true;
 
     const commonRunOptions = {
         sloppy: commandOptions.sloppy === true,
         changelogPath,
         stdout: commandOptions.stdout === true,
-        unreleased
+        unreleased,
+        autoVersion
     };
 
     if (unreleased) {
+        if (autoVersion) {
+            return Result.err(new InvalidArgumentError('A version number must not be auto-derived when --unreleased was provided'));
+        }
+
         if (isString(versionNumber)) {
             return Result.err(
                 new InvalidArgumentError('A version number is not allowed when --unreleased was provided')
@@ -48,6 +65,22 @@ export function createCliRunOptions(options: CreateCliRunOptions): Result<CliRun
         return Result.ok({
             ...commonRunOptions,
             unreleased: true,
+            autoVersion: false,
+            versionNumber: Maybe.nothing()
+        });
+    }
+
+    if (autoVersion) {
+        if (isString(versionNumber)) {
+            return Result.err(
+                new InvalidArgumentError('A version number is not allowed when --auto-version was provided')
+            );
+        }
+
+        return Result.ok({
+            ...commonRunOptions,
+            unreleased: false,
+            autoVersion: true,
             versionNumber: Maybe.nothing()
         });
     }
@@ -57,6 +90,7 @@ export function createCliRunOptions(options: CreateCliRunOptions): Result<CliRun
             return Result.ok({
                 ...commonRunOptions,
                 unreleased: false,
+                autoVersion: false,
                 versionNumber: Maybe.just(value) as Just<string>
             });
         },

--- a/source/lib/cli-run-options.ts
+++ b/source/lib/cli-run-options.ts
@@ -30,7 +30,7 @@ type CliRunOptionsReleasedAuto = {
     readonly stdout: boolean;
 };
 
-export type CliRunOptions = CliRunOptionsReleasedExplicit | CliRunOptionsReleasedAuto | CliRunOptionsUnreleased;
+export type CliRunOptions = CliRunOptionsReleasedAuto | CliRunOptionsReleasedExplicit | CliRunOptionsUnreleased;
 
 export type CreateCliRunOptions = {
     readonly versionNumber: string | undefined;
@@ -38,53 +38,65 @@ export type CreateCliRunOptions = {
     readonly changelogPath: string;
 };
 
-export function createCliRunOptions(options: CreateCliRunOptions): Result<CliRunOptions, InvalidArgumentError> {
-    const { versionNumber, commandOptions, changelogPath } = options;
-    const unreleased = commandOptions.unreleased === true;
-    const autoVersion = commandOptions.autoVersion === true;
+type CommonRunOptions = {
+    readonly sloppy: boolean;
+    readonly changelogPath: string;
+    readonly stdout: boolean;
+};
 
-    const commonRunOptions = {
+function getCommonRunOptions(options: CreateCliRunOptions): CommonRunOptions {
+    const { commandOptions, changelogPath } = options;
+
+    return {
         sloppy: commandOptions.sloppy === true,
         changelogPath,
-        stdout: commandOptions.stdout === true,
-        unreleased,
-        autoVersion
+        stdout: commandOptions.stdout === true
     };
+}
 
-    if (unreleased) {
-        if (autoVersion) {
-            return Result.err(new InvalidArgumentError('A version number must not be auto-derived when --unreleased was provided'));
-        }
-
-        if (isString(versionNumber)) {
-            return Result.err(
-                new InvalidArgumentError('A version number is not allowed when --unreleased was provided')
-            );
-        }
-
-        return Result.ok({
-            ...commonRunOptions,
-            unreleased: true,
-            autoVersion: false,
-            versionNumber: Maybe.nothing()
-        });
-    }
-
+function createUnreleasedRunOptions(
+    commonRunOptions: CommonRunOptions,
+    versionNumber: string | undefined,
+    autoVersion: boolean
+): Result<CliRunOptions, InvalidArgumentError> {
     if (autoVersion) {
-        if (isString(versionNumber)) {
-            return Result.err(
-                new InvalidArgumentError('A version number is not allowed when --auto-version was provided')
-            );
-        }
-
-        return Result.ok({
-            ...commonRunOptions,
-            unreleased: false,
-            autoVersion: true,
-            versionNumber: Maybe.nothing()
-        });
+        return Result.err(
+            new InvalidArgumentError('A version number must not be auto-derived when --unreleased was provided')
+        );
     }
 
+    if (isString(versionNumber)) {
+        return Result.err(new InvalidArgumentError('A version number is not allowed when --unreleased was provided'));
+    }
+
+    return Result.ok({
+        ...commonRunOptions,
+        unreleased: true,
+        autoVersion: false,
+        versionNumber: Maybe.nothing()
+    });
+}
+
+function createAutoVersionRunOptions(
+    commonRunOptions: CommonRunOptions,
+    versionNumber: string | undefined
+): Result<CliRunOptions, InvalidArgumentError> {
+    if (isString(versionNumber)) {
+        return Result.err(new InvalidArgumentError('A version number is not allowed when --auto-version was provided'));
+    }
+
+    return Result.ok({
+        ...commonRunOptions,
+        unreleased: false,
+        autoVersion: true,
+        versionNumber: Maybe.nothing()
+    });
+}
+
+function createReleasedRunOptions(
+    commonRunOptions: CommonRunOptions,
+    versionNumber: string | undefined
+): Result<CliRunOptions, InvalidArgumentError> {
     return Maybe.of(versionNumber).match<Result<CliRunOptions, InvalidArgumentError>>({
         Just(value) {
             return Result.ok({
@@ -98,4 +110,20 @@ export function createCliRunOptions(options: CreateCliRunOptions): Result<CliRun
             return Result.err(new InvalidArgumentError('Version number is missing'));
         }
     });
+}
+
+export function createCliRunOptions(options: CreateCliRunOptions): Result<CliRunOptions, InvalidArgumentError> {
+    const { versionNumber, commandOptions } = options;
+    const commonRunOptions = getCommonRunOptions(options);
+    const autoVersion = commandOptions.autoVersion === true;
+
+    if (commandOptions.unreleased === true) {
+        return createUnreleasedRunOptions(commonRunOptions, versionNumber, autoVersion);
+    }
+
+    if (autoVersion) {
+        return createAutoVersionRunOptions(commonRunOptions, versionNumber);
+    }
+
+    return createReleasedRunOptions(commonRunOptions, versionNumber);
 }

--- a/source/lib/cli.test.ts
+++ b/source/lib/cli.test.ts
@@ -11,6 +11,7 @@ import { defaultValidLabels } from './valid-labels.ts';
 const cliRunOptionsFactory = Factory.define<CliRunOptions>(() => {
     return {
         unreleased: false,
+        autoVersion: false,
         versionNumber: Maybe.just('1.2.3') as Just<string>,
         changelogPath: '/foo/CHANGELOG.md',
         sloppy: false,
@@ -21,6 +22,7 @@ const cliRunOptionsFactory = Factory.define<CliRunOptions>(() => {
 function createCli(dependencies: Partial<CliRunnerDependencies> = {}): CliRunner {
     const {
         ensureCleanLocalGitState = stub().resolves(),
+        getLatestVersionTag = stub().resolves('1.2.2'),
         getMergedPullRequests = stub().resolves([]),
         createChangelog = stub().returns(''),
         prependFile = stub().resolves() as unknown as typeof _prependFile,
@@ -30,6 +32,7 @@ function createCli(dependencies: Partial<CliRunnerDependencies> = {}): CliRunner
 
     return createCliRunner({
         ensureCleanLocalGitState,
+        getLatestVersionTag,
         getMergedPullRequests,
         createChangelog,
         prependFile,
@@ -276,10 +279,14 @@ test('reports the generated unreleased changelog to a file when stdout is set to
         createChangelog,
         prependFile: prependFile as unknown as typeof _prependFile
     });
-    const options = cliRunOptionsFactory.build({
+    const options: CliRunOptions = {
         unreleased: true,
+        autoVersion: false,
+        versionNumber: Maybe.nothing(),
+        changelogPath: '/foo/CHANGELOG.md',
+        sloppy: false,
         stdout: false
-    });
+    };
 
     await cli.run(options);
 
@@ -289,11 +296,87 @@ test('reports the generated unreleased changelog to a file when stdout is set to
         mergedPullRequests: [],
         githubRepo: 'foo/bar',
         unreleased: true,
-        versionNumber: Maybe.just('1.2.3')
+        versionNumber: Maybe.nothing()
     });
 
     assert.strictEqual(prependFile.callCount, 1);
     assert.deepStrictEqual(prependFile.firstCall.args, ['/foo/CHANGELOG.md', 'generated changelog\n\n']);
+});
+
+test('derives the version number automatically from merged pull request labels', async () => {
+    const createChangelog = stub().returns('generated changelog');
+    const prependFile = stub().resolves();
+    const getLatestVersionTag = stub().resolves('1.2.3');
+    const getMergedPullRequests = stub().resolves([
+        { id: 1, title: 'Add thing', label: 'feature' }
+    ]);
+    const cli = createCli({
+        createChangelog,
+        prependFile: prependFile as unknown as typeof _prependFile,
+        getLatestVersionTag,
+        getMergedPullRequests
+    });
+    const options: CliRunOptions = {
+        unreleased: false,
+        autoVersion: true,
+        versionNumber: Maybe.nothing(),
+        changelogPath: '/foo/CHANGELOG.md',
+        sloppy: false,
+        stdout: false
+    };
+
+    await cli.run(options);
+
+    assert.strictEqual(getLatestVersionTag.callCount, 1);
+    assert.deepStrictEqual(createChangelog.firstCall.args[0], {
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: 1, title: 'Add thing', label: 'feature' }],
+        githubRepo: 'foo/bar',
+        unreleased: false,
+        versionNumber: Maybe.just('1.3.0')
+    });
+});
+
+test('uses configured version bump labels for auto-versioning', async () => {
+    const createChangelog = stub().returns('generated changelog');
+    const prependFile = stub().resolves();
+    const getLatestVersionTag = stub().resolves('1.2.3');
+    const getMergedPullRequests = stub().resolves([
+        { id: 1, title: 'Docs', label: 'documentation' }
+    ]);
+    const packageInfo = {
+        repository: { url: 'https://github.com/foo/bar.git' },
+        'pr-log': {
+            versionBumps: {
+                patch: ['documentation']
+            }
+        }
+    };
+    const cli = createCli({
+        createChangelog,
+        prependFile: prependFile as unknown as typeof _prependFile,
+        getLatestVersionTag,
+        getMergedPullRequests,
+        packageInfo
+    });
+    const options: CliRunOptions = {
+        unreleased: false,
+        autoVersion: true,
+        versionNumber: Maybe.nothing(),
+        changelogPath: '/foo/CHANGELOG.md',
+        sloppy: false,
+        stdout: false
+    };
+
+    await cli.run(options);
+
+    assert.deepStrictEqual(createChangelog.firstCall.args[0], {
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: 1, title: 'Docs', label: 'documentation' }],
+        githubRepo: 'foo/bar',
+        unreleased: false,
+        versionNumber: Maybe.just('1.2.4')
+    });
 });
 
 test('strips trailing empty lines from the generated changelog', async () => {

--- a/source/lib/cli.test.ts
+++ b/source/lib/cli.test.ts
@@ -307,9 +307,7 @@ test('derives the version number automatically from merged pull request labels',
     const createChangelog = stub().returns('generated changelog');
     const prependFile = stub().resolves();
     const getLatestVersionTag = stub().resolves('1.2.3');
-    const getMergedPullRequests = stub().resolves([
-        { id: 1, title: 'Add thing', label: 'feature' }
-    ]);
+    const getMergedPullRequests = stub().resolves([{ id: 1, title: 'Add thing', label: 'feature' }]);
     const cli = createCli({
         createChangelog,
         prependFile: prependFile as unknown as typeof _prependFile,
@@ -341,9 +339,7 @@ test('uses configured version bump labels for auto-versioning', async () => {
     const createChangelog = stub().returns('generated changelog');
     const prependFile = stub().resolves();
     const getLatestVersionTag = stub().resolves('1.2.3');
-    const getMergedPullRequests = stub().resolves([
-        { id: 1, title: 'Docs', label: 'documentation' }
-    ]);
+    const getMergedPullRequests = stub().resolves([{ id: 1, title: 'Docs', label: 'documentation' }]);
     const packageInfo = {
         repository: { url: 'https://github.com/foo/bar.git' },
         'pr-log': {

--- a/source/lib/cli.ts
+++ b/source/lib/cli.ts
@@ -1,18 +1,12 @@
 import type _prependFile from 'prepend-file';
 import type { Logger } from 'loglevel';
-import Maybe, { type Just } from 'true-myth/maybe';
-import { isPlainObject, isString } from '@sindresorhus/is';
 import type { CliRunOptions } from './cli-run-options.ts';
 import type { CreateChangelog } from './create-changelog.ts';
 import type { GetMergedPullRequests } from './get-merged-pull-requests.ts';
 import type { EnsureCleanLocalGitState } from './ensure-clean-local-git-state.ts';
+import { getGithubRepoFromPackageInfo, getValidLabels } from './package-info.ts';
+import { type GetLatestVersionTag, resolveReleasedVersionNumber } from './resolve-version-number.ts';
 import { validateVersionNumber } from './version-number.ts';
-import { getGithubRepo } from './get-github-repo.ts';
-import { defaultValidLabels } from './valid-labels.ts';
-import { getVersionBumpConfig } from './version-bump-config.ts';
-import { proposeVersionNumber } from './propose-version-number.ts';
-
-export type GetLatestVersionTag = () => Promise<string>;
 
 function stripTrailingEmptyLine(text: string): string {
     if (text.endsWith('\n\n')) {
@@ -20,15 +14,6 @@ function stripTrailingEmptyLine(text: string): string {
     }
 
     return text;
-}
-
-function getValidLabels(packageInfo: Record<string, unknown>): ReadonlyMap<string, string> {
-    const prLogConfig = packageInfo['pr-log'];
-    if (isPlainObject(prLogConfig) && Array.isArray(prLogConfig.validLabels)) {
-        return new Map(prLogConfig.validLabels);
-    }
-
-    return defaultValidLabels;
 }
 
 export type CliRunnerDependencies = {
@@ -45,88 +30,126 @@ export type CliRunner = {
     run(options: CliRunOptions): Promise<void>;
 };
 
+type ReleasedCliRunOptions = Extract<CliRunOptions, { unreleased: false }>;
+type UnreleasedCliRunOptions = Extract<CliRunOptions, { unreleased: true }>;
+
+type GenerateChangelogContext = Pick<
+    CliRunnerDependencies,
+    'createChangelog' | 'ensureCleanLocalGitState' | 'getLatestVersionTag' | 'getMergedPullRequests' | 'packageInfo'
+>;
+
+type ChangelogData = {
+    readonly githubRepo: string;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly mergedPullRequests: Awaited<ReturnType<GetMergedPullRequests>>;
+};
+
+type WriteChangelogContext = Pick<CliRunnerDependencies, 'logger' | 'prependFile'>;
+
+async function ensureCleanState(
+    ensureCleanLocalGitState: EnsureCleanLocalGitState,
+    options: CliRunOptions,
+    githubRepo: string
+): Promise<void> {
+    if (!options.sloppy) {
+        await ensureCleanLocalGitState(githubRepo);
+    }
+}
+
+function generateUnreleasedChangelog(
+    createChangelog: CreateChangelog,
+    options: UnreleasedCliRunOptions,
+    changelogData: ChangelogData
+): string {
+    const { githubRepo, validLabels, mergedPullRequests } = changelogData;
+
+    return stripTrailingEmptyLine(
+        createChangelog({
+            validLabels,
+            mergedPullRequests,
+            githubRepo,
+            unreleased: true,
+            versionNumber: options.versionNumber
+        })
+    );
+}
+
+async function generateReleasedChangelog(
+    context: Pick<CliRunnerDependencies, 'createChangelog' | 'getLatestVersionTag' | 'packageInfo'>,
+    options: ReleasedCliRunOptions,
+    changelogData: ChangelogData
+): Promise<string> {
+    const { createChangelog, packageInfo, getLatestVersionTag } = context;
+    const { githubRepo, validLabels, mergedPullRequests } = changelogData;
+    const versionNumber = options.autoVersion
+        ? await resolveReleasedVersionNumber(packageInfo, validLabels, getLatestVersionTag, mergedPullRequests)
+        : options.versionNumber;
+
+    return stripTrailingEmptyLine(
+        createChangelog({
+            validLabels,
+            mergedPullRequests,
+            githubRepo,
+            unreleased: false,
+            versionNumber
+        })
+    );
+}
+
+async function generateChangelog(
+    dependencies: GenerateChangelogContext,
+    options: CliRunOptions,
+    githubRepo: string,
+    validLabels: ReadonlyMap<string, string>
+): Promise<string> {
+    const { ensureCleanLocalGitState, getLatestVersionTag, getMergedPullRequests, createChangelog, packageInfo } =
+        dependencies;
+
+    await ensureCleanState(ensureCleanLocalGitState, options, githubRepo);
+
+    const changelogData: ChangelogData = {
+        githubRepo,
+        validLabels,
+        mergedPullRequests: await getMergedPullRequests(githubRepo, validLabels)
+    };
+
+    if (options.unreleased) {
+        return generateUnreleasedChangelog(createChangelog, options, changelogData);
+    }
+
+    return generateReleasedChangelog({ createChangelog, packageInfo, getLatestVersionTag }, options, changelogData);
+}
+
+async function writeChangelog(
+    context: WriteChangelogContext,
+    changelog: string,
+    options: CliRunOptions
+): Promise<void> {
+    const { prependFile, logger } = context;
+    const trimmedChangelog = changelog.trim();
+
+    if (options.stdout) {
+        logger.log(trimmedChangelog);
+    } else {
+        await prependFile(options.changelogPath, `${trimmedChangelog}\n\n`);
+    }
+}
+
 export function createCliRunner(dependencies: CliRunnerDependencies): CliRunner {
-    const {
-        ensureCleanLocalGitState,
-        getLatestVersionTag,
-        getMergedPullRequests,
-        createChangelog,
-        packageInfo,
-        prependFile,
-        logger
-    } = dependencies;
-
-    async function ensureCleanState(options: CliRunOptions, githubRepo: string): Promise<void> {
-        if (!options.sloppy) {
-            await ensureCleanLocalGitState(githubRepo);
-        }
-    }
-
-    async function generateChangelog(
-        options: CliRunOptions,
-        githubRepo: string,
-        validLabels: ReadonlyMap<string, string>
-    ): Promise<string> {
-        await ensureCleanState(options, githubRepo);
-
-        const mergedPullRequests = await getMergedPullRequests(githubRepo, validLabels);
-        const commonChangelogOptions = { validLabels, mergedPullRequests, githubRepo };
-
-        if (options.unreleased) {
-            const changelog = createChangelog({
-                ...commonChangelogOptions,
-                unreleased: true,
-                versionNumber: options.versionNumber
-            });
-
-            return stripTrailingEmptyLine(changelog);
-        }
-
-        const versionNumber = options.autoVersion
-            ? (Maybe.just(
-                  proposeVersionNumber(
-                      await getLatestVersionTag(),
-                      mergedPullRequests,
-                      getVersionBumpConfig(packageInfo, validLabels)
-                  )
-              ) as Just<string>)
-            : options.versionNumber;
-
-        const changelogOptions = { ...commonChangelogOptions, unreleased: false, versionNumber } as const;
-        const changelog = createChangelog(changelogOptions);
-
-        return stripTrailingEmptyLine(changelog);
-    }
-
-    async function writeChangelog(changelog: string, options: CliRunOptions): Promise<void> {
-        const trimmedChangelog = changelog.trim();
-
-        if (options.stdout) {
-            logger.log(trimmedChangelog);
-        } else {
-            await prependFile(options.changelogPath, `${trimmedChangelog}\n\n`);
-        }
-    }
+    const { packageInfo } = dependencies;
 
     return {
         async run(options: CliRunOptions) {
-            const { repository } = packageInfo;
-            if (!isPlainObject(repository)) {
-                throw new Error('Repository information missing in package.json');
-            }
-            if (!isString(repository.url)) {
-                throw new TypeError('Repository url is not a string in package.json');
-            }
-            const githubRepo = getGithubRepo(repository.url);
+            const githubRepo = getGithubRepoFromPackageInfo(packageInfo);
             const validLabels = getValidLabels(packageInfo);
 
             validateVersionNumber(options).unwrapOrElse((error) => {
                 throw error;
             });
 
-            const changelog = await generateChangelog(options, githubRepo, validLabels);
+            const changelog = await generateChangelog(dependencies, options, githubRepo, validLabels);
 
-            await writeChangelog(changelog, options);
+            await writeChangelog(dependencies, changelog, options);
         }
     };
 }

--- a/source/lib/cli.ts
+++ b/source/lib/cli.ts
@@ -1,5 +1,6 @@
 import type _prependFile from 'prepend-file';
 import type { Logger } from 'loglevel';
+import Maybe, { type Just } from 'true-myth/maybe';
 import { isPlainObject, isString } from '@sindresorhus/is';
 import type { CliRunOptions } from './cli-run-options.ts';
 import type { CreateChangelog } from './create-changelog.ts';
@@ -8,6 +9,10 @@ import type { EnsureCleanLocalGitState } from './ensure-clean-local-git-state.ts
 import { validateVersionNumber } from './version-number.ts';
 import { getGithubRepo } from './get-github-repo.ts';
 import { defaultValidLabels } from './valid-labels.ts';
+import { getVersionBumpConfig } from './version-bump-config.ts';
+import { proposeVersionNumber } from './propose-version-number.ts';
+
+export type GetLatestVersionTag = () => Promise<string>;
 
 function stripTrailingEmptyLine(text: string): string {
     if (text.endsWith('\n\n')) {
@@ -28,6 +33,7 @@ function getValidLabels(packageInfo: Record<string, unknown>): ReadonlyMap<strin
 
 export type CliRunnerDependencies = {
     readonly ensureCleanLocalGitState: EnsureCleanLocalGitState;
+    readonly getLatestVersionTag: GetLatestVersionTag;
     readonly getMergedPullRequests: GetMergedPullRequests;
     readonly createChangelog: CreateChangelog;
     readonly packageInfo: Record<string, unknown>;
@@ -40,23 +46,53 @@ export type CliRunner = {
 };
 
 export function createCliRunner(dependencies: CliRunnerDependencies): CliRunner {
-    const { ensureCleanLocalGitState, getMergedPullRequests, createChangelog, packageInfo, prependFile, logger } =
-        dependencies;
+    const {
+        ensureCleanLocalGitState,
+        getLatestVersionTag,
+        getMergedPullRequests,
+        createChangelog,
+        packageInfo,
+        prependFile,
+        logger
+    } = dependencies;
+
+    async function ensureCleanState(options: CliRunOptions, githubRepo: string): Promise<void> {
+        if (!options.sloppy) {
+            await ensureCleanLocalGitState(githubRepo);
+        }
+    }
 
     async function generateChangelog(
         options: CliRunOptions,
         githubRepo: string,
         validLabels: ReadonlyMap<string, string>
     ): Promise<string> {
-        if (!options.sloppy) {
-            await ensureCleanLocalGitState(githubRepo);
-        }
+        await ensureCleanState(options, githubRepo);
 
         const mergedPullRequests = await getMergedPullRequests(githubRepo, validLabels);
         const commonChangelogOptions = { validLabels, mergedPullRequests, githubRepo };
-        const changelogOptions = options.unreleased
-            ? ({ ...commonChangelogOptions, unreleased: true, versionNumber: options.versionNumber } as const)
-            : ({ ...commonChangelogOptions, unreleased: false, versionNumber: options.versionNumber } as const);
+
+        if (options.unreleased) {
+            const changelog = createChangelog({
+                ...commonChangelogOptions,
+                unreleased: true,
+                versionNumber: options.versionNumber
+            });
+
+            return stripTrailingEmptyLine(changelog);
+        }
+
+        const versionNumber = options.autoVersion
+            ? (Maybe.just(
+                  proposeVersionNumber(
+                      await getLatestVersionTag(),
+                      mergedPullRequests,
+                      getVersionBumpConfig(packageInfo, validLabels)
+                  )
+              ) as Just<string>)
+            : options.versionNumber;
+
+        const changelogOptions = { ...commonChangelogOptions, unreleased: false, versionNumber } as const;
         const changelog = createChangelog(changelogOptions);
 
         return stripTrailingEmptyLine(changelog);

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -1,8 +1,8 @@
-import semver from 'semver';
 import type { Octokit } from '@octokit/rest';
 import { isUndefined } from '@sindresorhus/is';
 import type { GetPullRequestLabel } from './get-pull-request-label.ts';
 import type { GitCommandRunner } from './git-command-runner.ts';
+import { determineLatestVersionTag } from './latest-version-tag.ts';
 
 export type PullRequest = {
     readonly id: number;
@@ -29,17 +29,7 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
 
     async function getLatestVersionTag(): Promise<string> {
         const tags = await gitCommandRunner.listTags();
-        const versionTags = tags.filter((tag: string) => {
-            return semver.valid(tag) !== null && semver.prerelease(tag) === null;
-        });
-        const orderedVersionTags = versionTags.sort(semver.compare);
-        const latestTag = orderedVersionTags.at(-1);
-
-        if (isUndefined(latestTag)) {
-            throw new TypeError('Failed to determine latest version number git tag');
-        }
-
-        return latestTag;
+        return determineLatestVersionTag(tags);
     }
 
     async function getPullRequests(fromTag: string): Promise<readonly PullRequest[]> {

--- a/source/lib/latest-version-tag.test.ts
+++ b/source/lib/latest-version-tag.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { determineLatestVersionTag } from './latest-version-tag.ts';
+
+test('throws when there is no semver tag', () => {
+    assert.throws(
+        () => {
+            determineLatestVersionTag(['foo', 'bar']);
+        },
+        { message: 'Failed to determine latest version number git tag' }
+    );
+});
+
+test('returns the highest stable semver tag', () => {
+    const actual = determineLatestVersionTag(['1.0.0', '0.0.0', '2.0.0', '3.0.0-alpha.1']);
+
+    assert.strictEqual(actual, '2.0.0');
+});

--- a/source/lib/latest-version-tag.ts
+++ b/source/lib/latest-version-tag.ts
@@ -1,0 +1,16 @@
+import semver from 'semver';
+import { isUndefined } from '@sindresorhus/is';
+
+export function determineLatestVersionTag(tags: readonly string[]): string {
+    const versionTags = tags.filter((tag: string) => {
+        return semver.valid(tag) !== null && semver.prerelease(tag) === null;
+    });
+    const orderedVersionTags = versionTags.sort(semver.compare);
+    const latestTag = orderedVersionTags.at(-1);
+
+    if (isUndefined(latestTag)) {
+        throw new TypeError('Failed to determine latest version number git tag');
+    }
+
+    return latestTag;
+}

--- a/source/lib/package-info.ts
+++ b/source/lib/package-info.ts
@@ -1,0 +1,29 @@
+import { isPlainObject, isString } from '@sindresorhus/is';
+import { getGithubRepo } from './get-github-repo.ts';
+import { defaultValidLabels } from './valid-labels.ts';
+
+type PackageInfo = Record<string, unknown>;
+
+export function getGithubRepoFromPackageInfo(packageInfo: PackageInfo): string {
+    const { repository } = packageInfo;
+
+    if (!isPlainObject(repository)) {
+        throw new Error('Repository information missing in package.json');
+    }
+
+    if (!isString(repository.url)) {
+        throw new TypeError('Repository url is not a string in package.json');
+    }
+
+    return getGithubRepo(repository.url);
+}
+
+export function getValidLabels(packageInfo: PackageInfo): ReadonlyMap<string, string> {
+    const prLogConfig = packageInfo['pr-log'];
+
+    if (isPlainObject(prLogConfig) && Array.isArray(prLogConfig.validLabels)) {
+        return new Map(prLogConfig.validLabels);
+    }
+
+    return defaultValidLabels;
+}

--- a/source/lib/propose-version-number.test.ts
+++ b/source/lib/propose-version-number.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert';
+import { proposeVersionNumber } from './propose-version-number.ts';
+import type { VersionBumpConfig } from './version-bump-config.ts';
+
+const defaultVersionBumpConfig: VersionBumpConfig = {
+    major: ['breaking'],
+    minor: ['feature'],
+    patch: ['bug', 'documentation']
+};
+
+test('proposes a major version when a breaking change is present', () => {
+    const actual = proposeVersionNumber(
+        '1.2.3',
+        [{ id: 1, title: 'Breaking change', label: 'breaking' }],
+        defaultVersionBumpConfig
+    );
+
+    assert.strictEqual(actual, '2.0.0');
+});
+
+test('proposes a minor version when a feature is present without a breaking change', () => {
+    const actual = proposeVersionNumber(
+        '1.2.3',
+        [{ id: 1, title: 'Feature', label: 'feature' }],
+        defaultVersionBumpConfig
+    );
+
+    assert.strictEqual(actual, '1.3.0');
+});
+
+test('proposes a patch version for patch labels', () => {
+    const actual = proposeVersionNumber(
+        '1.2.3',
+        [{ id: 1, title: 'Fix', label: 'bug' }],
+        defaultVersionBumpConfig
+    );
+
+    assert.strictEqual(actual, '1.2.4');
+});
+
+test('chooses the highest-precedence bump across multiple labels', () => {
+    const actual = proposeVersionNumber(
+        '1.2.3',
+        [
+            { id: 1, title: 'Docs', label: 'documentation' },
+            { id: 2, title: 'Feature', label: 'feature' }
+        ],
+        defaultVersionBumpConfig
+    );
+
+    assert.strictEqual(actual, '1.3.0');
+});
+
+test('throws when no merged pull requests are available', () => {
+    assert.throws(
+        () => {
+            proposeVersionNumber('1.2.3', [], defaultVersionBumpConfig);
+        },
+        { message: 'Failed to propose next version number because no merged pull requests were found' }
+    );
+});
+
+test('throws when no labels match the configured version bumps', () => {
+    assert.throws(
+        () => {
+            proposeVersionNumber(
+                '1.2.3',
+                [{ id: 1, title: 'Docs', label: 'documentation' }],
+                { major: ['breaking'], minor: ['feature'], patch: [] }
+            );
+        },
+        { message: 'Failed to propose next version number because no merged pull request labels match version bumps' }
+    );
+});

--- a/source/lib/propose-version-number.test.ts
+++ b/source/lib/propose-version-number.test.ts
@@ -29,11 +29,7 @@ test('proposes a minor version when a feature is present without a breaking chan
 });
 
 test('proposes a patch version for patch labels', () => {
-    const actual = proposeVersionNumber(
-        '1.2.3',
-        [{ id: 1, title: 'Fix', label: 'bug' }],
-        defaultVersionBumpConfig
-    );
+    const actual = proposeVersionNumber('1.2.3', [{ id: 1, title: 'Fix', label: 'bug' }], defaultVersionBumpConfig);
 
     assert.strictEqual(actual, '1.2.4');
 });
@@ -63,11 +59,11 @@ test('throws when no merged pull requests are available', () => {
 test('throws when no labels match the configured version bumps', () => {
     assert.throws(
         () => {
-            proposeVersionNumber(
-                '1.2.3',
-                [{ id: 1, title: 'Docs', label: 'documentation' }],
-                { major: ['breaking'], minor: ['feature'], patch: [] }
-            );
+            proposeVersionNumber('1.2.3', [{ id: 1, title: 'Docs', label: 'documentation' }], {
+                major: ['breaking'],
+                minor: ['feature'],
+                patch: []
+            });
         },
         { message: 'Failed to propose next version number because no merged pull request labels match version bumps' }
     );

--- a/source/lib/propose-version-number.test.ts
+++ b/source/lib/propose-version-number.test.ts
@@ -68,3 +68,12 @@ test('throws when no labels match the configured version bumps', () => {
         { message: 'Failed to propose next version number because no merged pull request labels match version bumps' }
     );
 });
+
+test('throws when the latest version tag cannot be incremented', () => {
+    assert.throws(
+        () => {
+            proposeVersionNumber('invalid', [{ id: 1, title: 'Feature', label: 'feature' }], defaultVersionBumpConfig);
+        },
+        { message: 'Failed to increment version number' }
+    );
+});

--- a/source/lib/propose-version-number.ts
+++ b/source/lib/propose-version-number.ts
@@ -1,0 +1,49 @@
+import semver from 'semver';
+import type { PullRequestWithLabel } from './get-merged-pull-requests.ts';
+import type { VersionBumpConfig, VersionBumpLevel } from './version-bump-config.ts';
+
+const orderedVersionBumpLevels: readonly VersionBumpLevel[] = ['major', 'minor', 'patch'];
+
+function includesAnyLabel(labels: ReadonlySet<string>, candidates: readonly string[]): boolean {
+    return candidates.some((candidate) => {
+        return labels.has(candidate);
+    });
+}
+
+function determineVersionBumpLevel(
+    pullRequests: readonly PullRequestWithLabel[],
+    versionBumpConfig: VersionBumpConfig
+): VersionBumpLevel {
+    if (pullRequests.length === 0) {
+        throw new Error('Failed to propose next version number because no merged pull requests were found');
+    }
+
+    const labels = new Set(
+        pullRequests.map((pullRequest) => {
+            return pullRequest.label;
+        })
+    );
+
+    for (const level of orderedVersionBumpLevels) {
+        if (includesAnyLabel(labels, versionBumpConfig[level])) {
+            return level;
+        }
+    }
+
+    throw new Error('Failed to propose next version number because no merged pull request labels match version bumps');
+}
+
+export function proposeVersionNumber(
+    latestVersionTag: string,
+    pullRequests: readonly PullRequestWithLabel[],
+    versionBumpConfig: VersionBumpConfig
+): string {
+    const versionBumpLevel = determineVersionBumpLevel(pullRequests, versionBumpConfig);
+    const versionNumber = semver.inc(latestVersionTag, versionBumpLevel);
+
+    if (versionNumber === null) {
+        throw new Error('Failed to increment version number');
+    }
+
+    return versionNumber;
+}

--- a/source/lib/resolve-version-number.ts
+++ b/source/lib/resolve-version-number.ts
@@ -1,0 +1,21 @@
+import Maybe, { type Just } from 'true-myth/maybe';
+import type { PullRequestWithLabel } from './get-merged-pull-requests.ts';
+import { proposeVersionNumber } from './propose-version-number.ts';
+import { getVersionBumpConfig } from './version-bump-config.ts';
+
+export type GetLatestVersionTag = () => Promise<string>;
+
+export async function resolveReleasedVersionNumber(
+    packageInfo: Record<string, unknown>,
+    validLabels: ReadonlyMap<string, string>,
+    getLatestVersionTag: GetLatestVersionTag,
+    mergedPullRequests: readonly PullRequestWithLabel[]
+): Promise<Just<string>> {
+    const versionNumber = proposeVersionNumber(
+        await getLatestVersionTag(),
+        mergedPullRequests,
+        getVersionBumpConfig(packageInfo, validLabels)
+    );
+
+    return Maybe.just(versionNumber) as Just<string>;
+}

--- a/source/lib/version-bump-config.test.ts
+++ b/source/lib/version-bump-config.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert';
+import { defaultValidLabels } from './valid-labels.ts';
+import { getVersionBumpConfig } from './version-bump-config.ts';
+
+test('uses the default version bump config when none is provided', () => {
+    const actual = getVersionBumpConfig({}, defaultValidLabels);
+
+    assert.deepStrictEqual(actual, {
+        major: ['breaking'],
+        minor: ['feature'],
+        patch: ['bug', 'enhancement', 'documentation', 'upgrade', 'refactor', 'build']
+    });
+});
+
+test('uses the configured version bump config', () => {
+    const packageInfo = {
+        'pr-log': {
+            versionBumps: {
+                major: ['breaking'],
+                patch: ['documentation']
+            }
+        }
+    };
+
+    const actual = getVersionBumpConfig(packageInfo, defaultValidLabels);
+
+    assert.deepStrictEqual(actual, {
+        major: ['breaking'],
+        minor: [],
+        patch: ['documentation']
+    });
+});
+
+test('throws when configured version bumps is not an object', () => {
+    assert.throws(
+        () => {
+            getVersionBumpConfig({ 'pr-log': { versionBumps: 'foo' } }, defaultValidLabels);
+        },
+        { message: 'Configured version bumps must be an object' }
+    );
+});
+
+test('throws when an unsupported version bump level is configured', () => {
+    assert.throws(
+        () => {
+            getVersionBumpConfig({ 'pr-log': { versionBumps: { foo: ['bug'] } } }, defaultValidLabels);
+        },
+        { message: 'Configured version bump level "foo" is not supported' }
+    );
+});
+
+test('throws when a version bump level is not configured as an array of labels', () => {
+    assert.throws(
+        () => {
+            getVersionBumpConfig({ 'pr-log': { versionBumps: { major: 'breaking' } } }, defaultValidLabels);
+        },
+        { message: 'Configured version bump "major" must be an array of labels' }
+    );
+});
+
+test('throws when a configured version bump label is not valid', () => {
+    assert.throws(
+        () => {
+            getVersionBumpConfig({ 'pr-log': { versionBumps: { patch: ['unknown'] } } }, defaultValidLabels);
+        },
+        { message: 'Configured version bump label "unknown" is not a valid label' }
+    );
+});
+
+test('throws when a configured version bump label is duplicated across levels', () => {
+    assert.throws(
+        () => {
+            getVersionBumpConfig(
+                { 'pr-log': { versionBumps: { major: ['breaking'], patch: ['breaking'] } } },
+                defaultValidLabels
+            );
+        },
+        { message: 'Configured version bump labels must not appear in multiple bump levels' }
+    );
+});

--- a/source/lib/version-bump-config.test.ts
+++ b/source/lib/version-bump-config.test.ts
@@ -31,6 +31,25 @@ test('uses the configured version bump config', () => {
     });
 });
 
+test('falls back to empty arrays for omitted configured bump levels', () => {
+    const packageInfo = {
+        'pr-log': {
+            versionBumps: {
+                major: ['breaking'],
+                minor: ['feature']
+            }
+        }
+    };
+
+    const actual = getVersionBumpConfig(packageInfo, defaultValidLabels);
+
+    assert.deepStrictEqual(actual, {
+        major: ['breaking'],
+        minor: ['feature'],
+        patch: []
+    });
+});
+
 test('throws when configured version bumps is not an object', () => {
     assert.throws(
         () => {

--- a/source/lib/version-bump-config.ts
+++ b/source/lib/version-bump-config.ts
@@ -25,7 +25,7 @@ function getDefaultVersionBumpConfig(validLabels: ReadonlyMap<string, string>): 
 }
 
 function assertValidConfiguredLabels(
-    versionBumps: Partial<Record<VersionBumpLevel, readonly string[]>>,
+    versionBumps: Readonly<Partial<Record<VersionBumpLevel, readonly string[]>>>,
     validLabels: ReadonlyMap<string, string>
 ): void {
     const configuredLabels = Object.values(versionBumps).flat();
@@ -57,6 +57,22 @@ function parseVersionBumpLabels(
     return value;
 }
 
+function parseConfiguredVersionBumps(versionBumps: Record<string, unknown>): VersionBumpConfig {
+    return {
+        major: parseVersionBumpLabels(versionBumps, 'major') ?? [],
+        minor: parseVersionBumpLabels(versionBumps, 'minor') ?? [],
+        patch: parseVersionBumpLabels(versionBumps, 'patch') ?? []
+    };
+}
+
+function assertSupportedVersionBumpLevels(versionBumps: Record<string, unknown>): void {
+    for (const key of Object.keys(versionBumps)) {
+        if (!versionBumpLevels.includes(key as VersionBumpLevel)) {
+            throw new TypeError(`Configured version bump level "${key}" is not supported`);
+        }
+    }
+}
+
 export function getVersionBumpConfig(
     packageInfo: PackageInfo,
     validLabels: ReadonlyMap<string, string>
@@ -67,23 +83,15 @@ export function getVersionBumpConfig(
         return getDefaultVersionBumpConfig(validLabels);
     }
 
-    const versionBumps = prLogConfig.versionBumps;
+    const { versionBumps } = prLogConfig;
 
     if (!isPlainObject(versionBumps)) {
         throw new TypeError('Configured version bumps must be an object');
     }
 
-    for (const key of Object.keys(versionBumps)) {
-        if (!versionBumpLevels.includes(key as VersionBumpLevel)) {
-            throw new TypeError(`Configured version bump level "${key}" is not supported`);
-        }
-    }
+    assertSupportedVersionBumpLevels(versionBumps);
 
-    const parsedVersionBumps = {
-        major: parseVersionBumpLabels(versionBumps, 'major') ?? [],
-        minor: parseVersionBumpLabels(versionBumps, 'minor') ?? [],
-        patch: parseVersionBumpLabels(versionBumps, 'patch') ?? []
-    } satisfies VersionBumpConfig;
+    const parsedVersionBumps = parseConfiguredVersionBumps(versionBumps);
 
     assertValidConfiguredLabels(parsedVersionBumps, validLabels);
 

--- a/source/lib/version-bump-config.ts
+++ b/source/lib/version-bump-config.ts
@@ -1,0 +1,91 @@
+import { isArray, isPlainObject, isString } from '@sindresorhus/is';
+
+export const versionBumpLevels = ['major', 'minor', 'patch'] as const;
+
+export type VersionBumpLevel = (typeof versionBumpLevels)[number];
+
+export type VersionBumpConfig = Readonly<Record<VersionBumpLevel, readonly string[]>>;
+
+type PackageInfo = Record<string, unknown>;
+
+function hasDuplicateLabels(labels: readonly string[]): boolean {
+    return new Set(labels).size !== labels.length;
+}
+
+function getDefaultVersionBumpConfig(validLabels: ReadonlyMap<string, string>): VersionBumpConfig {
+    const allLabels = Array.from(validLabels.keys());
+
+    return {
+        major: ['breaking'],
+        minor: ['feature'],
+        patch: allLabels.filter((label) => {
+            return label !== 'breaking' && label !== 'feature';
+        })
+    };
+}
+
+function assertValidConfiguredLabels(
+    versionBumps: Partial<Record<VersionBumpLevel, readonly string[]>>,
+    validLabels: ReadonlyMap<string, string>
+): void {
+    const configuredLabels = Object.values(versionBumps).flat();
+
+    for (const label of configuredLabels) {
+        if (!validLabels.has(label)) {
+            throw new TypeError(`Configured version bump label "${label}" is not a valid label`);
+        }
+    }
+
+    if (hasDuplicateLabels(configuredLabels)) {
+        throw new TypeError('Configured version bump labels must not appear in multiple bump levels');
+    }
+}
+
+function parseVersionBumpLabels(
+    versionBumps: Record<string, unknown>,
+    level: VersionBumpLevel
+): readonly string[] | undefined {
+    if (!(level in versionBumps)) {
+        return undefined;
+    }
+
+    const value = versionBumps[level];
+    if (!isArray(value) || !value.every(isString)) {
+        throw new TypeError(`Configured version bump "${level}" must be an array of labels`);
+    }
+
+    return value;
+}
+
+export function getVersionBumpConfig(
+    packageInfo: PackageInfo,
+    validLabels: ReadonlyMap<string, string>
+): VersionBumpConfig {
+    const prLogConfig = packageInfo['pr-log'];
+
+    if (!isPlainObject(prLogConfig) || !('versionBumps' in prLogConfig)) {
+        return getDefaultVersionBumpConfig(validLabels);
+    }
+
+    const versionBumps = prLogConfig.versionBumps;
+
+    if (!isPlainObject(versionBumps)) {
+        throw new TypeError('Configured version bumps must be an object');
+    }
+
+    for (const key of Object.keys(versionBumps)) {
+        if (!versionBumpLevels.includes(key as VersionBumpLevel)) {
+            throw new TypeError(`Configured version bump level "${key}" is not supported`);
+        }
+    }
+
+    const parsedVersionBumps = {
+        major: parseVersionBumpLabels(versionBumps, 'major') ?? [],
+        minor: parseVersionBumpLabels(versionBumps, 'minor') ?? [],
+        patch: parseVersionBumpLabels(versionBumps, 'patch') ?? []
+    } satisfies VersionBumpConfig;
+
+    assertValidConfiguredLabels(parsedVersionBumps, validLabels);
+
+    return parsedVersionBumps;
+}

--- a/source/lib/version-number.test.ts
+++ b/source/lib/version-number.test.ts
@@ -1,46 +1,50 @@
 import assert from 'node:assert';
-import { Factory } from 'fishery';
 import { Maybe, Result, Unit } from 'true-myth';
-import type { Just } from 'true-myth/maybe';
 import { validateVersionNumber, type ValidateVersionNumberOptions } from './version-number.ts';
-
-const validateVersionNumberOptionsFactory = Factory.define<ValidateVersionNumberOptions>(() => {
-    return {
-        unreleased: false,
-        versionNumber: Maybe.just('1.2.3') as Just<string>
-    };
-});
 
 const validateVersionNumberTestCases = [
     {
         testName: 'validateVersionNumber() returns a Result Ok when version is unreleased',
-        optionsOverrides: {
+        options: {
             unreleased: true,
+            autoVersion: false,
+            versionNumber: Maybe.nothing<string>()
+        },
+        expectedResult: Result.ok(Unit)
+    },
+    {
+        testName: 'validateVersionNumber() returns a Result Ok when version is auto-derived',
+        options: {
+            unreleased: false,
+            autoVersion: true,
             versionNumber: Maybe.nothing<string>()
         },
         expectedResult: Result.ok(Unit)
     },
     {
         testName: 'validateVersionNumber() returns a Result Err when version number is an empty string',
-        optionsOverrides: {
+        options: {
             unreleased: false,
-            versionNumber: Maybe.just('') as Just<string>
+            autoVersion: false,
+            versionNumber: Maybe.just('')
         },
         expectedResult: Result.err(new TypeError('version-number not specified'))
     },
     {
         testName: 'validateVersionNumber() returns a Result Err when version number is not valid',
-        optionsOverrides: {
+        options: {
             unreleased: false,
-            versionNumber: Maybe.just('foo.bar') as Just<string>
+            autoVersion: false,
+            versionNumber: Maybe.just('foo.bar')
         },
         expectedResult: Result.err(new Error('version-number is invalid'))
     },
     {
         testName: 'validateVersionNumber() returns a Result Ok when version number is valid',
-        optionsOverrides: {
+        options: {
             unreleased: false,
-            versionNumber: Maybe.just('1.2.3') as Just<string>
+            autoVersion: false,
+            versionNumber: Maybe.just('1.2.3')
         },
         expectedResult: Result.ok(Unit)
     }
@@ -48,8 +52,7 @@ const validateVersionNumberTestCases = [
 
 for (const validateVersionNumberTestCase of validateVersionNumberTestCases) {
     test(validateVersionNumberTestCase.testName, () => {
-        const options = validateVersionNumberOptionsFactory.build(validateVersionNumberTestCase.optionsOverrides);
-        const actual = validateVersionNumber(options);
+        const actual = validateVersionNumber(validateVersionNumberTestCase.options as ValidateVersionNumberOptions);
 
         assert.deepStrictEqual(actual, validateVersionNumberTestCase.expectedResult);
     });

--- a/source/lib/version-number.ts
+++ b/source/lib/version-number.ts
@@ -5,20 +5,29 @@ import Unit from 'true-myth/unit';
 
 type ValidateVersionNumberOptionsUnreleased = {
     readonly unreleased: true;
+    readonly autoVersion: false;
+    readonly versionNumber: Nothing<string>;
+};
+
+type ValidateVersionNumberOptionsAuto = {
+    readonly unreleased: false;
+    readonly autoVersion: true;
     readonly versionNumber: Nothing<string>;
 };
 
 type ValidateVersionNumberOptionsReleased = {
     readonly unreleased: false;
+    readonly autoVersion: false;
     readonly versionNumber: Just<string>;
 };
 
 export type ValidateVersionNumberOptions =
     | ValidateVersionNumberOptionsReleased
+    | ValidateVersionNumberOptionsAuto
     | ValidateVersionNumberOptionsUnreleased;
 
 export function validateVersionNumber(options: ValidateVersionNumberOptions): Result<Unit, Error> {
-    if (options.unreleased) {
+    if (options.unreleased || options.autoVersion) {
         return Result.ok(Unit);
     }
 

--- a/source/lib/version-number.ts
+++ b/source/lib/version-number.ts
@@ -22,8 +22,8 @@ type ValidateVersionNumberOptionsReleased = {
 };
 
 export type ValidateVersionNumberOptions =
-    | ValidateVersionNumberOptionsReleased
     | ValidateVersionNumberOptionsAuto
+    | ValidateVersionNumberOptionsReleased
     | ValidateVersionNumberOptionsUnreleased;
 
 export function validateVersionNumber(options: ValidateVersionNumberOptions): Result<Unit, Error> {


### PR DESCRIPTION
Introduce an explicit --auto-version CLI mode that derives the next release number from merged pull request labels since the latest stable semver tag.

Add reusable helpers for latest tag selection, version bump config, and version proposal so the logic stays separate from changelog formatting. Support package.json customization via pr-log.versionBumps and document the new behavior in the README.

Cover the new flow with parser, runner, config, and proposal tests while keeping explicit-version and unreleased modes unchanged.