### PR TITLE
Respect GitHub rate limit headers during pull request label lookup

### DIFF
--- a/source/bin/pr-log.ts
+++ b/source/bin/pr-log.ts
@@ -32,6 +32,11 @@ const config = (await readJson(prLogPackageJsonURL.pathname)) as Record<string, 
 const { GH_TOKEN } = process.env;
 const githubClient = new Octokit({ auth: GH_TOKEN });
 const labelLookupIntervalMilliseconds = 250;
+const maximumRateLimitRetryCount = 3;
+
+function getCurrentDate(): Readonly<Date> {
+    return new Date();
+}
 
 let isTracingEnabled = false;
 
@@ -45,13 +50,12 @@ const getMergedPullRequests = getMergedPullRequestsFactory({
     waitForMilliseconds: async (durationMilliseconds) => {
         await waitForTimeout(durationMilliseconds);
     },
-    labelLookupIntervalMilliseconds
+    labelLookupIntervalMilliseconds,
+    getCurrentDate,
+    maximumRateLimitRetryCount
 });
 const getLatestVersionTag = async (): Promise<string> => {
     return determineLatestVersionTag(await gitCommandRunner.listTags());
-};
-const getCurrentDate = (): Readonly<Date> => {
-    return new Date();
 };
 
 const program = createCommand(config.name ?? '');

--- a/source/bin/pr-log.ts
+++ b/source/bin/pr-log.ts
@@ -2,6 +2,7 @@
 
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { setTimeout as waitForTimeout } from 'node:timers/promises';
 import { createCommand } from 'commander';
 import { Octokit } from '@octokit/rest';
 import prependFile from 'prepend-file';
@@ -30,6 +31,7 @@ const config = (await readJson(prLogPackageJsonURL.pathname)) as Record<string, 
 
 const { GH_TOKEN } = process.env;
 const githubClient = new Octokit({ auth: GH_TOKEN });
+const labelLookupIntervalMilliseconds = 250;
 
 let isTracingEnabled = false;
 
@@ -39,7 +41,11 @@ const findRemoteAlias = findRemoteAliasFactory({ gitCommandRunner });
 const getMergedPullRequests = getMergedPullRequestsFactory({
     githubClient,
     gitCommandRunner,
-    getPullRequestLabel
+    getPullRequestLabel,
+    waitForMilliseconds: async (durationMilliseconds) => {
+        await waitForTimeout(durationMilliseconds);
+    },
+    labelLookupIntervalMilliseconds
 });
 const getLatestVersionTag = async (): Promise<string> => {
     return determineLatestVersionTag(await gitCommandRunner.listTags());

--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -10,12 +10,15 @@ import {
 const anyRepo = 'any/repo';
 const latestVersion = '1.2.3';
 const expectedPullRequestLabelCallCount = 2;
+const expectedWaitForMillisecondsCallCount = 2;
 const comparedArgumentCount = 3;
 
 type Overrides = {
     readonly listTags?: SinonSpy;
     readonly getMergeCommitLogs?: SinonSpy;
     readonly getPullRequestLabel?: SinonSpy;
+    readonly waitForMilliseconds?: SinonSpy;
+    readonly labelLookupIntervalMilliseconds?: number;
 };
 
 type ControlledLabelLookup = {
@@ -28,12 +31,16 @@ function factory(overrides: Overrides = {}): GetMergedPullRequests {
     const {
         listTags = fake.resolves([latestVersion]),
         getMergeCommitLogs = fake.resolves([]),
-        getPullRequestLabel = fake.resolves('bug')
+        getPullRequestLabel = fake.resolves('bug'),
+        waitForMilliseconds = fake.resolves(undefined),
+        labelLookupIntervalMilliseconds
     } = overrides;
 
     const dependencies = {
         getPullRequestLabel,
-        gitCommandRunner: { listTags, getMergeCommitLogs }
+        gitCommandRunner: { listTags, getMergeCommitLogs },
+        waitForMilliseconds,
+        labelLookupIntervalMilliseconds
     } as unknown as GetMergedPullRequestsDependencies;
 
     return getMergedPullRequestsFactory(dependencies);
@@ -213,4 +220,28 @@ test('looks up pull request labels sequentially', async () => {
         { id: 1, title: 'pr-1 message', label: 'bug' },
         { id: 2, title: 'pr-2 message', label: 'documentation' }
     ]);
+});
+
+test('waits between pull request label lookups', async () => {
+    const getMergeCommitLogs = fake.resolves([
+        {
+            subject: 'Merge pull request #1 from branch',
+            body: 'pr-1 message'
+        },
+        { subject: 'Merge pull request #2 from other', body: 'pr-2 message' },
+        { subject: 'Merge pull request #3 from third', body: 'pr-3 message' }
+    ]);
+    const waitForMilliseconds = fake.resolves(undefined);
+    const labelLookupIntervalMilliseconds = 123;
+    const getMergedPullRequests = factory({
+        getMergeCommitLogs,
+        waitForMilliseconds,
+        labelLookupIntervalMilliseconds
+    });
+
+    await getMergedPullRequests(anyRepo, defaultValidLabels);
+
+    assert.strictEqual(waitForMilliseconds.callCount, expectedWaitForMillisecondsCallCount);
+    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [labelLookupIntervalMilliseconds]);
+    assert.deepStrictEqual(waitForMilliseconds.secondCall.args, [labelLookupIntervalMilliseconds]);
 });

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -17,6 +17,8 @@ export type GetMergedPullRequestsDependencies = {
     readonly gitCommandRunner: GitCommandRunner;
     readonly getPullRequestLabel: GetPullRequestLabel;
     readonly githubClient: Octokit;
+    readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
+    readonly labelLookupIntervalMilliseconds: number;
 };
 
 export type GetMergedPullRequests = (
@@ -25,7 +27,8 @@ export type GetMergedPullRequests = (
 ) => Promise<readonly PullRequestWithLabel[]>;
 
 export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequestsDependencies): GetMergedPullRequests {
-    const { gitCommandRunner, getPullRequestLabel } = dependencies;
+    const { gitCommandRunner, getPullRequestLabel, waitForMilliseconds, labelLookupIntervalMilliseconds } =
+        dependencies;
 
     async function getLatestVersionTag(): Promise<string> {
         const tags = await gitCommandRunner.listTags();
@@ -56,7 +59,11 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
     ): Promise<readonly PullRequestWithLabel[]> {
         const pullRequestsWithLabels: PullRequestWithLabel[] = [];
 
-        for (const pullRequest of pullRequests) {
+        for (const [pullRequestIndex, pullRequest] of pullRequests.entries()) {
+            if (pullRequestIndex > 0 && labelLookupIntervalMilliseconds > 0) {
+                await waitForMilliseconds(labelLookupIntervalMilliseconds);
+            }
+
             const label = await getPullRequestLabel(githubRepo, validLabels, pullRequest.id, dependencies);
 
             pullRequestsWithLabels.push({

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -19,6 +19,8 @@ export type GetMergedPullRequestsDependencies = {
     readonly githubClient: Octokit;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
     readonly labelLookupIntervalMilliseconds: number;
+    readonly getCurrentDate: () => Readonly<Date>;
+    readonly maximumRateLimitRetryCount: number;
 };
 
 export type GetMergedPullRequests = (

--- a/source/lib/get-pull-request-label.test.ts
+++ b/source/lib/get-pull-request-label.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { fake, type SinonSpy } from 'sinon';
+import { fake, stub, type SinonSpy } from 'sinon';
 import { oneLine } from 'common-tags';
 import type { Octokit } from '@octokit/rest';
 import { getPullRequestLabel } from './get-pull-request-label.ts';
@@ -7,32 +7,119 @@ import { defaultValidLabels } from './valid-labels.ts';
 
 type Overrides = {
     readonly listLabelsOnIssue?: SinonSpy;
+    readonly waitForMilliseconds?: SinonSpy;
+    readonly getCurrentDate?: SinonSpy;
+    readonly maximumRateLimitRetryCount?: number;
 };
 
-function createGithubClient(overrides: Overrides = {}): Readonly<Octokit> {
-    const { listLabelsOnIssue = fake.resolves({ data: [] }) } = overrides;
+type TestDependencies = {
+    readonly githubClient: Readonly<Octokit>;
+    readonly waitForMilliseconds: SinonSpy;
+    readonly getCurrentDate: SinonSpy;
+    readonly maximumRateLimitRetryCount: number;
+};
 
-    return {
+type GitHubRateLimitError = {
+    readonly message: string;
+    readonly status: number;
+    readonly response: {
+        readonly headers: Readonly<Record<string, number | string>>;
+    };
+};
+type GitHubErrorWithStatus = {
+    readonly message: string;
+    readonly status: number;
+};
+
+type GitHubRateLimitErrorWithoutHeaders = {
+    readonly message: string;
+    readonly status: number;
+    readonly response: Record<string, never>;
+};
+
+const currentTimeMilliseconds = 1000;
+const currentDate = new Date(currentTimeMilliseconds);
+const millisecondsPerSecond = 1000;
+const retryAfterSeconds = 60;
+const internalServerErrorStatus = 500;
+const expectedRequestAttemptCount = 2;
+const expectedRetryAfterDelayMilliseconds = retryAfterSeconds * millisecondsPerSecond;
+const expectedRateLimitResetDelayMilliseconds = 4000;
+const rateLimitResetSeconds =
+    (currentTimeMilliseconds + expectedRateLimitResetDelayMilliseconds) / millisecondsPerSecond;
+
+function createGitHubRateLimitError(
+    message: string,
+    headers: Readonly<Record<string, number | string>>
+): GitHubRateLimitError {
+    const error = new Error(message) as Error & {
+        status: number;
+        response: { headers: Readonly<Record<string, number | string>> };
+    };
+    error.status = 403;
+    error.response = { headers };
+
+    return error;
+}
+
+function createGitHubErrorWithStatus(status: number, message: string): GitHubErrorWithStatus {
+    const error = new Error(message) as Error & { status: number };
+    error.status = status;
+
+    return error;
+}
+
+function createGitHubRateLimitErrorWithoutHeaders(message: string): GitHubRateLimitErrorWithoutHeaders {
+    const error = new Error(message) as Error & { status: number; response: Record<string, never> };
+    error.status = 403;
+    error.response = {};
+
+    return error;
+}
+
+function createDependencies(overrides: Overrides = {}): TestDependencies {
+    const { listLabelsOnIssue = fake.resolves({ data: [] }) } = overrides;
+    const { waitForMilliseconds = fake.resolves(undefined) } = overrides;
+    const { getCurrentDate = fake.returns(currentDate) } = overrides;
+    const { maximumRateLimitRetryCount = 1 } = overrides;
+    const githubClient = {
         issues: { listLabelsOnIssue }
     } as unknown as Octokit;
+
+    return { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount };
 }
 
 const anyRepo = 'any/repo';
 const anyPullRequestId = 123;
 
 test('throws when the given repo doesn’t have a "/"', async () => {
-    const githubClient = createGithubClient();
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies();
 
-    await assert.rejects(getPullRequestLabel('foo', defaultValidLabels, anyPullRequestId, { githubClient }), {
-        message: 'Could not find a repository'
-    });
+    await assert.rejects(
+        getPullRequestLabel('foo', defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        {
+            message: 'Could not find a repository'
+        }
+    );
 });
 
 test('requests the labels for the correct repo and pull request', async () => {
     const listLabelsOnIssue = fake.resolves({ data: [{ name: 'bug' }] });
-    const githubClient = createGithubClient({ listLabelsOnIssue });
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
 
-    await getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, { githubClient });
+    await getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+        githubClient,
+        waitForMilliseconds,
+        getCurrentDate,
+        maximumRateLimitRetryCount
+    });
 
     assert.strictEqual(listLabelsOnIssue.callCount, 1);
     assert.deepStrictEqual(listLabelsOnIssue.firstCall.args, [{ owner: 'any', repo: 'repo', issue_number: 123 }]);
@@ -40,47 +127,270 @@ test('requests the labels for the correct repo and pull request', async () => {
 
 test('fulfills with the correct label name', async () => {
     const listLabelsOnIssue = fake.resolves({ data: [{ name: 'bug' }] });
-    const githubClient = createGithubClient({ listLabelsOnIssue });
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
 
     const expectedLabelName = 'bug';
 
     assert.strictEqual(
-        await getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, { githubClient }),
+        await getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
         expectedLabelName
     );
 });
 
 test('uses custom labels when provided', async () => {
     const listLabelsOnIssue = fake.resolves({ data: [{ name: 'addons' }] });
-    const githubClient = createGithubClient({ listLabelsOnIssue });
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
 
     const expectedLabelName = 'addons';
     const customValidLabels = new Map([['addons', 'Addons']]);
 
     assert.strictEqual(
-        await getPullRequestLabel(anyRepo, customValidLabels, anyPullRequestId, { githubClient }),
+        await getPullRequestLabel(anyRepo, customValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
         expectedLabelName
     );
 });
 
 test('rejects if the pull request doesn’t have one valid label', async () => {
-    const githubClient = createGithubClient();
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies();
 
     const expectedErrorMessage = oneLine`Pull Request #123 has no label of breaking, bug,
         feature, enhancement, documentation, upgrade, refactor, build`;
 
-    await assert.rejects(getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, { githubClient }), {
-        message: expectedErrorMessage
-    });
+    await assert.rejects(
+        getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        {
+            message: expectedErrorMessage
+        }
+    );
 });
 
 test('rejects if the pull request has more than one valid label', async () => {
     const listLabelsOnIssue = fake.resolves({ data: [{ name: 'bug' }, { name: 'documentation' }] });
-    const githubClient = createGithubClient({ listLabelsOnIssue });
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
     const expectedErrorMessage = oneLine`Pull Request #123 has multiple labels of breaking,
         bug, feature, enhancement, documentation, upgrade, refactor, build`;
 
-    await assert.rejects(getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, { githubClient }), {
-        message: expectedErrorMessage
+    await assert.rejects(
+        getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        {
+            message: expectedErrorMessage
+        }
+    );
+});
+
+test('retries using the retry-after header', async () => {
+    const listLabelsOnIssue = stub()
+        .onFirstCall()
+        .rejects(
+            createGitHubRateLimitError('You have exceeded a secondary rate limit.', {
+                'retry-after': retryAfterSeconds
+            })
+        );
+    listLabelsOnIssue.onSecondCall().resolves({ data: [{ name: 'bug' }] });
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
     });
+
+    const labelName = await getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+        githubClient,
+        waitForMilliseconds,
+        getCurrentDate,
+        maximumRateLimitRetryCount
+    });
+
+    assert.strictEqual(labelName, 'bug');
+    assert.strictEqual(listLabelsOnIssue.callCount, expectedRequestAttemptCount);
+    assert.strictEqual(waitForMilliseconds.callCount, 1);
+    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [expectedRetryAfterDelayMilliseconds]);
+});
+
+test('retries using the rate limit reset header when retry-after is missing', async () => {
+    const listLabelsOnIssue = stub()
+        .onFirstCall()
+        .rejects(
+            createGitHubRateLimitError('API rate limit exceeded.', {
+                'x-ratelimit-reset': rateLimitResetSeconds
+            })
+        );
+    listLabelsOnIssue.onSecondCall().resolves({ data: [{ name: 'bug' }] });
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
+
+    const labelName = await getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+        githubClient,
+        waitForMilliseconds,
+        getCurrentDate,
+        maximumRateLimitRetryCount
+    });
+
+    assert.strictEqual(labelName, 'bug');
+    assert.strictEqual(listLabelsOnIssue.callCount, expectedRequestAttemptCount);
+    assert.strictEqual(waitForMilliseconds.callCount, 1);
+    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [expectedRateLimitResetDelayMilliseconds]);
+});
+
+test('rejects immediately when a non-error value was thrown', async () => {
+    const rejectedValue = { boom: true };
+    const listLabelsOnIssue = stub().rejects(rejectedValue);
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
+
+    await assert.rejects(
+        async () => {
+            await getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+                githubClient,
+                waitForMilliseconds,
+                getCurrentDate,
+                maximumRateLimitRetryCount
+            });
+        },
+        (error: unknown) => {
+            assert.deepStrictEqual(error, rejectedValue);
+            return true;
+        }
+    );
+
+    assert.strictEqual(waitForMilliseconds.callCount, 0);
+});
+
+test('rejects immediately when the error is not a rate limit error', async () => {
+    const listLabelsOnIssue = stub().rejects(
+        createGitHubErrorWithStatus(internalServerErrorStatus, 'Internal Server Error')
+    );
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
+
+    await assert.rejects(
+        getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        {
+            message: 'Internal Server Error'
+        }
+    );
+
+    assert.strictEqual(waitForMilliseconds.callCount, 0);
+});
+
+test('rejects immediately when a rate limit error does not include retry headers', async () => {
+    const listLabelsOnIssue = stub().rejects(createGitHubRateLimitError('API rate limit exceeded.', {}));
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
+
+    await assert.rejects(
+        getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        {
+            message: 'API rate limit exceeded.'
+        }
+    );
+
+    assert.strictEqual(waitForMilliseconds.callCount, 0);
+});
+
+test('rejects immediately when a rate limit error does not include a headers object', async () => {
+    const listLabelsOnIssue = stub().rejects(createGitHubRateLimitErrorWithoutHeaders('API rate limit exceeded.'));
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
+
+    await assert.rejects(
+        getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        {
+            message: 'API rate limit exceeded.'
+        }
+    );
+
+    assert.strictEqual(waitForMilliseconds.callCount, 0);
+});
+
+test('rejects immediately when retry headers are not numeric', async () => {
+    const listLabelsOnIssue = stub().rejects(
+        createGitHubRateLimitError('API rate limit exceeded.', { 'retry-after': 'not-a-number' })
+    );
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
+
+    await assert.rejects(
+        getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        {
+            message: 'API rate limit exceeded.'
+        }
+    );
+
+    assert.strictEqual(waitForMilliseconds.callCount, 0);
+});
+
+test('rejects immediately when the retry budget is exhausted', async () => {
+    const listLabelsOnIssue = stub().rejects(
+        createGitHubRateLimitError('You have exceeded a secondary rate limit.', {
+            'retry-after': retryAfterSeconds
+        })
+    );
+    const { githubClient, waitForMilliseconds, getCurrentDate } = createDependencies({
+        listLabelsOnIssue,
+        maximumRateLimitRetryCount: 0
+    });
+
+    await assert.rejects(
+        getPullRequestLabel(anyRepo, defaultValidLabels, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount: 0
+        }),
+        {
+            message: 'You have exceeded a secondary rate limit.'
+        }
+    );
+
+    assert.strictEqual(waitForMilliseconds.callCount, 0);
 });

--- a/source/lib/get-pull-request-label.ts
+++ b/source/lib/get-pull-request-label.ts
@@ -1,11 +1,28 @@
 import type { Octokit } from '@octokit/rest';
+import { isError, isFiniteNumber, isString } from '@sindresorhus/is';
+import Maybe from 'true-myth/maybe';
 import { splitByString } from './split.ts';
 
 type Dependencies = {
     readonly githubClient: Octokit;
+    readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
+    readonly getCurrentDate: () => Readonly<Date>;
+    readonly maximumRateLimitRetryCount: number;
 };
 
 export type GetPullRequestLabel = typeof getPullRequestLabel;
+type Headers = Readonly<Record<string, number | string | undefined>>;
+type GitHubClientError = {
+    readonly message: string;
+    readonly status?: number;
+    readonly response?: {
+        readonly headers?: Headers;
+    };
+};
+const millisecondsPerSecond = 1000;
+const noDelayMilliseconds = 0;
+const forbiddenStatusCode = 403;
+const tooManyRequestsStatusCode = 429;
 
 function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo: string]> {
     const [owner, repo] = splitByString(githubRepo, '/');
@@ -31,16 +48,145 @@ async function fetchLabels(
     return labels;
 }
 
+function getHeaderValue(headers: Headers, headerName: string): string | undefined {
+    const value = headers[headerName];
+    if (isString(value)) {
+        return value;
+    }
+
+    if (isFiniteNumber(value)) {
+        return String(value);
+    }
+
+    return undefined;
+}
+
+function parseDelaySeconds(value: string): number | undefined {
+    const delaySeconds = Number(value);
+    if (!isFiniteNumber(delaySeconds)) {
+        return undefined;
+    }
+
+    return delaySeconds;
+}
+
+function determineRetryAfterDelayMilliseconds(headers: Headers): number | undefined {
+    return Maybe.of(getHeaderValue(headers, 'retry-after'))
+        .andThen((retryAfterValue) => {
+            return Maybe.of(parseDelaySeconds(retryAfterValue));
+        })
+        .map((retryAfterSeconds) => {
+            return retryAfterSeconds * millisecondsPerSecond;
+        })
+        .unwrapOr(undefined);
+}
+
+function determineRateLimitResetDelayMilliseconds(headers: Headers, currentDate: Readonly<Date>): number | undefined {
+    return Maybe.of(getHeaderValue(headers, 'x-ratelimit-reset'))
+        .andThen((rateLimitResetValue) => {
+            return Maybe.of(parseDelaySeconds(rateLimitResetValue));
+        })
+        .map((rateLimitResetSeconds) => {
+            const delayMilliseconds = rateLimitResetSeconds * millisecondsPerSecond - currentDate.getTime();
+            return Math.max(delayMilliseconds, noDelayMilliseconds);
+        })
+        .unwrapOr(undefined);
+}
+
+function isGitHubRateLimitError(error: GitHubClientError): boolean {
+    if (error.status !== forbiddenStatusCode && error.status !== tooManyRequestsStatusCode) {
+        return false;
+    }
+
+    return error.message.toLowerCase().includes('rate limit');
+}
+
+function determineRateLimitDelayMilliseconds(
+    error: GitHubClientError,
+    currentDate: Readonly<Date>
+): number | undefined {
+    if (!isGitHubRateLimitError(error)) {
+        return undefined;
+    }
+
+    const headers = error.response?.headers;
+    if (headers === undefined) {
+        return undefined;
+    }
+
+    const rateLimitResetDelayMilliseconds = determineRateLimitResetDelayMilliseconds(headers, currentDate);
+    return determineRetryAfterDelayMilliseconds(headers) ?? rateLimitResetDelayMilliseconds;
+}
+
+function getGitHubClientError(error: unknown): GitHubClientError | undefined {
+    if (!isError(error)) {
+        return undefined;
+    }
+
+    return error as GitHubClientError;
+}
+
+type FetchLabelsWithRateLimitRetryOptions = {
+    readonly githubRepo: string;
+    readonly pullRequestId: number;
+    readonly dependencies: Dependencies;
+};
+
+async function waitForRateLimitResetIfRetryable(
+    error: unknown,
+    dependencies: Dependencies,
+    retryCount: number
+): Promise<boolean> {
+    const { waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = dependencies;
+    const githubClientError = getGitHubClientError(error);
+    if (githubClientError === undefined) {
+        return false;
+    }
+
+    const delayMilliseconds = determineRateLimitDelayMilliseconds(githubClientError, getCurrentDate());
+    if (retryCount >= maximumRateLimitRetryCount || delayMilliseconds === undefined) {
+        return false;
+    }
+
+    await waitForMilliseconds(delayMilliseconds);
+    return true;
+}
+
+async function fetchLabelsWithRateLimitRetry(
+    options: Readonly<FetchLabelsWithRateLimitRetryOptions>,
+    retryCount: number
+): Promise<Label[]> {
+    const { githubRepo, pullRequestId, dependencies } = options;
+    const { githubClient } = dependencies;
+
+    try {
+        return await fetchLabels(githubClient, githubRepo, pullRequestId);
+    } catch (error) {
+        const shouldRetry = await waitForRateLimitResetIfRetryable(error, dependencies, retryCount);
+        if (!shouldRetry) {
+            throw error;
+        }
+
+        return fetchLabelsWithRateLimitRetry(options, retryCount + 1);
+    }
+}
+
 export async function getPullRequestLabel(
     githubRepo: string,
     validLabels: ReadonlyMap<string, string>,
     pullRequestId: number,
     dependencies: Dependencies
 ): Promise<string> {
-    const { githubClient } = dependencies;
     const validLabelNames = Array.from(validLabels.keys());
 
-    const labels = await fetchLabels(githubClient, githubRepo, pullRequestId);
+    const labels = await fetchLabelsWithRateLimitRetry(
+        {
+            githubRepo,
+            pullRequestId,
+            dependencies
+        },
+        0
+    );
 
     const listOfLabels = validLabelNames.join(', ');
     const filteredLabels = labels.filter((label) => {


### PR DESCRIPTION
`pr-log` can fail changelog generation when GitHub throttles repeated pull request label lookups with a rate-limit response.

The failing path is the GitHub API call used to read labels for merged pull requests while building the changelog. Before this change, the retry behavior did not properly follow GitHub’s HTTP backoff instructions. When GitHub returned a secondary rate-limit or rate-limit error, changelog generation could fail even though the response headers contained enough information to retry later.

The new behavior is:

- Prefer retry-after when GitHub provides it
- Fall back to x-ratelimit-reset when retry-after is absent
- Wait for the indicated delay before retrying
- Retry only up to an explicit retry limit

I kept the functional abstraction in the value domain, where it helps, and avoided pushing `Task` into the effect boundary for a relatively small retry flow. That keeps the code explicit and local while still improving the correctness of the retry decision.