### PR TITLE
Fetch pull request titles from GitHub when merge bodies are missing

### DIFF
--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
-import { fake, spy, type SinonSpy } from 'sinon';
+import type { Octokit } from '@octokit/rest';
+import { fake, spy, stub, type SinonSpy } from 'sinon';
 import { defaultValidLabels } from './valid-labels.ts';
 import {
     getMergedPullRequestsFactory,
@@ -17,6 +18,7 @@ type Overrides = {
     readonly listTags?: SinonSpy;
     readonly getMergeCommitLogs?: SinonSpy;
     readonly getPullRequestLabel?: SinonSpy;
+    readonly githubClient?: Octokit;
     readonly waitForMilliseconds?: SinonSpy;
     readonly labelLookupIntervalMilliseconds?: number;
 };
@@ -32,12 +34,18 @@ function factory(overrides: Overrides = {}): GetMergedPullRequests {
         listTags = fake.resolves([latestVersion]),
         getMergeCommitLogs = fake.resolves([]),
         getPullRequestLabel = fake.resolves('bug'),
+        githubClient = {
+            pulls: {
+                get: fake.resolves({ data: { title: 'pull-request-title' } })
+            }
+        } as unknown as Octokit,
         waitForMilliseconds = fake.resolves(undefined),
         labelLookupIntervalMilliseconds
     } = overrides;
 
     const dependencies = {
         getPullRequestLabel,
+        githubClient,
         gitCommandRunner: { listTags, getMergeCommitLogs },
         waitForMilliseconds,
         labelLookupIntervalMilliseconds
@@ -146,7 +154,44 @@ test('throws when the pull request cannot be extracted from the commit message',
     });
 });
 
-test('throws when the the commit log doesn’t have a body', async () => {
+test('falls back to the GitHub API when the commit log doesn’t have a body', async () => {
+    const get = fake.resolves({ data: { title: 'pull request title from github' } });
+    const githubClient = { pulls: { get } } as unknown as Octokit;
+    const getMergeCommitLogs = fake.resolves([
+        {
+            subject: 'Merge pull request #1 from branch',
+            body: undefined
+        }
+    ]);
+    const getMergedPullRequests = factory({ getMergeCommitLogs, githubClient });
+
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+
+    assert.strictEqual(get.callCount, 1);
+    assert.deepStrictEqual(get.firstCall.args, [{ owner: 'any', repo: 'repo', pull_number: 1 }]);
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'pull request title from github', label: 'bug' }]);
+});
+
+test('throws when the title is missing in the commit log and the GitHub API request fails', async () => {
+    const githubClient = {
+        pulls: {
+            get: stub().rejects(new Error('GitHub API failed'))
+        }
+    } as unknown as Octokit;
+    const getMergeCommitLogs = fake.resolves([
+        {
+            subject: 'Merge pull request #1 from branch',
+            body: undefined
+        }
+    ]);
+    const getMergedPullRequests = factory({ getMergeCommitLogs, githubClient });
+
+    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
+        message: 'GitHub API failed'
+    });
+});
+
+test('throws when the title is missing in the commit log and the repo is invalid', async () => {
     const getMergeCommitLogs = fake.resolves([
         {
             subject: 'Merge pull request #1 from branch',
@@ -155,8 +200,8 @@ test('throws when the the commit log doesn’t have a body', async () => {
     ]);
     const getMergedPullRequests = factory({ getMergeCommitLogs });
 
-    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
-        message: 'Failed to extract pull request title from merge commit log'
+    await assert.rejects(getMergedPullRequests('invalid-repo', defaultValidLabels), {
+        message: 'Could not find a repository'
     });
 });
 

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -28,30 +28,77 @@ export type GetMergedPullRequests = (
     validLabels: ReadonlyMap<string, string>
 ) => Promise<readonly PullRequestWithLabel[]>;
 
+type PullRequestData = Readonly<Awaited<ReturnType<Octokit['pulls']['get']>>['data']>;
+
+function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo: string]> {
+    const [owner, repo] = githubRepo.split('/');
+
+    if (owner === undefined || repo === undefined) {
+        throw new TypeError('Could not find a repository');
+    }
+
+    return [owner, repo];
+}
+
+function extractPullRequestId(subject: string): number {
+    const matches = /^Merge pull request #(?<id>\d+) from .*$/u.exec(subject);
+    const pullRequestIdentifier = matches?.groups?.id;
+
+    if (isUndefined(pullRequestIdentifier)) {
+        throw new TypeError('Failed to extract pull request id from merge commit log');
+    }
+
+    return Number.parseInt(pullRequestIdentifier, 10);
+}
+
+async function fetchPullRequestTitle(
+    githubClient: Readonly<Octokit>,
+    githubRepo: string,
+    pullRequestId: number
+): Promise<string> {
+    const [owner, repo] = determineRepoDetails(githubRepo);
+    const { data: pullRequest } = await githubClient.pulls.get({
+        owner,
+        repo,
+        pull_number: pullRequestId
+    });
+
+    return (pullRequest as PullRequestData).title;
+}
+
+async function createPullRequest(
+    githubClient: Readonly<Octokit>,
+    githubRepo: string,
+    mergeCommitLog: { readonly subject: string; readonly body: string | undefined }
+): Promise<PullRequest> {
+    const pullRequestId = extractPullRequestId(mergeCommitLog.subject);
+    const title = mergeCommitLog.body ?? (await fetchPullRequestTitle(githubClient, githubRepo, pullRequestId));
+
+    return { id: pullRequestId, title };
+}
+
 export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequestsDependencies): GetMergedPullRequests {
-    const { gitCommandRunner, getPullRequestLabel, waitForMilliseconds, labelLookupIntervalMilliseconds } =
-        dependencies;
+    const {
+        gitCommandRunner,
+        getPullRequestLabel,
+        githubClient,
+        waitForMilliseconds,
+        labelLookupIntervalMilliseconds
+    } = dependencies;
 
     async function getLatestVersionTag(): Promise<string> {
         const tags = await gitCommandRunner.listTags();
         return determineLatestVersionTag(tags);
     }
 
-    async function getPullRequests(fromTag: string): Promise<readonly PullRequest[]> {
+    async function getPullRequests(fromTag: string, githubRepo: string): Promise<readonly PullRequest[]> {
         const mergeCommits = await gitCommandRunner.getMergeCommitLogs(fromTag);
 
-        return mergeCommits.map((log) => {
-            const matches = /^Merge pull request #(?<id>\d+) from .*$/u.exec(log.subject);
-            if (isUndefined(matches?.groups?.id)) {
-                throw new TypeError('Failed to extract pull request id from merge commit log');
-            }
-
-            if (isUndefined(log.body)) {
-                throw new TypeError('Failed to extract pull request title from merge commit log');
-            }
-
-            return { id: Number.parseInt(matches.groups.id, 10), title: log.body };
-        });
+        return Promise.all(
+            mergeCommits.map(async (log) => {
+                return createPullRequest(githubClient, githubRepo, log);
+            })
+        );
     }
 
     async function extendWithLabel(
@@ -80,7 +127,7 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
 
     return async function getMergedPullRequests(githubRepo: string, validLabels: ReadonlyMap<string, string>) {
         const latestVersionTag = await getLatestVersionTag();
-        const pullRequests = await getPullRequests(latestVersionTag);
+        const pullRequests = await getPullRequests(latestVersionTag, githubRepo);
         const pullRequestsWithLabels = await extendWithLabel(githubRepo, validLabels, pullRequests);
 
         return pullRequestsWithLabels;


### PR DESCRIPTION
Use the GitHub pull request API as a fallback when a merge commit body does not contain the pull request title.

This preserves changelog generation for repositories whose merge commit messages omit the PR body while keeping the existing label lookup flow unchanged.

Fixes #304