### PR TITLE
Run required checks for merge queues

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,18 +3,27 @@ name: Check pull request labels
 on:
     pull_request:
         types: [opened, labeled, unlabeled]
+    merge_group:
 
 jobs:
     check-labels:
         runs-on: ubuntu-latest
         if: >
-            contains(github.event.pull_request.labels.*.name, 'breaking') == false &&
-            contains(github.event.pull_request.labels.*.name, 'bug') == false &&
-            contains(github.event.pull_request.labels.*.name, 'feature') == false &&
-            contains(github.event.pull_request.labels.*.name, 'enhancement') == false &&
-            contains(github.event.pull_request.labels.*.name, 'documentation') == false &&
-            contains(github.event.pull_request.labels.*.name, 'upgrade') == false &&
-            contains(github.event.pull_request.labels.*.name, 'refactor') == false &&
-            contains(github.event.pull_request.labels.*.name, 'build') == false
+            github.event_name == 'merge_group' ||
+            (
+                contains(github.event.pull_request.labels.*.name, 'breaking') == false &&
+                contains(github.event.pull_request.labels.*.name, 'bug') == false &&
+                contains(github.event.pull_request.labels.*.name, 'feature') == false &&
+                contains(github.event.pull_request.labels.*.name, 'enhancement') == false &&
+                contains(github.event.pull_request.labels.*.name, 'documentation') == false &&
+                contains(github.event.pull_request.labels.*.name, 'upgrade') == false &&
+                contains(github.event.pull_request.labels.*.name, 'refactor') == false &&
+                contains(github.event.pull_request.labels.*.name, 'build') == false
+            )
         steps:
-            - run: echo "None of the required pull request labels are set" && exit 1
+            - name: Accept queued merge group
+              if: github.event_name == 'merge_group'
+              run: echo "Pull request labels were checked before entering the merge queue"
+            - name: Reject unlabeled pull request
+              if: github.event_name == 'pull_request'
+              run: echo "None of the required pull request labels are set" && exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches: [main]
     pull_request:
+    merge_group:
 
 jobs:
     build:


### PR DESCRIPTION
Add the merge_group trigger to required GitHub Actions workflows so GitHub merge queues receive the expected status checks when pull requests enter the queue.

Keep the label check behavior focused on pull requests while allowing queued merge groups to report a passing status, since pull request labels have already been validated before a pull request can enter the queue.

---

In GitHub repository settings you need to enable merge queues.

1. Go to repository Settings → Branches or Rules / Rulesets.
2. Edit the protection rule or ruleset for main.
3. Enable Require merge queue.
4. Make sure the required status checks include the checks that must pass in the queue, for example:
    - Node v22
    - Node v24
    - Node v26
    - coverage
    - check-labels if that is intended to be required
5. Save the rule.