### PR TITLE
Support revert commits in merged pull request detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8030,6 +8030,19 @@
             "optional": true,
             "peer": true
         },
+        "node_modules/packtory/node_modules/semver": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",

--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -43,7 +43,9 @@ test('exports pull request collection and label resolution', async () => {
         githubRepo: 'owner/repo',
         baseRef: 'base',
         git: {
-            getMergeCommitLogs: fake.resolves([{ subject: 'Merge pull request #1 from branch', body: 'title' }])
+            getFirstParentCommitLogs: fake.resolves([
+                { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: 'title' }
+            ])
         },
         pullRequestTitleReader: { getTitle: fake.resolves('fallback title') }
     });

--- a/source/index.ts
+++ b/source/index.ts
@@ -12,8 +12,8 @@ import {
 import {
     collectMergedPullRequests as collectMergedPullRequestsValue,
     type CollectMergedPullRequestsInput as CollectMergedPullRequestsInputValue,
+    type FirstParentCommitLogEntry as FirstParentCommitLogEntryValue,
     type GitRangeReader as GitRangeReaderValue,
-    type MergeCommitLogEntry as MergeCommitLogEntryValue,
     type PullRequest as PullRequestValue,
     type PullRequestTitleReader as PullRequestTitleReaderValue
 } from './lib/collect-merged-pull-requests.ts';
@@ -92,10 +92,10 @@ export async function resolvePullRequestLabels(
 export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue;
 export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
+export type FirstParentCommitLogEntry = FirstParentCommitLogEntryValue;
 export type GitRangeReader = GitRangeReaderValue;
 export type GitRefReader = GitRefReaderValue;
 export type LatestSemverTagBaseRefInput = LatestSemverTagBaseRefInputValue;
-export type MergeCommitLogEntry = MergeCommitLogEntryValue;
 export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
 export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;

--- a/source/lib/collect-merged-pull-requests.test.ts
+++ b/source/lib/collect-merged-pull-requests.test.ts
@@ -5,23 +5,85 @@ import { collectMergedPullRequests } from './collect-merged-pull-requests.ts';
 const secondPullRequestId = 2;
 
 test('collects merged pull requests for a base ref', async () => {
-    const getMergeCommitLogs = fake.resolves([
-        { subject: 'Merge pull request #1 from branch', body: 'Use commit body title' },
-        { subject: 'Merge pull request #2 from other', body: undefined }
+    const getFirstParentCommitLogs = fake.resolves([
+        { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: 'Use commit body title' },
+        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: undefined }
     ]);
     const getTitle = fake.resolves('Use GitHub title');
 
     const pullRequests = await collectMergedPullRequests({
         githubRepo: 'owner/repo',
         baseRef: 'base-ref',
-        git: { getMergeCommitLogs },
+        git: { getFirstParentCommitLogs },
         pullRequestTitleReader: { getTitle }
     });
 
-    assert.deepStrictEqual(getMergeCommitLogs.firstCall.args, ['base-ref']);
+    assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, ['base-ref']);
     assert.deepStrictEqual(getTitle.firstCall.args, ['owner/repo', secondPullRequestId]);
     assert.deepStrictEqual(pullRequests, [
         { id: 1, title: 'Use commit body title' },
         { id: secondPullRequestId, title: 'Use GitHub title' }
     ]);
+});
+
+test('removes a merge and its revert when both are in the range', async () => {
+    const revertedMergeCommitHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            subject: 'Revert "Merge pull request #1 from branch"',
+            body: `This reverts commit ${revertedMergeCommitHash}.`
+        },
+        { hash: revertedMergeCommitHash, subject: 'Merge pull request #1 from branch', body: 'Use commit body title' }
+    ]);
+
+    const pullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base-ref',
+        git: { getFirstParentCommitLogs },
+        pullRequestTitleReader: { getTitle: fake.resolves('Use GitHub title') }
+    });
+
+    assert.deepStrictEqual(pullRequests, []);
+});
+
+test('keeps a revert when the reverted merge is outside the range', async () => {
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            subject: 'Revert "Merge pull request #1 from branch"',
+            body: 'This reverts commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
+        }
+    ]);
+    const getTitle = fake.resolves('Use GitHub title');
+
+    const pullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base-ref',
+        git: { getFirstParentCommitLogs },
+        pullRequestTitleReader: { getTitle }
+    });
+
+    assert.deepStrictEqual(getTitle.firstCall.args, ['owner/repo', 1]);
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Revert "Use GitHub title"' }]);
+});
+
+test('throws when the reverted pull request cannot be extracted from the commit message', async () => {
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            subject: 'Revert "Merge pull request foo from branch"',
+            body: 'This reverts commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
+        }
+    ]);
+
+    await assert.rejects(
+        collectMergedPullRequests({
+            githubRepo: 'owner/repo',
+            baseRef: 'base-ref',
+            git: { getFirstParentCommitLogs },
+            pullRequestTitleReader: { getTitle: fake.resolves('Use GitHub title') }
+        }),
+        { message: 'Failed to extract pull request id from reverted merge commit log' }
+    );
 });

--- a/source/lib/collect-merged-pull-requests.ts
+++ b/source/lib/collect-merged-pull-requests.ts
@@ -5,13 +5,14 @@ export type PullRequest = {
     readonly title: string;
 };
 
-export type MergeCommitLogEntry = {
+export type FirstParentCommitLogEntry = {
+    readonly hash: string;
     readonly subject: string;
     readonly body: string | undefined;
 };
 
 export type GitRangeReader = {
-    getMergeCommitLogs(baseRef: string): Promise<readonly MergeCommitLogEntry[]>;
+    getFirstParentCommitLogs(baseRef: string): Promise<readonly FirstParentCommitLogEntry[]>;
 };
 
 export type PullRequestTitleReader = {
@@ -25,35 +26,138 @@ export type CollectMergedPullRequestsInput = {
     readonly pullRequestTitleReader: PullRequestTitleReader;
 };
 
-function extractPullRequestId(subject: string): number {
+type MergedPullRequestCommit = {
+    readonly type: 'merge';
+    readonly id: number;
+    readonly title: string | undefined;
+};
+
+type RevertedPullRequestCommit = {
+    readonly type: 'revert';
+    readonly id: number;
+};
+
+type PullRequestCommit = MergedPullRequestCommit | RevertedPullRequestCommit;
+
+function parsePullRequestId(value: string): number {
+    return Number.parseInt(value, 10);
+}
+
+function extractPullRequestId(subject: string): number | undefined {
     const matches = /^Merge pull request #(?<id>\d+) from .*$/u.exec(subject);
     const pullRequestIdentifier = matches?.groups?.id;
 
     if (isUndefined(pullRequestIdentifier)) {
-        throw new TypeError('Failed to extract pull request id from merge commit log');
+        if (subject.startsWith('Merge pull request ')) {
+            throw new TypeError('Failed to extract pull request id from merge commit log');
+        }
+
+        return undefined;
     }
 
-    return Number.parseInt(pullRequestIdentifier, 10);
+    return parsePullRequestId(pullRequestIdentifier);
+}
+
+function extractRevertedPullRequestId(subject: string): number | undefined {
+    const matches = /^Revert "Merge pull request #(?<id>\d+) from .*"$/u.exec(subject);
+    const pullRequestIdentifier = matches?.groups?.id;
+
+    if (isUndefined(pullRequestIdentifier)) {
+        if (subject.startsWith('Revert "Merge pull request ')) {
+            throw new TypeError('Failed to extract pull request id from reverted merge commit log');
+        }
+
+        return undefined;
+    }
+
+    return parsePullRequestId(pullRequestIdentifier);
+}
+
+function extractRevertedCommitHash(commitBody: string | undefined): string | undefined {
+    const matches = /^This reverts commit (?<hash>[0-9a-f]+)\./mu.exec(commitBody ?? '');
+    return matches?.groups?.hash;
+}
+
+function collectActiveFirstParentCommitLogs(
+    firstParentCommitLogs: readonly FirstParentCommitLogEntry[]
+): readonly FirstParentCommitLogEntry[] {
+    const firstParentCommitHashes = new Set(
+        firstParentCommitLogs.map((firstParentCommitLog) => {
+            return firstParentCommitLog.hash;
+        })
+    );
+    const revertedCommitHashes = new Set<string>();
+
+    return firstParentCommitLogs.reduce<readonly FirstParentCommitLogEntry[]>(
+        (activeCommitLogs, firstParentCommitLog) => {
+            if (revertedCommitHashes.has(firstParentCommitLog.hash)) {
+                return activeCommitLogs;
+            }
+
+            const revertedCommitHash = extractRevertedCommitHash(firstParentCommitLog.body);
+            if (!isUndefined(revertedCommitHash) && firstParentCommitHashes.has(revertedCommitHash)) {
+                revertedCommitHashes.add(revertedCommitHash);
+                return activeCommitLogs;
+            }
+
+            return [...activeCommitLogs, firstParentCommitLog];
+        },
+        []
+    );
+}
+
+function createPullRequestCommit(firstParentCommitLog: FirstParentCommitLogEntry): PullRequestCommit | undefined {
+    const pullRequestId = extractPullRequestId(firstParentCommitLog.subject);
+
+    if (!isUndefined(pullRequestId)) {
+        return { type: 'merge', id: pullRequestId, title: firstParentCommitLog.body };
+    }
+
+    const revertedPullRequestId = extractRevertedPullRequestId(firstParentCommitLog.subject);
+
+    if (!isUndefined(revertedPullRequestId)) {
+        return { type: 'revert', id: revertedPullRequestId };
+    }
+
+    return undefined;
 }
 
 async function createPullRequest(
     input: Pick<CollectMergedPullRequestsInput, 'githubRepo' | 'pullRequestTitleReader'>,
-    mergeCommitLog: MergeCommitLogEntry
-): Promise<PullRequest> {
-    const pullRequestId = extractPullRequestId(mergeCommitLog.subject);
-    const title = mergeCommitLog.body ?? (await input.pullRequestTitleReader.getTitle(input.githubRepo, pullRequestId));
+    firstParentCommitLog: FirstParentCommitLogEntry
+): Promise<PullRequest | undefined> {
+    const pullRequestCommit = createPullRequestCommit(firstParentCommitLog);
 
-    return { id: pullRequestId, title };
+    if (isUndefined(pullRequestCommit)) {
+        return undefined;
+    }
+
+    if (pullRequestCommit.type === 'revert') {
+        const title = await input.pullRequestTitleReader.getTitle(input.githubRepo, pullRequestCommit.id);
+        return { id: pullRequestCommit.id, title: `Revert "${title}"` };
+    }
+
+    const title =
+        pullRequestCommit.title ??
+        (await input.pullRequestTitleReader.getTitle(input.githubRepo, pullRequestCommit.id));
+
+    return { id: pullRequestCommit.id, title };
+}
+
+function isPullRequest(pullRequest: PullRequest | undefined): pullRequest is PullRequest {
+    return !isUndefined(pullRequest);
 }
 
 export async function collectMergedPullRequests(
     input: CollectMergedPullRequestsInput
 ): Promise<readonly PullRequest[]> {
-    const mergeCommits = await input.git.getMergeCommitLogs(input.baseRef);
-
-    return Promise.all(
-        mergeCommits.map(async (log) => {
+    const firstParentCommitLogs = await input.git.getFirstParentCommitLogs(input.baseRef);
+    const activeFirstParentCommitLogs = collectActiveFirstParentCommitLogs(firstParentCommitLogs);
+    const pullRequests = await Promise.all(
+        activeFirstParentCommitLogs.map(async (log) => {
             return createPullRequest(input, log);
         })
     );
+
+    return pullRequests.filter(isPullRequest);
 }

--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -13,10 +13,11 @@ const latestVersion = '1.2.3';
 const expectedPullRequestLabelCallCount = 2;
 const expectedWaitForMillisecondsCallCount = 2;
 const comparedArgumentCount = 3;
+const secondPullRequestIdentifier = 2;
 
 type Overrides = {
     readonly listTags?: SinonSpy;
-    readonly getMergeCommitLogs?: SinonSpy;
+    readonly getFirstParentCommitLogs?: SinonSpy;
     readonly getPullRequestLabel?: SinonSpy;
     readonly githubClient?: Octokit;
     readonly waitForMilliseconds?: SinonSpy;
@@ -32,7 +33,7 @@ type ControlledLabelLookup = {
 function factory(overrides: Overrides = {}): GetMergedPullRequests {
     const {
         listTags = fake.resolves([latestVersion]),
-        getMergeCommitLogs = fake.resolves([]),
+        getFirstParentCommitLogs = fake.resolves([]),
         getPullRequestLabel = fake.resolves('bug'),
         githubClient = {
             pulls: {
@@ -46,7 +47,7 @@ function factory(overrides: Overrides = {}): GetMergedPullRequests {
     const dependencies = {
         getPullRequestLabel,
         githubClient,
-        gitCommandRunner: { listTags, getMergeCommitLogs },
+        gitCommandRunner: { listTags, getFirstParentCommitLogs },
         waitForMilliseconds,
         labelLookupIntervalMilliseconds
     } as unknown as GetMergedPullRequestsDependencies;
@@ -109,61 +110,63 @@ test('throws when there are only non-semver tags', async () => {
 
 test('ignores non-semver tag', async () => {
     const listTags = fake.resolves(['0.0.1', 'foo', '0.0.2', '0.0.0.0.1']);
-    const getMergeCommitLogs = fake.resolves([]);
-    const getMergedPullRequests = factory({ listTags, getMergeCommitLogs });
+    const getFirstParentCommitLogs = fake.resolves([]);
+    const getMergedPullRequests = factory({ listTags, getFirstParentCommitLogs });
 
     await getMergedPullRequests(anyRepo, defaultValidLabels);
 
-    assert.strictEqual(getMergeCommitLogs.callCount, 1);
-    assert.deepStrictEqual(getMergeCommitLogs.firstCall.args, ['0.0.2']);
+    assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
+    assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, ['0.0.2']);
 });
 
 test('always uses the highest version', async () => {
     const listTags = fake.resolves(['1.0.0', '0.0.0', '0.7.5', '2.0.0', '0.2.5', '0.5.0']);
-    const getMergeCommitLogs = fake.resolves([]);
-    const getMergedPullRequests = factory({ listTags, getMergeCommitLogs });
+    const getFirstParentCommitLogs = fake.resolves([]);
+    const getMergedPullRequests = factory({ listTags, getFirstParentCommitLogs });
 
     await getMergedPullRequests(anyRepo, defaultValidLabels);
 
-    assert.strictEqual(getMergeCommitLogs.callCount, 1);
-    assert.deepStrictEqual(getMergeCommitLogs.firstCall.args, ['2.0.0']);
+    assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
+    assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, ['2.0.0']);
 });
 
 test('ignores prerelease versions', async () => {
     const listTags = fake.resolves(['1.0.0', '0.0.0', '0.7.5', '2.0.0', '0.2.5', '3.0.0-alpha.1']);
-    const getMergeCommitLogs = fake.resolves([]);
-    const getMergedPullRequests = factory({ listTags, getMergeCommitLogs });
+    const getFirstParentCommitLogs = fake.resolves([]);
+    const getMergedPullRequests = factory({ listTags, getFirstParentCommitLogs });
 
     await getMergedPullRequests(anyRepo, defaultValidLabels);
 
-    assert.strictEqual(getMergeCommitLogs.callCount, 1);
-    assert.deepStrictEqual(getMergeCommitLogs.firstCall.args, ['2.0.0']);
+    assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
+    assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, ['2.0.0']);
 });
 
 test('throws when the pull request cannot be extracted from the commit message', async () => {
-    const getMergeCommitLogs = fake.resolves([
+    const getFirstParentCommitLogs = fake.resolves([
         {
+            hash: 'hash-1',
             subject: 'Merge pull request foo from branch',
             body: 'pr-1 message'
         }
     ]);
-    const getMergedPullRequests = factory({ getMergeCommitLogs });
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs });
 
     await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
         message: 'Failed to extract pull request id from merge commit log'
     });
 });
 
-test('falls back to the GitHub API when the commit log doesn’t have a body', async () => {
+test('falls back to the GitHub API when the commit log does not have a body', async () => {
     const get = fake.resolves({ data: { title: 'pull request title from github' } });
     const githubClient = { pulls: { get } } as unknown as Octokit;
-    const getMergeCommitLogs = fake.resolves([
+    const getFirstParentCommitLogs = fake.resolves([
         {
+            hash: 'hash-1',
             subject: 'Merge pull request #1 from branch',
             body: undefined
         }
     ]);
-    const getMergedPullRequests = factory({ getMergeCommitLogs, githubClient });
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, githubClient });
 
     const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
 
@@ -178,13 +181,14 @@ test('throws when the title is missing in the commit log and the GitHub API requ
             get: stub().rejects(new Error('GitHub API failed'))
         }
     } as unknown as Octokit;
-    const getMergeCommitLogs = fake.resolves([
+    const getFirstParentCommitLogs = fake.resolves([
         {
+            hash: 'hash-1',
             subject: 'Merge pull request #1 from branch',
             body: undefined
         }
     ]);
-    const getMergedPullRequests = factory({ getMergeCommitLogs, githubClient });
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, githubClient });
 
     await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
         message: 'GitHub API failed'
@@ -192,13 +196,14 @@ test('throws when the title is missing in the commit log and the GitHub API requ
 });
 
 test('throws when the title is missing in the commit log and the repo is invalid', async () => {
-    const getMergeCommitLogs = fake.resolves([
+    const getFirstParentCommitLogs = fake.resolves([
         {
+            hash: 'hash-1',
             subject: 'Merge pull request #1 from branch',
             body: undefined
         }
     ]);
-    const getMergedPullRequests = factory({ getMergeCommitLogs });
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs });
 
     await assert.rejects(getMergedPullRequests('invalid-repo', defaultValidLabels), {
         message: 'Could not find a repository'
@@ -209,14 +214,15 @@ test('extracts id, title and label for merged pull requests', async () => {
     const firstExpectedPullRequest = { id: 1, title: 'pr-1 message', label: 'bug' };
     const secondExpectedPullRequest = { id: 2, title: 'pr-2 message', label: 'bug' };
     const getPullRequestLabel = fake.resolves('bug');
-    const getMergeCommitLogs = fake.resolves([
+    const getFirstParentCommitLogs = fake.resolves([
         {
+            hash: 'hash-1',
             subject: 'Merge pull request #1 from branch',
             body: 'pr-1 message'
         },
-        { subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
+        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
     ]);
-    const getMergedPullRequests = factory({ getMergeCommitLogs, getPullRequestLabel });
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabel });
 
     const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
 
@@ -231,20 +237,20 @@ test('extracts id, title and label for merged pull requests', async () => {
         defaultValidLabels,
         secondExpectedPullRequest.id
     ]);
-
     assert.deepStrictEqual(pullRequests, [firstExpectedPullRequest, secondExpectedPullRequest]);
 });
 
 test('looks up pull request labels sequentially', async () => {
-    const getMergeCommitLogs = fake.resolves([
+    const getFirstParentCommitLogs = fake.resolves([
         {
+            hash: 'hash-1',
             subject: 'Merge pull request #1 from branch',
             body: 'pr-1 message'
         },
-        { subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
+        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
     ]);
     const { getPullRequestLabel, firstLabelLookupStarted, resolveFirstLabelLookup } = createControlledLabelLookup();
-    const getMergedPullRequests = factory({ getMergeCommitLogs, getPullRequestLabel });
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabel });
     const mergedPullRequests = getMergedPullRequests(anyRepo, defaultValidLabels);
 
     await firstLabelLookupStarted;
@@ -268,18 +274,19 @@ test('looks up pull request labels sequentially', async () => {
 });
 
 test('waits between pull request label lookups', async () => {
-    const getMergeCommitLogs = fake.resolves([
+    const getFirstParentCommitLogs = fake.resolves([
         {
+            hash: 'hash-1',
             subject: 'Merge pull request #1 from branch',
             body: 'pr-1 message'
         },
-        { subject: 'Merge pull request #2 from other', body: 'pr-2 message' },
-        { subject: 'Merge pull request #3 from third', body: 'pr-3 message' }
+        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: 'pr-2 message' },
+        { hash: 'hash-3', subject: 'Merge pull request #3 from third', body: 'pr-3 message' }
     ]);
     const waitForMilliseconds = fake.resolves(undefined);
     const labelLookupIntervalMilliseconds = 123;
     const getMergedPullRequests = factory({
-        getMergeCommitLogs,
+        getFirstParentCommitLogs,
         waitForMilliseconds,
         labelLookupIntervalMilliseconds
     });
@@ -289,4 +296,97 @@ test('waits between pull request label lookups', async () => {
     assert.strictEqual(waitForMilliseconds.callCount, expectedWaitForMillisecondsCallCount);
     assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [labelLookupIntervalMilliseconds]);
     assert.deepStrictEqual(waitForMilliseconds.secondCall.args, [labelLookupIntervalMilliseconds]);
+});
+
+test('ignores first-parent commits that are not merge commits', async () => {
+    const getFirstParentCommitLogs = fake.resolves([
+        { hash: 'hash-2', subject: 'chore: prepare release', body: 'release housekeeping' },
+        { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: 'pr-1 message' }
+    ]);
+    const getPullRequestLabel = fake.resolves('bug');
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabel });
+
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+
+    assert.strictEqual(getPullRequestLabel.callCount, 1);
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'pr-1 message', label: 'bug' }]);
+});
+
+test('ignores merge commits that were reverted later', async () => {
+    const revertedMergeCommitHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'cccccccccccccccccccccccccccccccccccccccc',
+            subject: 'Revert "Merge pull request #1 from branch"',
+            body: `This reverts commit ${revertedMergeCommitHash}.`
+        },
+        {
+            hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            subject: 'Merge pull request #2 from other',
+            body: 'pr-2 message'
+        },
+        { hash: revertedMergeCommitHash, subject: 'Merge pull request #1 from branch', body: 'pr-1 message' }
+    ]);
+    const getPullRequestLabel = fake.resolves('bug');
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabel });
+
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+
+    assert.strictEqual(getPullRequestLabel.callCount, 1);
+    assert.deepStrictEqual(getPullRequestLabel.firstCall.args.slice(0, comparedArgumentCount), [
+        'any/repo',
+        defaultValidLabels,
+        secondPullRequestIdentifier
+    ]);
+    assert.deepStrictEqual(pullRequests, [{ id: secondPullRequestIdentifier, title: 'pr-2 message', label: 'bug' }]);
+});
+
+test('includes a merge commit again when its revert was reverted later', async () => {
+    const revertedMergeCommitHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const revertCommitHash = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'cccccccccccccccccccccccccccccccccccccccc',
+            subject: 'Revert "Revert \\"Merge pull request #1 from branch\\""',
+            body: `This reverts commit ${revertCommitHash}.`
+        },
+        {
+            hash: revertCommitHash,
+            subject: 'Revert "Merge pull request #1 from branch"',
+            body: `This reverts commit ${revertedMergeCommitHash}.`
+        },
+        { hash: revertedMergeCommitHash, subject: 'Merge pull request #1 from branch', body: 'pr-1 message' }
+    ]);
+    const getPullRequestLabel = fake.resolves('bug');
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabel });
+
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+
+    assert.strictEqual(getPullRequestLabel.callCount, 1);
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'pr-1 message', label: 'bug' }]);
+});
+
+test('includes a revert commit when the reverted merge was already released', async () => {
+    const get = fake.resolves({ data: { title: 'pr-1 message' } });
+    const githubClient = { pulls: { get } } as unknown as Octokit;
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            subject: 'Revert "Merge pull request #1 from branch"',
+            body: 'This reverts commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
+        }
+    ]);
+    const getPullRequestLabel = fake.resolves('bug');
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabel, githubClient });
+
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+
+    assert.deepStrictEqual(get.firstCall.args, [{ owner: 'any', repo: 'repo', pull_number: 1 }]);
+    assert.strictEqual(getPullRequestLabel.callCount, 1);
+    assert.deepStrictEqual(getPullRequestLabel.firstCall.args.slice(0, comparedArgumentCount), [
+        'any/repo',
+        defaultValidLabels,
+        1
+    ]);
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Revert "pr-1 message"', label: 'bug' }]);
 });

--- a/source/lib/git-command-runner.test.ts
+++ b/source/lib/git-command-runner.test.ts
@@ -227,3 +227,84 @@ test('getMergeCommitLogs() falls back to undefined when the body is an empty str
 
     assert.deepStrictEqual(result, [{ subject: 'foo', body: undefined }]);
 });
+
+test('getFirstParentCommitLogs() executes "git log" with the correct options', async () => {
+    const execute = fake.resolves({ stdout: '' });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    await runner.getFirstParentCommitLogs('foo');
+
+    assert.strictEqual(execute.callCount, 1);
+    assert.deepStrictEqual(execute.firstCall.args, [
+        'git log --first-parent --no-color --pretty=format:%H__||__%s__||__%b##$$@@$$## foo..HEAD'
+    ]);
+});
+
+test('getFirstParentCommitLogs() returns the parsed command output', async () => {
+    const execute = fake.resolves({
+        stdout: 'hash-1__||__foo__||__bar##$$@@$$##\nhash-2__||__baz__||__qux##$$@@$$##\n\n'
+    });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    const result = await runner.getFirstParentCommitLogs('');
+
+    assert.deepStrictEqual(result, [
+        { hash: 'hash-1', subject: 'foo', body: 'bar' },
+        { hash: 'hash-2', subject: 'baz', body: 'qux' }
+    ]);
+});
+
+test('getFirstParentCommitLogs() parses multi-line message bodies correctly', async () => {
+    const execute = fake.resolves({
+        stdout: 'hash-1__||__foo__||__bar\nbaz\nqux##$$@@$$##\nhash-2__||__baz__||__qux##$$@@$$##\n\n'
+    });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    const result = await runner.getFirstParentCommitLogs('');
+
+    assert.deepStrictEqual(result, [
+        { hash: 'hash-1', subject: 'foo', body: 'bar\nbaz\nqux' },
+        { hash: 'hash-2', subject: 'baz', body: 'qux' }
+    ]);
+});
+
+test('getFirstParentCommitLogs() parses multi-line bodies correctly when it doesn’t end with a line break', async () => {
+    const execute = fake.resolves({
+        stdout: 'hash-1__||__foo__||__bar\nbaz\nqux##$$@@$$##\nhash-2__||__baz__||__qux##$$@@$$##'
+    });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    const result = await runner.getFirstParentCommitLogs('');
+
+    assert.deepStrictEqual(result, [
+        { hash: 'hash-1', subject: 'foo', body: 'bar\nbaz\nqux' },
+        { hash: 'hash-2', subject: 'baz', body: 'qux' }
+    ]);
+});
+
+test('getFirstParentCommitLogs() falls back to undefined when the body couldn’t be extracted', async () => {
+    const execute = fake.resolves({ stdout: 'hash-1__||__foo##$$@@$$##\n\n\n' });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    const result = await runner.getFirstParentCommitLogs('');
+
+    assert.deepStrictEqual(result, [{ hash: 'hash-1', subject: 'foo', body: undefined }]);
+});
+
+test('getFirstParentCommitLogs() falls back to undefined when the body is an empty string', async () => {
+    const execute = fake.resolves({ stdout: 'hash-1__||__foo__||__##$$@@$$##\n\n\n' });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    const result = await runner.getFirstParentCommitLogs('');
+
+    assert.deepStrictEqual(result, [{ hash: 'hash-1', subject: 'foo', body: undefined }]);
+});
+
+test('getFirstParentCommitLogs() throws when the commit subject cannot be determined', async () => {
+    const execute = fake.resolves({ stdout: 'hash-1##$$@@$$##\n\n\n' });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    await assert.rejects(runner.getFirstParentCommitLogs(''), {
+        message: 'Failed to determine git commit log entry'
+    });
+});

--- a/source/lib/git-command-runner.ts
+++ b/source/lib/git-command-runner.ts
@@ -12,6 +12,15 @@ type MergeCommitLogEntry = {
     readonly body: string | undefined;
 };
 
+type FirstParentCommitLogEntry = {
+    readonly hash: string;
+    readonly subject: string;
+    readonly body: string | undefined;
+};
+
+type FirstParentCommitLogFields = readonly [hash: string, subject: string, body: string | undefined];
+type FirstParentCommitLogParts = readonly [hash: string, subject: string, ...remainingFields: readonly string[]];
+
 export type GitCommandRunner = {
     getShortStatus(): Promise<string>;
     getCurrentBranchName(): Promise<string>;
@@ -21,6 +30,7 @@ export type GitCommandRunner = {
     listTags(): Promise<readonly string[]>;
     hasRef(ref: string): Promise<boolean>;
     getMergeCommitLogs(from: string): Promise<readonly MergeCommitLogEntry[]>;
+    getFirstParentCommitLogs(from: string): Promise<readonly FirstParentCommitLogEntry[]>;
 };
 
 export type GitCommandRunnerDependencies = {
@@ -41,11 +51,22 @@ function splitLines(value: string, lineSeparator = '\n'): readonly string[] {
 
 const lineSeparator = '##$$@@$$##';
 const fieldSeparator = '__||__';
+const minimumCommitLogFieldCount = 2;
+const bodyFieldIndex = 2;
 
-function createParsableGitLogFormat(): string {
+function createParsableMergeGitLogFormat(): string {
     const subjectPlaceholder = '%s';
     const bodyPlaceholder = '%b';
     const fields = [subjectPlaceholder, bodyPlaceholder];
+
+    return `${fields.join(fieldSeparator)}${lineSeparator}`;
+}
+
+function createParsableFirstParentGitLogFormat(): string {
+    const hashPlaceholder = '%H';
+    const subjectPlaceholder = '%s';
+    const bodyPlaceholder = '%b';
+    const fields = [hashPlaceholder, subjectPlaceholder, bodyPlaceholder];
 
     return `${fields.join(fieldSeparator)}${lineSeparator}`;
 }
@@ -59,47 +80,124 @@ async function hasExistingRef(execute: typeof execaCommand, ref: string): Promis
     }
 }
 
+function hasFirstParentCommitLogFields(parts: readonly string[]): parts is FirstParentCommitLogParts {
+    return parts.length >= minimumCommitLogFieldCount;
+}
+
+function parseFirstParentCommitLogFields(log: string): FirstParentCommitLogFields {
+    const parts = splitByString(log, fieldSeparator);
+
+    if (!hasFirstParentCommitLogFields(parts)) {
+        throw new TypeError('Failed to determine git commit log entry');
+    }
+
+    const [hash, subject] = parts;
+    const body = parts[bodyFieldIndex];
+
+    return [hash, subject, body];
+}
+
+async function readShortStatus(execute: typeof execaCommand): Promise<string> {
+    const result = await execute('git status --short');
+    return result.stdout.trim();
+}
+
+async function readCurrentBranchName(execute: typeof execaCommand): Promise<string> {
+    const result = await execute('git rev-parse --abbrev-ref HEAD');
+    return result.stdout.trim();
+}
+
+async function fetchRemoteByAlias(execute: typeof execaCommand, remoteAlias: string): Promise<void> {
+    await execute(`git fetch ${remoteAlias}`);
+}
+
+async function readSymmetricBranchDifferences(
+    execute: typeof execaCommand,
+    branchA: string,
+    branchB: string
+): Promise<readonly string[]> {
+    const result = await execute(`git rev-list --left-right ${branchA}...${branchB}`);
+    return splitLines(result.stdout);
+}
+
+async function readRemoteAliases(execute: typeof execaCommand): Promise<readonly RemoteAlias[]> {
+    const result = await execute('git remote -v');
+
+    return splitLines(result.stdout).map((line: string) => {
+        const remoteLineTokens = splitByPattern(line, /\s/);
+        const [alias, url] = remoteLineTokens;
+
+        if (url === undefined) {
+            throw new TypeError('Failed to determine git remote alias');
+        }
+
+        return { alias, url };
+    });
+}
+
+async function readTags(execute: typeof execaCommand): Promise<readonly string[]> {
+    const result = await execute('git tag --list');
+    return splitLines(result.stdout);
+}
+
+async function readMergeCommitLogs(
+    execute: typeof execaCommand,
+    from: string
+): Promise<readonly MergeCommitLogEntry[]> {
+    const result = await execute(oneLine`git log --first-parent --no-color
+        --pretty=format:${createParsableMergeGitLogFormat()} --merges ${from}..HEAD`);
+
+    const logs = splitLines(result.stdout, lineSeparator);
+    return logs.map((log) => {
+        const parts = splitByString(log, fieldSeparator);
+        const [subject, body] = parts;
+
+        return { subject, body: body === '' ? undefined : body };
+    });
+}
+
+async function readFirstParentCommitLogs(
+    execute: typeof execaCommand,
+    from: string
+): Promise<readonly FirstParentCommitLogEntry[]> {
+    const result = await execute(
+        oneLine`git log --first-parent --no-color
+            --pretty=format:${createParsableFirstParentGitLogFormat()} ${from}..HEAD`
+    );
+
+    const logs = splitLines(result.stdout, lineSeparator);
+    return logs.map((log) => {
+        const [hash, subject, body] = parseFirstParentCommitLogFields(log);
+        return { hash, subject, body: body === '' ? undefined : body };
+    });
+}
+
 export function createGitCommandRunner(dependencies: GitCommandRunnerDependencies): GitCommandRunner {
     const { execute } = dependencies;
 
     return {
         async getShortStatus() {
-            const result = await execute('git status --short');
-            return result.stdout.trim();
+            return readShortStatus(execute);
         },
 
         async getCurrentBranchName() {
-            const result = await execute('git rev-parse --abbrev-ref HEAD');
-            return result.stdout.trim();
+            return readCurrentBranchName(execute);
         },
 
         async fetchRemote(remoteAlias) {
-            await execute(`git fetch ${remoteAlias}`);
+            return fetchRemoteByAlias(execute, remoteAlias);
         },
 
         async getSymmetricDifferencesBetweenBranches(branchA, branchB) {
-            const result = await execute(`git rev-list --left-right ${branchA}...${branchB}`);
-            return splitLines(result.stdout);
+            return readSymmetricBranchDifferences(execute, branchA, branchB);
         },
 
         async getRemoteAliases() {
-            const result = await execute('git remote -v');
-
-            return splitLines(result.stdout).map((line: string) => {
-                const remoteLineTokens = splitByPattern(line, /\s/);
-                const [alias, url] = remoteLineTokens;
-
-                if (url === undefined) {
-                    throw new TypeError('Failed to determine git remote alias');
-                }
-
-                return { alias, url };
-            });
+            return readRemoteAliases(execute);
         },
 
         async listTags() {
-            const result = await execute('git tag --list');
-            return splitLines(result.stdout);
+            return readTags(execute);
         },
 
         async hasRef(ref) {
@@ -107,16 +205,11 @@ export function createGitCommandRunner(dependencies: GitCommandRunnerDependencie
         },
 
         async getMergeCommitLogs(from) {
-            const result = await execute(oneLine`git log --first-parent --no-color
-                    --pretty=format:${createParsableGitLogFormat()} --merges ${from}..HEAD`);
+            return readMergeCommitLogs(execute, from);
+        },
 
-            const logs = splitLines(result.stdout, lineSeparator);
-            return logs.map((log) => {
-                const parts = splitByString(log, fieldSeparator);
-                const [subject, body] = parts;
-
-                return { subject, body: body === '' ? undefined : body };
-            });
+        async getFirstParentCommitLogs(from) {
+            return readFirstParentCommitLogs(execute, from);
         }
     };
 }


### PR DESCRIPTION
Read first-parent history so revert commits can affect changelog collection. Reverts remove an in-range merge and its revert from the release notes, while reverts of merges that were already released remain as `Revert "<original title>"` entries using the original pull request label and title lookup.\n\nFixes #303