### PR TITLE
Throttle pull request label lookups

### DIFF
--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { fake, type SinonSpy } from 'sinon';
+import { fake, spy, type SinonSpy } from 'sinon';
 import { defaultValidLabels } from './valid-labels.ts';
 import {
     getMergedPullRequestsFactory,
@@ -18,6 +18,12 @@ type Overrides = {
     readonly getPullRequestLabel?: SinonSpy;
 };
 
+type ControlledLabelLookup = {
+    readonly getPullRequestLabel: SinonSpy;
+    readonly firstLabelLookupStarted: Promise<void>;
+    resolveFirstLabelLookup(label: string): void;
+};
+
 function factory(overrides: Overrides = {}): GetMergedPullRequests {
     const {
         listTags = fake.resolves([latestVersion]),
@@ -31,6 +37,41 @@ function factory(overrides: Overrides = {}): GetMergedPullRequests {
     } as unknown as GetMergedPullRequestsDependencies;
 
     return getMergedPullRequestsFactory(dependencies);
+}
+
+function failUninitializedControlledLabelLookupResolver(): never {
+    throw new Error('Controlled label lookup resolver was called before initialization');
+}
+
+function createControlledLabelLookup(): ControlledLabelLookup {
+    let resolveFirstLabelLookup: (label: string) => void = failUninitializedControlledLabelLookupResolver;
+    const firstLabelLookup = new Promise<string>((resolve) => {
+        resolveFirstLabelLookup = resolve;
+    });
+    let resolveFirstLabelLookupStarted: () => void = failUninitializedControlledLabelLookupResolver;
+    const firstLabelLookupStarted = new Promise<void>((resolve) => {
+        resolveFirstLabelLookupStarted = resolve;
+    });
+    const getPullRequestLabel = spy(async (_githubRepo, _validLabels, pullRequestId: number): Promise<string> => {
+        if (pullRequestId === 1) {
+            resolveFirstLabelLookupStarted();
+            return firstLabelLookup;
+        }
+
+        return 'documentation';
+    });
+
+    return { getPullRequestLabel, firstLabelLookupStarted, resolveFirstLabelLookup };
+}
+
+function assertFirstPullRequestLabelLookup(callCount: number, comparedArguments: readonly unknown[]): void {
+    assert.strictEqual(callCount, 1);
+    assert.deepStrictEqual(comparedArguments, ['any/repo', defaultValidLabels, 1]);
+}
+
+function assertSecondPullRequestLabelLookup(callCount: number, comparedArguments: readonly unknown[]): void {
+    assert.strictEqual(callCount, expectedPullRequestLabelCallCount);
+    assert.deepStrictEqual(comparedArguments, ['any/repo', defaultValidLabels, expectedPullRequestLabelCallCount]);
 }
 
 test('throws when there is no tag at all', async () => {
@@ -140,4 +181,36 @@ test('extracts id, title and label for merged pull requests', async () => {
     ]);
 
     assert.deepStrictEqual(pullRequests, [firstExpectedPullRequest, secondExpectedPullRequest]);
+});
+
+test('looks up pull request labels sequentially', async () => {
+    const getMergeCommitLogs = fake.resolves([
+        {
+            subject: 'Merge pull request #1 from branch',
+            body: 'pr-1 message'
+        },
+        { subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
+    ]);
+    const { getPullRequestLabel, firstLabelLookupStarted, resolveFirstLabelLookup } = createControlledLabelLookup();
+    const getMergedPullRequests = factory({ getMergeCommitLogs, getPullRequestLabel });
+    const mergedPullRequests = getMergedPullRequests(anyRepo, defaultValidLabels);
+
+    await firstLabelLookupStarted;
+
+    assertFirstPullRequestLabelLookup(
+        getPullRequestLabel.callCount,
+        getPullRequestLabel.firstCall.args.slice(0, comparedArgumentCount)
+    );
+
+    resolveFirstLabelLookup('bug');
+    const pullRequests = await mergedPullRequests;
+
+    assertSecondPullRequestLabelLookup(
+        getPullRequestLabel.callCount,
+        getPullRequestLabel.secondCall.args.slice(0, comparedArgumentCount)
+    );
+    assert.deepStrictEqual(pullRequests, [
+        { id: 1, title: 'pr-1 message', label: 'bug' },
+        { id: 2, title: 'pr-2 message', label: 'documentation' }
+    ]);
 });

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -54,17 +54,19 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
         validLabels: ReadonlyMap<string, string>,
         pullRequests: readonly PullRequest[]
     ): Promise<readonly PullRequestWithLabel[]> {
-        const promises = pullRequests.map(async (pullRequest): Promise<PullRequestWithLabel> => {
+        const pullRequestsWithLabels: PullRequestWithLabel[] = [];
+
+        for (const pullRequest of pullRequests) {
             const label = await getPullRequestLabel(githubRepo, validLabels, pullRequest.id, dependencies);
 
-            return {
+            pullRequestsWithLabels.push({
                 id: pullRequest.id,
                 title: pullRequest.title,
                 label
-            };
-        });
+            });
+        }
 
-        return Promise.all(promises);
+        return pullRequestsWithLabels;
     }
 
     return async function getMergedPullRequests(githubRepo: string, validLabels: ReadonlyMap<string, string>) {


### PR DESCRIPTION
Fetch pull request labels sequentially during changelog generation to avoid bursting GitHub's issues label endpoint. This reduces the chance of hitting secondary rate limits during release runs while preserving changelog ordering.

---

<img width="821" height="23" alt="Screenshot 2026-05-17 at 09 40 56" src="https://github.com/user-attachments/assets/27e1df22-f520-4d41-b061-03cb6057d26e" />
