### PR TITLE
Run push CI only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Continuous integration
 
-on: [push, pull_request]
+on:
+    push:
+        branches: [main]
+    pull_request:
 
 jobs:
     build:


### PR DESCRIPTION
The intent is to avoid running the same CI matrix twice for the same pull request update.

Before this change, pushing to a branch with an open pull request triggered CI twice:

- once from the push event
- once from the pull_request event

That produced duplicate checks like Node v24 (push) and Node v24 (pull_request). This change keeps PR validation on pull_request, while limiting push CI to main so direct/default- branch changes are still validated.