### PR TITLE
Collapse repeated upgrade changelog entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,49 @@ If you want to use a custom date format you can configure `pr-log.dateFormat` in
 
 Please refer to the [`dates-fn` documentation](https://date-fns.org/docs/format) for details about the format expressions.
 
+#### Collapse repeated pull requests
+
+If your changelog tends to collect several pull requests that represent one logical change, you can configure `pr-log.collapseRules`.
+This is useful for dependency upgrade bots, but the feature is intentionally generic and works with any pull request title format you control.
+
+Each collapse rule:
+
+-   applies only to one label
+-   matches pull request titles with a regular expression
+-   groups entries by one named capture group
+-   collapses only continuous chains where one entry ends with the version the next entry starts from
+-   renders the collapsed title with a replacement template
+
+For example:
+
+```json
+{
+    "pr-log": {
+        "collapseRules": [
+            {
+                "label": "upgrade",
+                "pattern": "^Update (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$",
+                "replace": "Update $<dependency> from $<from> to $<to>"
+            }
+        ]
+    }
+}
+```
+
+With that configuration, these pull requests in one release:
+
+-   `Update foo from 1 to 2`
+-   `Update foo from 2 to 3`
+-   `Update foo from 3 to 4`
+
+become one changelog entry:
+
+-   `Update foo from 1 to 4`
+
+The default capture group names are `dependency`, `from`, and `to`.
+If your title format uses different names, you can override them with `keyGroup`, `fromGroup`, and `toGroup`.
+Collapsed entries include links to all pull requests that contributed to the final line item.
+
 ## Usage
 
 To create or update your changelog run

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ This is useful for dependency upgrade bots, but the feature is intentionally gen
 
 Each collapse rule:
 
--   applies only to one label
--   matches pull request titles with a regular expression
--   groups entries by one named capture group
--   collapses only continuous chains where one entry ends with the version the next entry starts from
--   renders the collapsed title with a replacement template
+- applies only to one label
+- matches pull request titles with a regular expression
+- groups entries by one named capture group
+- collapses only continuous chains where one entry ends with the version the next entry starts from
+- renders the collapsed title with a replacement template
 
 For example:
 
@@ -130,13 +130,13 @@ For example:
 
 With that configuration, these pull requests in one release:
 
--   `Update foo from 1 to 2`
--   `Update foo from 2 to 3`
--   `Update foo from 3 to 4`
+- `Update foo from 1 to 2`
+- `Update foo from 2 to 3`
+- `Update foo from 3 to 4`
 
 become one changelog entry:
 
--   `Update foo from 1 to 4`
+- `Update foo from 1 to 4`
 
 The default capture group names are `dependency`, `from`, and `to`.
 If your title format uses different names, you can override them with `keyGroup`, `fromGroup`, and `toGroup`.

--- a/source/lib/create-changelog.test.ts
+++ b/source/lib/create-changelog.test.ts
@@ -14,13 +14,34 @@ const changelogOptionsFactory = Factory.define<ChangelogOptions>(() => {
     };
 });
 
-test('contains no title when version was not released', () => {
-    const createChangelog = createChangelogFactory({
+function createChangelogWithPackageInfo(
+    packageInfo: Record<string, unknown> = {}
+): ReturnType<typeof createChangelogFactory> {
+    return createChangelogFactory({
         getCurrentDate: () => {
             return new Date(0);
         },
-        packageInfo: {}
+        packageInfo
     });
+}
+
+function createUpgradeCollapseRulePackageInfo(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        'pr-log': {
+            collapseRules: [
+                {
+                    label: 'upgrade',
+                    pattern: '^Update (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
+                    replace: 'Update $<dependency> from $<from> to $<to>',
+                    ...overrides
+                }
+            ]
+        }
+    };
+}
+
+test('contains no title when version was not released', () => {
+    const createChangelog = createChangelogWithPackageInfo();
     const options = changelogOptionsFactory.build({
         unreleased: true,
         versionNumber: Maybe.nothing()
@@ -33,12 +54,7 @@ test('contains no title when version was not released', () => {
 });
 
 test('contains a title with the version number and the formatted date when version was released', () => {
-    const createChangelog = createChangelogFactory({
-        getCurrentDate: () => {
-            return new Date(0);
-        },
-        packageInfo: {}
-    });
+    const createChangelog = createChangelogWithPackageInfo();
     const options = changelogOptionsFactory.build();
     const changelog = createChangelog(options);
     const expectedTitle = '## 1.0.0 (January 1, 1970)';
@@ -48,12 +64,7 @@ test('contains a title with the version number and the formatted date when versi
 
 test('format the date with a custom date format when version was released', () => {
     const packageInfo = { 'pr-log': { dateFormat: 'dd.MM.yyyy' } };
-    const createChangelog = createChangelogFactory({
-        getCurrentDate: () => {
-            return new Date(0);
-        },
-        packageInfo
-    });
+    const createChangelog = createChangelogWithPackageInfo(packageInfo);
     const options = changelogOptionsFactory.build();
     const changelog = createChangelog(options);
     const expectedTitle = '## 1.0.0 (01.01.1970)';
@@ -62,12 +73,7 @@ test('format the date with a custom date format when version was released', () =
 });
 
 test('creates a formatted changelog when version was released', () => {
-    const createChangelog = createChangelogFactory({
-        getCurrentDate: () => {
-            return new Date(0);
-        },
-        packageInfo: {}
-    });
+    const createChangelog = createChangelogWithPackageInfo();
     const mergedPullRequests = [
         {
             id: 1,
@@ -108,12 +114,7 @@ test('creates a formatted changelog when version was released', () => {
 });
 
 test('uses custom labels when provided and version was released', () => {
-    const createChangelog = createChangelogFactory({
-        getCurrentDate: () => {
-            return new Date(0);
-        },
-        packageInfo: {}
-    });
+    const createChangelog = createChangelogWithPackageInfo();
     const customValidLabels = new Map([
         ['core', 'Core Features'],
         ['addons', 'Addons']
@@ -159,12 +160,7 @@ test('uses custom labels when provided and version was released', () => {
 });
 
 test('uses the same order for the changelog sections as in validLabels when version was released', () => {
-    const createChangelog = createChangelogFactory({
-        getCurrentDate: () => {
-            return new Date(0);
-        },
-        packageInfo: {}
-    });
+    const createChangelog = createChangelogWithPackageInfo();
     const customValidLabels = new Map([
         ['first', 'First Section'],
         ['second', 'Second Section']
@@ -207,4 +203,141 @@ test('uses the same order for the changelog sections as in validLabels when vers
     const changelog = createChangelog(options);
 
     assert.ok(changelog.includes(expectedChangelog));
+});
+
+test('collapses repeated pull requests when a matching collapse rule is configured', () => {
+    const createChangelog = createChangelogWithPackageInfo(createUpgradeCollapseRulePackageInfo());
+    const validLabels = new Map([['upgrade', 'Dependency Upgrades']]);
+    const mergedPullRequests = [
+        {
+            id: 4,
+            title: 'Update foo from 3 to 4',
+            label: 'upgrade'
+        },
+        {
+            id: 5,
+            title: 'Update bar from 1 to 2',
+            label: 'upgrade'
+        },
+        {
+            id: 3,
+            title: 'Update foo from 2 to 3',
+            label: 'upgrade'
+        },
+        {
+            id: 2,
+            title: 'Update foo from 1 to 2',
+            label: 'upgrade'
+        }
+    ] as const;
+
+    const expectedChangelog = [
+        '### Dependency Upgrades',
+        '',
+        '* Update foo from 1 to 4 ([#4](https://github.com/any/repo/pull/4), [#3](https://github.com/any/repo/pull/3), [#2](https://github.com/any/repo/pull/2))',
+        '* Update bar from 1 to 2 ([#5](https://github.com/any/repo/pull/5))',
+        ''
+    ].join('\n');
+
+    const options = changelogOptionsFactory.build({
+        validLabels,
+        mergedPullRequests,
+        githubRepo: 'any/repo'
+    });
+    const changelog = createChangelog(options);
+
+    assert.ok(changelog.includes(expectedChangelog));
+});
+
+test('does not collapse pull requests when the configured version chain is incomplete', () => {
+    const createChangelog = createChangelogWithPackageInfo(createUpgradeCollapseRulePackageInfo());
+    const validLabels = new Map([['upgrade', 'Dependency Upgrades']]);
+    const mergedPullRequests = [
+        {
+            id: 4,
+            title: 'Update foo from 3 to 4',
+            label: 'upgrade'
+        },
+        {
+            id: 2,
+            title: 'Update foo from 1 to 2',
+            label: 'upgrade'
+        }
+    ] as const;
+
+    const expectedChangelog = [
+        '### Dependency Upgrades',
+        '',
+        '* Update foo from 3 to 4 ([#4](https://github.com/any/repo/pull/4))',
+        '* Update foo from 1 to 2 ([#2](https://github.com/any/repo/pull/2))',
+        ''
+    ].join('\n');
+
+    const options = changelogOptionsFactory.build({
+        validLabels,
+        mergedPullRequests,
+        githubRepo: 'any/repo'
+    });
+    const changelog = createChangelog(options);
+
+    assert.ok(changelog.includes(expectedChangelog));
+});
+
+test('supports custom capture group names in collapse rules', () => {
+    const createChangelog = createChangelogWithPackageInfo({
+        'pr-log': {
+            collapseRules: [
+                {
+                    label: 'upgrade',
+                    pattern: '^Bump (?<name>.+?) \\((?<previous>.+?) -> (?<next>.+?)\\)$',
+                    replace: 'Bump $<name> ($<previous> -> $<next>)',
+                    keyGroup: 'name',
+                    fromGroup: 'previous',
+                    toGroup: 'next'
+                }
+            ]
+        }
+    });
+    const validLabels = new Map([['upgrade', 'Dependency Upgrades']]);
+    const mergedPullRequests = [
+        {
+            id: 3,
+            title: 'Bump foo (2 -> 3)',
+            label: 'upgrade'
+        },
+        {
+            id: 2,
+            title: 'Bump foo (1 -> 2)',
+            label: 'upgrade'
+        }
+    ] as const;
+
+    const expectedChangelog = [
+        '### Dependency Upgrades',
+        '',
+        '* Bump foo (1 -> 3) ([#3](https://github.com/any/repo/pull/3), [#2](https://github.com/any/repo/pull/2))',
+        ''
+    ].join('\n');
+
+    const options = changelogOptionsFactory.build({
+        validLabels,
+        mergedPullRequests,
+        githubRepo: 'any/repo'
+    });
+    const changelog = createChangelog(options);
+
+    assert.ok(changelog.includes(expectedChangelog));
+});
+
+test('throws when a collapse rule is missing required fields', () => {
+    assert.throws(
+        () => {
+            createChangelogWithPackageInfo({
+                'pr-log': {
+                    collapseRules: [{ label: 'upgrade', pattern: '^Update .+$' }]
+                }
+            });
+        },
+        { message: 'pr-log.collapseRules[].replace must be a string' }
+    );
 });

--- a/source/lib/create-changelog.test.ts
+++ b/source/lib/create-changelog.test.ts
@@ -329,6 +329,46 @@ test('supports custom capture group names in collapse rules', () => {
     assert.ok(changelog.includes(expectedChangelog));
 });
 
+test('falls back to an empty string for missing placeholders in collapse rule replacements', () => {
+    const createChangelog = createChangelogWithPackageInfo({
+        'pr-log': {
+            collapseRules: [
+                {
+                    label: 'upgrade',
+                    pattern: '^Update (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
+                    replace: 'Update $<dependency> from $<from> to $<to>$<suffix>'
+                }
+            ]
+        }
+    });
+    const validLabels = new Map([['upgrade', 'Dependency Upgrades']]);
+    const mergedPullRequests = [
+        {
+            id: 3,
+            title: 'Update foo from 2 to 3',
+            label: 'upgrade'
+        },
+        {
+            id: 2,
+            title: 'Update foo from 1 to 2',
+            label: 'upgrade'
+        }
+    ] as const;
+
+    const options = changelogOptionsFactory.build({
+        validLabels,
+        mergedPullRequests,
+        githubRepo: 'any/repo'
+    });
+    const changelog = createChangelog(options);
+
+    assert.ok(
+        changelog.includes(
+            '* Update foo from 1 to 3 ([#3](https://github.com/any/repo/pull/3), [#2](https://github.com/any/repo/pull/2))'
+        )
+    );
+});
+
 test('throws when a collapse rule is missing required fields', () => {
     assert.throws(
         () => {
@@ -341,3 +381,88 @@ test('throws when a collapse rule is missing required fields', () => {
         { message: 'pr-log.collapseRules[].replace must be a string' }
     );
 });
+
+test('throws when a collapse rule entry is not an object', () => {
+    assert.throws(
+        () => {
+            createChangelogWithPackageInfo({
+                'pr-log': {
+                    collapseRules: ['invalid']
+                }
+            });
+        },
+        { message: 'pr-log.collapseRules[] entries must be objects' }
+    );
+});
+
+test('does not collapse pull requests when titles do not match the configured collapse rule', () => {
+    const createChangelog = createChangelogWithPackageInfo(createUpgradeCollapseRulePackageInfo());
+    const validLabels = new Map([['upgrade', 'Dependency Upgrades']]);
+    const mergedPullRequests = [
+        {
+            id: 7,
+            title: 'Refresh foo dependency',
+            label: 'upgrade'
+        }
+    ] as const;
+
+    const options = changelogOptionsFactory.build({
+        validLabels,
+        mergedPullRequests,
+        githubRepo: 'any/repo'
+    });
+    const changelog = createChangelog(options);
+
+    assert.ok(changelog.includes('* Refresh foo dependency ([#7](https://github.com/any/repo/pull/7))'));
+});
+
+const invalidCaptureGroupTestCases = [
+    {
+        testName: 'throws when the configured key capture group is missing',
+        packageInfo: createUpgradeCollapseRulePackageInfo({
+            keyGroup: 'packageName'
+        }),
+        expectedErrorMessage: 'Collapse rule for label "upgrade" requires capture group "packageName"'
+    },
+    {
+        testName: 'throws when the configured from capture group is missing',
+        packageInfo: createUpgradeCollapseRulePackageInfo({
+            fromGroup: 'previous'
+        }),
+        expectedErrorMessage: 'Collapse rule for label "upgrade" requires capture group "previous"'
+    },
+    {
+        testName: 'throws when the configured to capture group is missing',
+        packageInfo: createUpgradeCollapseRulePackageInfo({
+            toGroup: 'next'
+        }),
+        expectedErrorMessage: 'Collapse rule for label "upgrade" requires capture group "next"'
+    }
+] as const;
+
+for (const testCase of invalidCaptureGroupTestCases) {
+    test(testCase.testName, () => {
+        const createChangelog = createChangelogWithPackageInfo(testCase.packageInfo);
+        const validLabels = new Map([['upgrade', 'Dependency Upgrades']]);
+        const mergedPullRequests = [
+            {
+                id: 2,
+                title: 'Update foo from 1 to 2',
+                label: 'upgrade'
+            }
+        ] as const;
+
+        const options = changelogOptionsFactory.build({
+            validLabels,
+            mergedPullRequests,
+            githubRepo: 'any/repo'
+        });
+
+        assert.throws(
+            () => {
+                createChangelog(options);
+            },
+            { message: testCase.expectedErrorMessage }
+        );
+    });
+}

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -225,7 +225,7 @@ function createUpdatedChains(
     const { rule, ruleMatch } = context;
     const previousChain = existingChains.at(-1);
 
-    if (previousChain === undefined || previousChain.groups[rule.fromGroup] !== ruleMatch.to) {
+    if (previousChain?.groups[rule.fromGroup] !== ruleMatch.to) {
         return [...existingChains, createCollapseChain(index, entry, ruleMatch.groups)];
     }
 

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -2,26 +2,35 @@ import { format as formatDate } from 'date-fns';
 import { isPlainObject, isArray, isString } from '@sindresorhus/is';
 import enLocale from 'date-fns/locale/en-US/index.js';
 import type { Just, Nothing } from 'true-myth/maybe';
-import type { PullRequest, PullRequestWithLabel } from './get-merged-pull-requests.ts';
+import type { PullRequestWithLabel } from './get-merged-pull-requests.ts';
 
 function formatLinkToPullRequest(pullRequestId: number, repo: string): string {
     return `[#${pullRequestId}](https://github.com/${repo}/pull/${pullRequestId})`;
 }
 
-function formatPullRequest(pullRequest: PullRequest, repo: string): string {
-    return `* ${pullRequest.title} (${formatLinkToPullRequest(pullRequest.id, repo)})\n`;
+type ChangelogEntry = {
+    readonly title: string;
+    readonly pullRequestIds: readonly number[];
+};
+
+function formatPullRequest(entry: ChangelogEntry, repo: string): string {
+    const formattedLinks = entry.pullRequestIds.map((pullRequestId) => {
+        return formatLinkToPullRequest(pullRequestId, repo);
+    });
+
+    return `* ${entry.title} (${formattedLinks.join(', ')})\n`;
 }
 
-function formatListOfPullRequests(pullRequests: readonly PullRequest[], repo: string): string {
-    return pullRequests
-        .map((pr) => {
-            return formatPullRequest(pr, repo);
+function formatListOfPullRequests(entries: readonly ChangelogEntry[], repo: string): string {
+    return entries
+        .map((entry) => {
+            return formatPullRequest(entry, repo);
         })
         .join('');
 }
 
-function formatSection(displayLabel: string, pullRequests: readonly PullRequest[], repo: string): string {
-    return `### ${displayLabel}\n\n${formatListOfPullRequests(pullRequests, repo)}\n`;
+function formatSection(displayLabel: string, entries: readonly ChangelogEntry[], repo: string): string {
+    return `### ${displayLabel}\n\n${formatListOfPullRequests(entries, repo)}\n`;
 }
 
 export type CreateChangelog = (options: ChangelogOptions) => string;
@@ -41,6 +50,56 @@ function getConfigValueFromPackageInfo(packageInfo: PackageInfo, fieldName: stri
     return fallback;
 }
 
+type CollapseRule = {
+    readonly label: string;
+    readonly pattern: RegExp;
+    readonly replace: string;
+    readonly keyGroup: string;
+    readonly fromGroup: string;
+    readonly toGroup: string;
+};
+
+function getRequiredStringField(rule: Record<string, unknown>, fieldName: string): string {
+    const value = rule[fieldName];
+
+    if (!isString(value)) {
+        throw new TypeError(`pr-log.collapseRules[].${fieldName} must be a string`);
+    }
+
+    return value;
+}
+
+function createCollapseRule(rule: Record<string, unknown>): CollapseRule {
+    const customKeyGroup = rule.keyGroup;
+    const customFromGroup = rule.fromGroup;
+    const customToGroup = rule.toGroup;
+
+    return {
+        label: getRequiredStringField(rule, 'label'),
+        pattern: new RegExp(getRequiredStringField(rule, 'pattern'), 'u'),
+        replace: getRequiredStringField(rule, 'replace'),
+        keyGroup: isString(customKeyGroup) ? customKeyGroup : 'dependency',
+        fromGroup: isString(customFromGroup) ? customFromGroup : 'from',
+        toGroup: isString(customToGroup) ? customToGroup : 'to'
+    };
+}
+
+function getCollapseRules(packageInfo: PackageInfo): readonly CollapseRule[] {
+    const prLogConfig = packageInfo['pr-log'];
+
+    if (!isPlainObject(prLogConfig) || !isArray(prLogConfig.collapseRules)) {
+        return [];
+    }
+
+    return prLogConfig.collapseRules.map((rule) => {
+        if (!isPlainObject(rule)) {
+            throw new TypeError('pr-log.collapseRules[] entries must be objects');
+        }
+
+        return createCollapseRule(rule);
+    });
+}
+
 function groupByLabel(pullRequests: readonly PullRequestWithLabel[]): Record<string, PullRequestWithLabel[]> {
     return pullRequests.reduce((groupedObject: Record<string, PullRequestWithLabel[]>, pullRequest) => {
         const { label } = pullRequest;
@@ -58,6 +117,212 @@ function groupByLabel(pullRequests: readonly PullRequestWithLabel[]): Record<str
             [label]: [pullRequest]
         };
     }, {});
+}
+
+type ChangelogEntryWithLabel = ChangelogEntry & {
+    readonly label: string;
+};
+
+type CollapseMatch = {
+    readonly groups: Record<string, string>;
+};
+
+type RuleMatch = CollapseMatch & {
+    readonly key: string;
+    readonly from: string;
+    readonly to: string;
+};
+
+type CollapseChain = {
+    readonly firstIndex: number;
+    readonly indexes: readonly number[];
+    readonly groups: Readonly<Record<string, string>>;
+    readonly pullRequestIds: readonly number[];
+};
+
+function createChangelogEntries(pullRequests: readonly PullRequestWithLabel[]): readonly ChangelogEntryWithLabel[] {
+    return pullRequests.map((pullRequest) => {
+        return {
+            title: pullRequest.title,
+            pullRequestIds: [pullRequest.id],
+            label: pullRequest.label
+        };
+    });
+}
+
+function getRuleGroups(match: CollapseMatch, rule: CollapseRule): Readonly<[string, string, string]> {
+    const key = match.groups[rule.keyGroup];
+    const from = match.groups[rule.fromGroup];
+    const to = match.groups[rule.toGroup];
+
+    if (key === undefined) {
+        throw new TypeError(`Collapse rule for label "${rule.label}" requires capture group "${rule.keyGroup}"`);
+    }
+    if (from === undefined) {
+        throw new TypeError(`Collapse rule for label "${rule.label}" requires capture group "${rule.fromGroup}"`);
+    }
+    if (to === undefined) {
+        throw new TypeError(`Collapse rule for label "${rule.label}" requires capture group "${rule.toGroup}"`);
+    }
+
+    return [key, from, to];
+}
+
+function renderCollapsedTitle(replace: string, groups: Record<string, string>): string {
+    return replace.replaceAll(/\$<(?<groupName>[^>]+)>/gu, (_match, groupName: string) => {
+        return groups[groupName] ?? '';
+    });
+}
+
+function getRuleMatch(entry: ChangelogEntryWithLabel, rule: CollapseRule): RuleMatch | undefined {
+    const match = rule.pattern.exec(entry.title);
+
+    if (match?.groups === undefined) {
+        return undefined;
+    }
+
+    const [key, from, to] = getRuleGroups({ groups: match.groups }, rule);
+
+    return { key, from, to, groups: { ...match.groups } };
+}
+
+function createExtendedChain(
+    chain: CollapseChain,
+    entry: ChangelogEntryWithLabel,
+    index: number,
+    update: { readonly fromGroup: string; readonly from: string }
+): CollapseChain {
+    return {
+        ...chain,
+        indexes: [...chain.indexes, index],
+        groups: {
+            ...chain.groups,
+            [update.fromGroup]: update.from
+        },
+        pullRequestIds: [...chain.pullRequestIds, ...entry.pullRequestIds]
+    };
+}
+
+function createCollapseChain(
+    index: number,
+    entry: ChangelogEntryWithLabel,
+    groups: Record<string, string>
+): CollapseChain {
+    return {
+        firstIndex: index,
+        indexes: [index],
+        groups,
+        pullRequestIds: Array.from(entry.pullRequestIds)
+    };
+}
+
+function createUpdatedChains(
+    existingChains: readonly CollapseChain[],
+    entry: ChangelogEntryWithLabel,
+    index: number,
+    context: { readonly rule: CollapseRule; readonly ruleMatch: RuleMatch }
+): readonly CollapseChain[] {
+    const { rule, ruleMatch } = context;
+    const previousChain = existingChains.at(-1);
+
+    if (previousChain === undefined || previousChain.groups[rule.fromGroup] !== ruleMatch.to) {
+        return [...existingChains, createCollapseChain(index, entry, ruleMatch.groups)];
+    }
+
+    return [
+        ...existingChains.slice(0, -1),
+        createExtendedChain(previousChain, entry, index, {
+            fromGroup: rule.fromGroup,
+            from: ruleMatch.from
+        })
+    ];
+}
+
+function createUpdatedChainsByKey(
+    chainsByKey: ReadonlyMap<string, readonly CollapseChain[]>,
+    entry: ChangelogEntryWithLabel,
+    index: number,
+    rule: CollapseRule
+): ReadonlyMap<string, readonly CollapseChain[]> {
+    const ruleMatch = getRuleMatch(entry, rule);
+
+    if (ruleMatch === undefined) {
+        return chainsByKey;
+    }
+
+    const nextChainsByKey = new Map(chainsByKey);
+    const existingChains = chainsByKey.get(ruleMatch.key) ?? [];
+    const updatedChains = createUpdatedChains(existingChains, entry, index, { rule, ruleMatch });
+
+    nextChainsByKey.set(ruleMatch.key, updatedChains);
+    return nextChainsByKey;
+}
+
+function createChainsByKey(
+    entries: readonly ChangelogEntryWithLabel[],
+    rule: CollapseRule
+): ReadonlyMap<string, readonly CollapseChain[]> {
+    return entries.reduce<ReadonlyMap<string, readonly CollapseChain[]>>((chainsByKey, entry, index) => {
+        return createUpdatedChainsByKey(chainsByKey, entry, index, rule);
+    }, new Map<string, readonly CollapseChain[]>());
+}
+
+function createCollapsedEntriesByIndex(
+    chainsByKey: ReadonlyMap<string, readonly CollapseChain[]>,
+    rule: CollapseRule
+): Readonly<[Map<number, ChangelogEntryWithLabel>, Set<number>]> {
+    const collapsedEntries = new Map<number, ChangelogEntryWithLabel>();
+    const skippedIndexes = new Set<number>();
+    const minimumChainLength = 2;
+    const collapsedChains = Array.from(chainsByKey.values())
+        .flat()
+        .filter((chain) => {
+            return chain.indexes.length >= minimumChainLength;
+        });
+
+    collapsedChains.forEach((chain) => {
+        const [, ...remainingIndexes] = chain.indexes;
+
+        collapsedEntries.set(chain.firstIndex, {
+            title: renderCollapsedTitle(rule.replace, chain.groups),
+            pullRequestIds: chain.pullRequestIds,
+            label: rule.label
+        });
+
+        remainingIndexes.forEach((index) => {
+            skippedIndexes.add(index);
+        });
+    });
+
+    return [collapsedEntries, skippedIndexes];
+}
+
+function collapseEntriesForRule(
+    entries: readonly ChangelogEntryWithLabel[],
+    rule: CollapseRule
+): readonly ChangelogEntryWithLabel[] {
+    const chainsByKey = createChainsByKey(entries, rule);
+    const [collapsedEntries, skippedIndexes] = createCollapsedEntriesByIndex(chainsByKey, rule);
+
+    return entries.flatMap((entry, index) => {
+        if (skippedIndexes.has(index)) {
+            return [];
+        }
+
+        return [collapsedEntries.get(index) ?? entry];
+    });
+}
+
+function collapseEntries(
+    label: string,
+    entries: readonly ChangelogEntryWithLabel[],
+    rules: readonly CollapseRule[]
+): readonly ChangelogEntryWithLabel[] {
+    return rules
+        .filter((rule) => {
+            return rule.label === label;
+        })
+        .reduce(collapseEntriesForRule, entries);
 }
 
 type Dependencies = {
@@ -88,6 +353,7 @@ const defaultDateFormat = 'MMMM d, yyyy';
 export function createChangelogFactory(dependencies: Dependencies): CreateChangelog {
     const { getCurrentDate, packageInfo } = dependencies;
     const dateFormat = getConfigValueFromPackageInfo(packageInfo, 'dateFormat', defaultDateFormat);
+    const collapseRules = getCollapseRules(packageInfo);
 
     function createChangelogTitle(options: ChangelogOptions): string {
         const { unreleased } = options;
@@ -112,7 +378,8 @@ export function createChangelogFactory(dependencies: Dependencies): CreateChange
             const pullRequests = groupedPullRequests[label];
 
             if (isArray(pullRequests)) {
-                changelog += formatSection(displayLabel, pullRequests, githubRepo);
+                const entries = collapseEntries(label, createChangelogEntries(pullRequests), collapseRules);
+                changelog += formatSection(displayLabel, entries, githubRepo);
             }
         }
 


### PR DESCRIPTION
Adds configurable collapse rules so repeated upgrade PRs can be merged into a single changelog entry.