### PR TITLE
Add `@pr-log/core` API package

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,34 @@ Given the following setup:
 - Fix some spelling mistakes in documentation. (#22)
 ```
 
+## Library API
+
+The reusable changelog behavior is published as `@pr-log/core`.
+The CLI package `pr-log` composes the same API.
+
+```ts
+import {
+    collectMergedPullRequests,
+    resolveLatestSemverTagBaseRef,
+    resolvePullRequestLabels,
+    renderChangelogMarkdown
+} from '@pr-log/core';
+```
+
+`@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, and changelog rendering.
+Package impact and release planning stay outside pr-log.
+
+## Publishing
+
+This repo uses packtory to publish `pr-log` and `@pr-log/core` from one build without npm workspaces.
+Versions are manual and independent.
+
+```sh
+just pack-all
+just publish-dry-run
+just publish
+```
+
 ### Options
 
 #### --sloppy

--- a/justfile
+++ b/justfile
@@ -22,6 +22,26 @@ lint: eslint prettier-check
 
 lint-fix: eslint-fix prettier-fix
 
+prepare-packtory-source: compile
+    rm -rf target/packtory/source
+    cp -R target/build/source target/packtory/source
+    perl -pi -e 's/from ([\x22\x27])(\.[^\x22\x27]+)\.ts\1/from $1$2.js$1/g' $(find target/packtory/source -name '*.d.ts')
+
+pack PACKAGE VERSION OUTPUT: prepare-packtory-source
+    mkdir -p target/packages
+    packtory pack {{PACKAGE}} --format tar --out {{OUTPUT}} --version {{VERSION}}
+
+pack-all: prepare-packtory-source
+    mkdir -p target/packages
+    packtory pack pr-log --format tar --out target/packages/pr-log-6.1.1.tgz --version 6.1.1
+    packtory pack @pr-log/core --format tar --out target/packages/@pr-log-core-0.1.0.tgz --version 0.1.0
+
+publish: prepare-packtory-source
+    packtory publish --no-dry-run
+
+publish-dry-run: prepare-packtory-source
+    packtory publish
+
 test-unit:
     mocha --config mocha.config.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "@enormora/eslint-config-mocha": "0.0.26",
                 "@enormora/eslint-config-node": "0.0.26",
                 "@enormora/eslint-config-typescript": "0.0.36",
+                "@packtory/cli": "0.0.30",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.12.4",
@@ -49,10 +50,75 @@
                 "node": "^24.0.0 || ^26.0.0"
             }
         },
+        "node_modules/@andrewbranch/untar.js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+            "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+            "dev": true
+        },
+        "node_modules/@arethetypeswrong/core": {
+            "version": "0.18.3",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.3.tgz",
+            "integrity": "sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@andrewbranch/untar.js": "^1.0.3",
+                "@loaderkit/resolve": "^1.0.2",
+                "cjs-module-lexer": "^1.2.3",
+                "fflate": "^0.8.3",
+                "lru-cache": "^11.0.1",
+                "semver": "^7.5.4",
+                "typescript": "5.6.1-rc",
+                "validate-npm-package-name": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+            "version": "5.6.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+            "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -68,6 +134,13 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/@braidai/lang": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+            "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@cspell/cspell-bundled-dicts": {
             "version": "10.0.0",
@@ -1290,6 +1363,16 @@
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
+        "node_modules/@gar/promise-retry": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+            "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1384,6 +1467,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1412,6 +1506,16 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@loaderkit/resolve": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz",
+            "integrity": "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@braidai/lang": "^1.0.0"
+            }
+        },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -1429,6 +1533,228 @@
             "peerDependencies": {
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@npmcli/agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-5.0.1.tgz",
+            "integrity": "sha512-PsOUeQRpNOGH+Iks/YPY8AXtttvGVqNqKIo/Cp2LhI0jpeqW32JP14yYRym+OsTg+roH4Avw281YwHMp8X8L2Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^9.0.0",
+                "http-proxy-agent": "^9.0.0",
+                "https-proxy-agent": "^9.0.0",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^10.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/@npmcli/agent/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@npmcli/fs": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-6.0.0.tgz",
+            "integrity": "sha512-AheOs4swKka/XLtht6xxJDPezlQ7K2IYQ9Y8lST4JLDjnralnWuMM9AE2CdVcgQJ5omrXhsRzM7F7aYmeZBvKQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/@npmcli/git": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+            "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "ini": "^6.0.0",
+                "lru-cache": "^11.2.1",
+                "npm-pick-manifest": "^11.0.1",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/git/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@npmcli/git/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@npmcli/git/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/package-json": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+            "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "glob": "^13.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.5.3",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/package-json/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/package-json/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@npmcli/package-json/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@npmcli/promise-spawn": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+            "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@npmcli/promise-spawn/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@npmcli/redact": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-5.0.0.tgz",
+            "integrity": "sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@octokit/auth-token": {
@@ -1594,6 +1920,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@packtory/cli": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.30.tgz",
+            "integrity": "sha512-DGjOB232XujyPVk5TGI77zJebXsR8aj5LqbiR54qYleSwlMECUR3qtJadp1yMnySndkeVrDTqpXqnfiipXiANw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cmd-ts": "0.15.0",
+                "open": "11.0.0",
+                "packtory": "0.0.30",
+                "remeda": "2.37.0",
+                "ts-pattern": "5.9.0",
+                "yoctocolors": "2.1.2"
+            },
+            "bin": {
+                "packtory": "packages/command-line-interface/command-line-interface.entry-point.js"
+            },
+            "engines": {
+                "node": "^24 || ^26"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1618,11 +1965,351 @@
                 "url": "https://opencollective.com/pkgr"
             }
         },
+        "node_modules/@pnpm/config.env-replace": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "4.2.10"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@pnpm/npm-conf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+            "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pnpm/config.env-replace": "^1.1.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@schema-hub/zod-error-formatter": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.11.tgz",
+            "integrity": "sha512-5U+75sWcq9BBzNO0ui7iJZfhkU3QLpeZiF4uuxrWqpSYfmrfzyGOjVGfSVWTWeGlIZaepaON2eVn9ugTWvjppQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22 || ^24"
+            },
+            "peerDependencies": {
+                "zod": "^4.0.5"
+            }
+        },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
             "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
             "license": "MIT"
+        },
+        "node_modules/@sigstore/bundle": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+            "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/core": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
+            "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/protobuf-specs": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+            "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@sigstore/sign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+            "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.2",
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.0",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "make-fetch-happen": "^15.0.4",
+                "proc-log": "^6.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/@npmcli/fs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/@npmcli/redact": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/cacache": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^5.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/agent": "^4.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "cacache": "^20.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/minipass-fetch": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            },
+            "optionalDependencies": {
+                "iconv-lite": "^0.7.2"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sigstore/sign/node_modules/socks-proxy-agent": {
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@sigstore/tuf": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+            "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "tuf-js": "^4.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@sigstore/verify": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
+            "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.1",
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
         },
         "node_modules/@sindresorhus/is": {
             "version": "8.1.0",
@@ -1710,6 +2397,42 @@
                 "eslint": "^9.0.0 || ^10.0.0"
             }
         },
+        "node_modules/@ts-morph/common": {
+            "version": "0.29.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.29.0.tgz",
+            "integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimatch": "^10.0.1",
+                "path-browserify": "^1.0.1",
+                "tinyglobby": "^0.2.14"
+            }
+        },
+        "node_modules/@tufjs/canonical-json": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+            "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@tufjs/models": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+            "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/canonical-json": "2.0.0",
+                "minimatch": "^10.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.2",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -1773,6 +2496,55 @@
                 "undici-types": "~7.16.0"
             }
         },
+        "node_modules/@types/node-fetch": {
+            "version": "2.6.13",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+            "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "form-data": "^4.0.4"
+            }
+        },
+        "node_modules/@types/normalize-package-data": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/npm-package-arg": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/@types/npm-package-arg/-/npm-package-arg-6.1.4.tgz",
+            "integrity": "sha512-vDgdbMy2QXHnAruzlv68pUtXCjmqUk3WrBAsRboRovsOmxbfn/WiYCjmecyKjGztnMps5dWp4Uq2prp+Ilo17Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/npm-registry-fetch": {
+            "version": "8.0.9",
+            "resolved": "https://registry.npmjs.org/@types/npm-registry-fetch/-/npm-registry-fetch-8.0.9.tgz",
+            "integrity": "sha512-7NxvodR5Yrop3pb6+n8jhJNyzwOX0+6F+iagNEoi9u1CGxruYAwZD8pvGc9prIkL0+FdX5Xp0p80J9QPrGUp/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/node-fetch": "*",
+                "@types/npm-package-arg": "*",
+                "@types/npmlog": "*",
+                "@types/ssri": "*"
+            }
+        },
+        "node_modules/@types/npmlog": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-7.0.0.tgz",
+            "integrity": "sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/parse-github-repo-url": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/@types/parse-github-repo-url/-/parse-github-repo-url-1.4.2.tgz",
@@ -1809,6 +2581,16 @@
             "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/ssri": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.5.tgz",
+            "integrity": "sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.58.1",
@@ -2233,9 +3015,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2250,9 +3029,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2267,9 +3043,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2284,9 +3057,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2301,9 +3071,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2318,9 +3085,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2335,9 +3099,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2352,9 +3113,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2369,9 +3127,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2386,9 +3141,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2493,6 +3245,16 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.15.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2508,6 +3270,61 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-align": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.1.0"
+            }
+        },
+        "node_modules/ansi-align/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ansi-align/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/ansi-regex": {
@@ -2553,6 +3370,39 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/atomically": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+            "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "stubborn-fs": "^2.0.0",
+                "when-exit": "^2.1.4"
+            }
+        },
+        "node_modules/b4a": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "*"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -2561,6 +3411,103 @@
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/bare-events": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+            "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-fs": {
+            "version": "4.7.2",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+            "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4",
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
+            },
+            "engines": {
+                "bare": ">=1.16.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-os": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "bare": ">=1.14.0"
+            }
+        },
+        "node_modules/bare-path": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+            "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-os": "^3.0.1"
+            }
+        },
+        "node_modules/bare-stream": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "streamx": "^2.25.0",
+                "teex": "^1.0.1"
+            },
+            "peerDependencies": {
+                "bare-abort-controller": "*",
+                "bare-buffer": "*",
+                "bare-events": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                },
+                "bare-buffer": {
+                    "optional": true
+                },
+                "bare-events": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/bare-url": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/baseline-browser-mapping": {
@@ -2576,11 +3523,147 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/beautiful-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/beautiful-error/-/beautiful-error-1.1.0.tgz",
+            "integrity": "sha512-kpsSnOEEykI2K/8fW7G3KoJ41683jH9MqU6PhWlzI9cm33pS6k04jWGMUpZLMKarw07d5IwS295aI10Wk7Fjzw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk-string": "^4.0.0",
+                "figures": "^6.0.1",
+                "filter-obj": "^6.1.0",
+                "is-error-instance": "^3.0.1",
+                "is-plain-obj": "^4.1.0",
+                "normalize-exception": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
         "node_modules/before-after-hook": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
             "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
             "license": "Apache-2.0"
+        },
+        "node_modules/boxen": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+            "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-align": "^3.0.1",
+                "camelcase": "^8.0.0",
+                "chalk": "^5.3.0",
+                "cli-boxes": "^3.0.0",
+                "string-width": "^7.2.0",
+                "type-fest": "^4.21.0",
+                "widest-line": "^5.0.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/boxen/node_modules/camelcase": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+            "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/boxen/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/boxen/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "5.0.6",
@@ -2649,6 +3732,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2691,6 +3790,100 @@
                 "monocart-coverage-reports": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/cacache": {
+            "version": "21.0.0",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-21.0.0.tgz",
+            "integrity": "sha512-ohgebHsACA1Q2Pc99Vn/NWqoFoFoxY5aOktQY5Og/uyIyTaOx81YdxvnzpMq8qurTDxPd+CU3I0SNFdJWDb8ig==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^6.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^14.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/cacache/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/cacache/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/ssri": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-14.0.0.tgz",
+            "integrity": "sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/callsites": {
@@ -2755,6 +3948,19 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/chalk-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/chalk-string/-/chalk-string-4.0.0.tgz",
+            "integrity": "sha512-/EAe8GJnW2MKxrjiIoAxySKETk+loIfk0Qy/ov614CMqipR5i5tw0NIgM+vy0TiGizq3wgd3lK0S4/oF9Zrpig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "colors-option": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
         "node_modules/change-case": {
             "version": "5.4.4",
             "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
@@ -2794,6 +4000,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -2815,6 +4028,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cliui": {
@@ -2888,6 +4114,39 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/cmd-ts": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/cmd-ts/-/cmd-ts-0.15.0.tgz",
+            "integrity": "sha512-ASyAx+P6DNzNEZ6OYmvjjaLAQeI3L+4lm5rX2Jg8tondXdj06o9JTxi9mfC92KoVbrVFKhZ+j2TfBF8fcura6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.4.1",
+                "debug": "^4.4.1",
+                "didyoumean": "^1.2.2",
+                "strip-ansi": "^7.1.0"
+            }
+        },
+        "node_modules/cmd-ts/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/code-block-writer": {
+            "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+            "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2907,6 +4166,46 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/colors-option": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/colors-option/-/colors-option-6.1.2.tgz",
+            "integrity": "sha512-y23/k7HnkOTebqESoWtgu3Onrc2vydR0jn2kgNSlxLVBC1z2LUYhRadgUcfSgTWUXSpL2ONqUtePB4CCLTyVyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.4.1",
+                "is-plain-obj": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/colors-option/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/commander": {
             "version": "14.0.3",
@@ -2957,6 +4256,43 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "node_modules/config-chain/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/configstore": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+            "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "atomically": "^2.0.3",
+                "dot-prop": "^9.0.0",
+                "graceful-fs": "^4.2.11",
+                "xdg-basedir": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/content-type": {
             "version": "2.0.0",
@@ -3173,6 +4509,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3190,6 +4536,66 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/didyoumean": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/diff": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -3198,6 +4604,50 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dot-prop": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+            "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^4.18.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dot-prop/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/eastasianwidth": {
@@ -3251,6 +4701,55 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3259,6 +4758,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/escape-goat": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+            "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -3868,6 +5380,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/events-universal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+            "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bare-events": "^2.7.0"
+            }
+        },
         "node_modules/execa": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -3934,6 +5456,13 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3947,6 +5476,25 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -3965,6 +5513,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/figures": {
             "version": "6.1.0",
@@ -3992,6 +5547,19 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/filter-obj": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-6.1.0.tgz",
+            "integrity": "sha512-xdMtCAODmPloU9qtmPcdBV9Kd27NtMse+4ayThxqIHUES5Z2S6bGpap5PpdmNM56ub7y3i1eyr+vJJIIgWGKmA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/find-up": {
@@ -4082,6 +5650,46 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+            "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -4120,6 +5728,45 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4274,11 +5921,40 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "license": "ISC"
+        },
+        "node_modules/handle-cli-error": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/handle-cli-error/-/handle-cli-error-5.3.0.tgz",
+            "integrity": "sha512-fid3iuBNk7PsHe9uq4+62ZYIpc4BgJo2JaVv3gXBgG89NfYoKzRJGUEkZnGfK2h/g7Uzrfc7CjN0YtButlmTdw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "beautiful-error": "^1.1.0",
+                "filter-obj": "^6.1.0",
+                "is-plain-obj": "^4.1.0",
+                "normalize-exception": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -4288,6 +5964,48 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/he": {
@@ -4300,12 +6018,70 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/hosted-git-info": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.1.tgz",
+            "integrity": "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/hosted-git-info/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.0.0.tgz",
+            "integrity": "sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+            "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
         },
         "node_modules/human-signals": {
             "version": "8.0.1",
@@ -4314,6 +6090,24 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ignore": {
@@ -4373,6 +6167,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/index-to-position": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+            "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ini": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
@@ -4381,6 +6188,16 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/ip-address": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/is-builtin-module": {
@@ -4420,6 +6237,32 @@
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.7.1"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-error-instance": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/is-error-instance/-/is-error-instance-3.0.1.tgz",
+            "integrity": "sha512-nEw1ptjtbmXRkHOFrLvpHywsv+jMUZdtqI2BAC/XxMd24vUY5gXhvOprH0Bh4xA2gqQCQsEkr7aaxsgvxYRjnQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.18.0"
             }
         },
         "node_modules/is-extglob": {
@@ -4479,6 +6322,123 @@
             "peerDependencies": {
                 "eslint": "*",
                 "typescript": ">=4.7.4"
+            }
+        },
+        "node_modules/is-in-ci": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+            "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-in-ci": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-in-ssh": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+            "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-installed-globally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+            "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "global-directory": "^4.0.1",
+                "is-path-inside": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-installed-globally/node_modules/global-directory": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+            "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "4.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-installed-globally/node_modules/ini": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+            "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/is-installed-globally/node_modules/is-path-inside": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-npm": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
+            "integrity": "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-path-inside": {
@@ -4549,6 +6509,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4610,6 +6586,13 @@
                 "@pkgjs/parseargs": "^0.11.0"
             }
         },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/js-yaml": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -4643,6 +6626,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+            "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4661,6 +6654,16 @@
             "version": "3.5.8",
             "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
             "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+            "license": "MIT"
+        },
+        "node_modules/jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+            "dev": true,
+            "engines": [
+                "node >= 0.2.0"
+            ],
             "license": "MIT"
         },
         "node_modules/jsx-ast-utils-x": {
@@ -4683,6 +6686,35 @@
                 "json-buffer": "3.0.1"
             }
         },
+        "node_modules/ky": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+            "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/ky?sponsor=1"
+            }
+        },
+        "node_modules/latest-version": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
+            "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "package-json": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4695,6 +6727,287 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/libnpmpublish": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.2.0.tgz",
+            "integrity": "sha512-fAEts7UCM2r1xhI82Dv9PK4gFGZoyD7Z5sfIwBQKoO/f67VNVDC0DeH3uH1Yi+T4kwt5iBuCKkZ5XcpxfvsGHQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/package-json": "^7.0.0",
+                "ci-info": "^4.0.0",
+                "npm-package-arg": "^13.0.0",
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.7",
+                "sigstore": "^4.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/@npmcli/agent": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/@npmcli/fs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/@npmcli/redact": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/cacache": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^5.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/make-fetch-happen": {
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/agent": "^4.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "cacache": "^20.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/minipass-fetch": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            },
+            "optionalDependencies": {
+                "iconv-lite": "^0.7.2"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/npm-package-arg": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/npm-registry-fetch": {
+            "version": "19.1.1",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+            "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/redact": "^4.0.0",
+                "jsonparse": "^1.3.1",
+                "make-fetch-happen": "^15.0.0",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minizlib": "^3.0.1",
+                "npm-package-arg": "^13.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/socks-proxy-agent": {
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/libnpmpublish/node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/locate-path": {
@@ -4800,6 +7113,86 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/make-fetch-happen": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-16.0.1.tgz",
+            "integrity": "sha512-uUv1yxHzaKVVEPfcFeGSNov/Cehjv08ovlY8ImTljgL7Q+SiA0dAYLQ6SYVa2kkKqNj4Y3aZEI7xv2teadie0A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/agent": "^5.0.0",
+                "@npmcli/redact": "^5.0.0",
+                "cacache": "^21.0.0",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^6.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^7.0.0",
+                "ssri": "^14.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/proc-log": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+            "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/ssri": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-14.0.0.tgz",
+            "integrity": "sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/minimatch": {
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -4816,6 +7209,16 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/minipass": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -4824,6 +7227,115 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minipass-collect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+            "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minipass-fetch": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-6.0.0.tgz",
+            "integrity": "sha512-AWI8bKapGmgx/J0E6IGYSKj8TiHebZkmKWSs8raPSw8KXwgEAJ+Bw3+LSdXHR6T/RHKAWCOYk2MiLrYluaUU6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            },
+            "optionalDependencies": {
+                "iconv-lite": "^0.7.2"
+            }
+        },
+        "node_modules/minipass-flush": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+            "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-sized": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+            "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/mocha": {
@@ -5049,6 +7561,16 @@
                 "node": ">=18"
             }
         },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.46",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
@@ -5057,6 +7579,202 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/normalize-exception": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-exception/-/normalize-exception-4.0.1.tgz",
+            "integrity": "sha512-2fUwKMZLYvHIHZN4a6Bt2FYEea6mDwQcTVCffRvQ1bJHndQRRrNhq8+WQiLolOzJ7bJl59SCURGSwCLvQv/X7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-error-instance": "^3.0.1",
+                "is-plain-obj": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/normalize-package-data": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^7.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm-install-checks": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+            "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-normalize-package-bin": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+            "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-package-arg": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-14.0.0.tgz",
+            "integrity": "sha512-69XQh3k+dtGa1p+7RaR57IuG3rCko96xr/nUfN4yDYBXbTYICiWcOpsFKLN2GtGE9cyIljE+f1exnaYt9MvM+Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^10.1.0",
+                "proc-log": "^7.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^8.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/proc-log": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+            "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-8.0.0.tgz",
+            "integrity": "sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/npm-pick-manifest": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+            "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "npm-package-arg": "^13.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-pick-manifest/node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm-registry-fetch": {
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-20.0.0.tgz",
+            "integrity": "sha512-Hqaz3bQd4rnC41fskRZ2yzemzsfEvoA3WAuW7xkDC2RHtQ/W+o6n1dz8SHm61wmFFZGBITFzZD7kUPjXmYaNbw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/redact": "^5.0.0",
+                "jsonparse": "^1.3.1",
+                "make-fetch-happen": "^16.0.0",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^6.0.0",
+                "minizlib": "^3.0.1",
+                "npm-package-arg": "^14.0.0",
+                "proc-log": "^7.0.0"
+            },
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/npm-registry-fetch/node_modules/proc-log": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-7.0.0.tgz",
+            "integrity": "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/npm-run-path": {
@@ -5082,6 +7800,27 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/open": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.4.0",
+                "define-lazy-prop": "^3.0.0",
+                "is-in-ssh": "^1.0.0",
+                "is-inside-container": "^1.0.0",
+                "powershell-utils": "^0.1.0",
+                "wsl-utils": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5137,12 +7876,166 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-map": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/package-json": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+            "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ky": "^1.2.0",
+                "registry-auth-token": "^5.0.2",
+                "registry-url": "^6.0.1",
+                "semver": "^7.6.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
+        },
+        "node_modules/packtory": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.30.tgz",
+            "integrity": "sha512-w63364UqtfHp87TSvLd9fDw4kX0s3YXBpQFzJgPL00vjKStCUsRdX5gw4RYx7uygyNGAamXqJDy6CEdrAdd4Hg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@arethetypeswrong/core": "0.18.3",
+                "@cyclonedx/cyclonedx-library": "10.0.0",
+                "@jridgewell/gen-mapping": "0.3.13",
+                "@jridgewell/trace-mapping": "0.3.31",
+                "@schema-hub/zod-error-formatter": "0.0.11",
+                "@ts-morph/common": "0.29.0",
+                "@types/npm-registry-fetch": "8.0.9",
+                "common-tags": "1.8.2",
+                "diff": "9.0.0",
+                "fflate": "0.8.3",
+                "hosted-git-info": "10.1.1",
+                "libnpmpublish": "11.2.0",
+                "npm-package-arg": "14.0.0",
+                "npm-registry-fetch": "20.0.0",
+                "remeda": "2.37.0",
+                "semver": "7.8.1",
+                "spdx-expression-parse": "4.0.0",
+                "tar-stream": "3.1.8",
+                "true-myth": "9.4.0",
+                "ts-morph": "27.0.2",
+                "ts-pattern": "5.9.0",
+                "type-fest": "5.6.0",
+                "unix-permissions": "6.0.1",
+                "zod": "4.4.3"
+            },
+            "engines": {
+                "node": "^24 || ^26"
+            }
+        },
+        "node_modules/packtory/node_modules/@cyclonedx/cyclonedx-library": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-10.0.0.tgz",
+            "integrity": "sha512-xDXf2eqzeFHdjamj6oBV3duRSfrlmsJ5+2z9tXp7q5qxJP5Awmjf4ABSutS4qkVHHj7JzKFL/EM0V0Nihc7zPg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://owasp.org/donate/?reponame=www-project-cyclonedx&title=OWASP+CycloneDX"
+                }
+            ],
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=20.18.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.12.0",
+                "ajv-formats": "^3.0.1",
+                "ajv-formats-draft2019": "^1.6.1",
+                "libxmljs2": "^0.35||^0.37",
+                "packageurl-js": "*",
+                "spdx-expression-parse": "*",
+                "xmlbuilder2": "^3.0.2||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                },
+                "ajv-formats": {
+                    "optional": true
+                },
+                "ajv-formats-draft2019": {
+                    "optional": true
+                },
+                "libxmljs2": {
+                    "optional": true
+                },
+                "packageurl-js": {
+                    "optional": true
+                },
+                "spdx-expression-parse": {
+                    "optional": true
+                },
+                "xmlbuilder2": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/packtory/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/packtory/node_modules/diff": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+            "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/packtory/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -5163,6 +8056,37 @@
             "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
             "integrity": "sha512-bSWyzBKqcSL4RrncTpGsEKoJ7H8a4L3++ifTAbTFeMHyq2wRV+42DGmQcHIrJIvdcacjIOxEuKH/w4tthF17gg==",
             "license": "MIT"
+        },
+        "node_modules/parse-json": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+            "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.26.2",
+                "index-to-position": "^1.1.0",
+                "type-fest": "^4.39.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-json/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/parse-ms": {
             "version": "4.0.0",
@@ -5197,6 +8121,13 @@
             "engines": {
                 "node": ">=14.13.0"
             }
+        },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -5262,6 +8193,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/prelude-ls": {
@@ -5330,6 +8274,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/protocols": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
@@ -5346,6 +8307,22 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pupa": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+            "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-goat": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5354,6 +8331,116 @@
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/read-package-up": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+            "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up-simple": "^1.0.0",
+                "read-pkg": "^9.0.0",
+                "type-fest": "^4.6.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-package-up/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.3",
+                "normalize-package-data": "^6.0.0",
+                "parse-json": "^8.0.0",
+                "type-fest": "^4.6.0",
+                "unicorn-magic": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/unicorn-magic": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/readdirp": {
@@ -5407,6 +8494,35 @@
                 "regexp-tree": "bin/regexp-tree"
             }
         },
+        "node_modules/registry-auth-token": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+            "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pnpm/npm-conf": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/registry-url": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+            "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "1.2.8"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/regjsparser": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
@@ -5420,12 +8536,37 @@
                 "regjsparser": "bin/parser"
             }
         },
+        "node_modules/remeda": {
+            "version": "2.37.0",
+            "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.37.0.tgz",
+            "integrity": "sha512-wN6BXWua0t4o7vDamqc27J3VRxnokG9cDezsFN2nOnt2JD/IkJQHTYqM6UvmEctAZETAoviwEFQZJO3kZ4Ohew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/remeda"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5448,6 +8589,19 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/rust-just": {
@@ -5641,6 +8795,14 @@
             ],
             "license": "MIT"
         },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/scslre": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
@@ -5711,6 +8873,24 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/sigstore": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
+            "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.1",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "@sigstore/sign": "^4.1.1",
+                "@sigstore/tuf": "^4.0.2",
+                "@sigstore/verify": "^3.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/sinon": {
             "version": "22.0.0",
             "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.0.0.tgz",
@@ -5738,6 +8918,17 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
         "node_modules/smol-toml": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -5751,6 +8942,96 @@
                 "url": "https://github.com/sponsors/cyyynthia"
             }
         },
+        "node_modules/socks": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "^10.1.1",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks-proxy-agent": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.0.0.tgz",
+            "integrity": "sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/ssri": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+            "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/stable-hash-x": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -5759,6 +9040,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/streamx": {
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+            "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "events-universal": "^1.0.0",
+                "fast-fifo": "^1.3.2",
+                "text-decoder": "^1.1.0"
             }
         },
         "node_modules/string-width": {
@@ -5903,6 +9196,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/stubborn-fs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+            "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "stubborn-utils": "^1.0.1"
+            }
+        },
+        "node_modules/stubborn-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+            "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5932,6 +9242,19 @@
                 "url": "https://opencollective.com/synckit"
             }
         },
+        "node_modules/tagged-tag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+            "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/tapable": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -5944,6 +9267,29 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+            "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "b4a": "^1.6.4",
+                "bare-fs": "^4.5.5",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
+            }
+        },
+        "node_modules/teex": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+            "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "streamx": "^2.12.5"
             }
         },
         "node_modules/temp-dir": {
@@ -6067,6 +9413,16 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/text-decoder": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+            "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "b4a": "^1.6.4"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.16",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -6129,6 +9485,36 @@
                 "typescript": ">=4.0.0"
             }
         },
+        "node_modules/ts-morph": {
+            "version": "27.0.2",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+            "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ts-morph/common": "~0.28.1",
+                "code-block-writer": "^13.0.3"
+            }
+        },
+        "node_modules/ts-morph/node_modules/@ts-morph/common": {
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+            "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimatch": "^10.0.1",
+                "path-browserify": "^1.0.1",
+                "tinyglobby": "^0.2.14"
+            }
+        },
+        "node_modules/ts-pattern": {
+            "version": "5.9.0",
+            "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+            "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6136,6 +9522,223 @@
             "dev": true,
             "license": "0BSD",
             "optional": true
+        },
+        "node_modules/tuf-js": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+            "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/models": "4.1.0",
+                "debug": "^4.4.3",
+                "make-fetch-happen": "^15.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/tuf-js/node_modules/@npmcli/agent": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+            "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/tuf-js/node_modules/@npmcli/fs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/tuf-js/node_modules/@npmcli/redact": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/tuf-js/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/tuf-js/node_modules/cacache": {
+            "version": "20.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^5.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/tuf-js/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/tuf-js/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/tuf-js/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/tuf-js/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/tuf-js/node_modules/make-fetch-happen": {
+            "version": "15.0.6",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+            "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/agent": "^4.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "cacache": "^20.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/tuf-js/node_modules/minipass-fetch": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            },
+            "optionalDependencies": {
+                "iconv-lite": "^0.7.2"
+            }
+        },
+        "node_modules/tuf-js/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/tuf-js/node_modules/socks-proxy-agent": {
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -6158,6 +9761,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "dependencies": {
+                "tagged-tag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typescript": {
@@ -6198,6 +9817,124 @@
             "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
             "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
             "license": "ISC"
+        },
+        "node_modules/unix-permissions": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unix-permissions/-/unix-permissions-6.0.1.tgz",
+            "integrity": "sha512-vwrqKT13F00gpbeMykO42cVPZSNI7YzhzquYSIeLYOkgTOLw3rvU4PMWZeRgBS2vJAxOPrJjUHyQ/Oa6GuxBzA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "filter-obj": "^6.1.0",
+                "handle-cli-error": "^5.0.0",
+                "is-plain-obj": "^4.1.0",
+                "read-package-up": "^11.0.0",
+                "update-notifier": "^7.3.1",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "unix-permissions": "build/src/bin/main.js"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/unix-permissions/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/unix-permissions/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/unix-permissions/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/unix-permissions/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/unix-permissions/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/unix-permissions/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/unix-permissions/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/unrs-resolver": {
             "version": "1.12.2",
@@ -6268,6 +10005,44 @@
                 "browserslist": ">= 4.21.0"
             }
         },
+        "node_modules/update-notifier": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+            "integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boxen": "^8.0.1",
+                "chalk": "^5.3.0",
+                "configstore": "^7.0.0",
+                "is-in-ci": "^1.0.0",
+                "is-installed-globally": "^1.0.0",
+                "is-npm": "^6.0.0",
+                "latest-version": "^9.0.0",
+                "pupa": "^3.1.0",
+                "semver": "^7.6.3",
+                "xdg-basedir": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+            }
+        },
+        "node_modules/update-notifier/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6303,6 +10078,38 @@
                 "node": ">=10.12.0"
             }
         },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/validate-npm-package-name": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+            "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/vscode-languageserver-textdocument": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
@@ -6314,6 +10121,13 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
             "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/when-exit": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+            "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
             "dev": true,
             "license": "MIT"
         },
@@ -6330,6 +10144,47 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/widest-line": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+            "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/widest-line/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/widest-line/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/word-wrap": {
@@ -6444,6 +10299,23 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/wsl-utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0",
+                "powershell-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/xdg-basedir": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
@@ -6466,6 +10338,13 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "2.9.0",
@@ -6595,6 +10474,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "@enormora/eslint-config-mocha": "0.0.26",
         "@enormora/eslint-config-node": "0.0.26",
         "@enormora/eslint-config-typescript": "0.0.36",
+        "@packtory/cli": "0.0.30",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.12.4",

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -1,0 +1,89 @@
+// @ts-check
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const projectFolder = process.cwd();
+const sourcesFolder = path.join(projectFolder, 'target/packtory/source');
+
+async function readPackageInfo() {
+    const packageJsonContent = await fs.readFile(path.join(projectFolder, 'package.json'), { encoding: 'utf8' });
+    return JSON.parse(packageJsonContent);
+}
+
+function sharedPackageAttributes(packageInfo) {
+    return {
+        author: packageInfo.author,
+        contributors: packageInfo.contributors,
+        license: packageInfo.license,
+        repository: packageInfo.repository,
+        engines: packageInfo.engines
+    };
+}
+
+function commonPackageSettings(packageInfo) {
+    return {
+        sourcesFolder,
+        mainPackageJson: { type: 'module', dependencies: packageInfo.dependencies },
+        additionalFiles: [
+            { sourceFilePath: path.join(projectFolder, 'LICENSE'), targetFilePath: 'LICENSE' },
+            { sourceFilePath: path.join(projectFolder, 'README.md'), targetFilePath: 'README.md' }
+        ],
+        deadCodeElimination: { enabled: false },
+        publishSettings: {
+            access: 'public',
+            provenance: { type: 'auto' }
+        }
+    };
+}
+
+function corePackage(sharedAttributes) {
+    return {
+        name: '@pr-log/core',
+        versioning: { automatic: false, version: '0.1.0' },
+        roots: {
+            main: {
+                js: 'index.js',
+                declarationFile: 'index.d.ts'
+            }
+        },
+        packageInterface: {
+            modules: [{ root: 'main', export: '.' }]
+        },
+        additionalPackageJsonAttributes: {
+            ...sharedAttributes,
+            description: 'Library API for changelog generation from GitHub pull requests',
+            keywords: ['pr-log', 'changelog', 'github', 'pull-request', 'release-plan']
+        }
+    };
+}
+
+function cliPackage(packageInfo, sharedAttributes) {
+    return {
+        name: 'pr-log',
+        versioning: { automatic: false, version: packageInfo.version },
+        roots: {
+            cli: {
+                js: 'bin/pr-log.js'
+            }
+        },
+        packageInterface: {
+            bins: [{ root: 'cli', name: 'pr-log' }]
+        },
+        additionalPackageJsonAttributes: {
+            ...sharedAttributes,
+            description: packageInfo.description,
+            keywords: packageInfo.keywords
+        }
+    };
+}
+
+/** @returns {Promise<import('@packtory/cli').PacktoryConfig>} */
+export async function buildConfig() {
+    const packageInfo = await readPackageInfo();
+    const sharedAttributes = sharedPackageAttributes(packageInfo);
+
+    return {
+        commonPackageSettings: commonPackageSettings(packageInfo),
+        packages: [corePackage(sharedAttributes), cliPackage(packageInfo, sharedAttributes)]
+    };
+}

--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert';
+import { fake } from 'sinon';
+import {
+    collectMergedPullRequests,
+    createGitHubPullRequestChangedFilesReader,
+    fetchPullRequestChangedFiles,
+    renderChangelogMarkdown,
+    resolveLatestSemverTagBaseRef,
+    resolvePullRequestLabels,
+    type PullRequest
+} from './index.ts';
+import { defaultValidLabels } from './lib/valid-labels.ts';
+
+const pullRequestId = 1;
+const pullRequests: readonly PullRequest[] = [{ id: pullRequestId, title: 'title' }];
+
+test('exports base ref resolvers', () => {
+    assert.deepStrictEqual(resolveLatestSemverTagBaseRef({ tags: ['1.0.0'] }), { ref: '1.0.0' });
+});
+
+test('exports pull request collection and label resolution', async () => {
+    const collectedPullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base',
+        git: {
+            getMergeCommitLogs: fake.resolves([{ subject: 'Merge pull request #1 from branch', body: 'title' }])
+        },
+        pullRequestTitleReader: { getTitle: fake.resolves('fallback title') }
+    });
+
+    assert.deepStrictEqual(collectedPullRequests, pullRequests);
+    assert.deepStrictEqual(
+        await resolvePullRequestLabels({
+            githubRepo: 'owner/repo',
+            validLabels: defaultValidLabels,
+            pullRequests,
+            pullRequestLabelReader: { getLabel: fake.resolves('bug') },
+            waitForMilliseconds: fake.resolves(undefined),
+            labelLookupIntervalMilliseconds: 0
+        }),
+        [{ id: pullRequestId, title: 'title', label: 'bug' }]
+    );
+});
+
+test('exports changed file collection', async () => {
+    const changedFilesReader = createGitHubPullRequestChangedFilesReader({
+        paginate: fake.resolves([{ filename: 'source/index.ts' }]),
+        pulls: { listFiles: fake() }
+    } as never);
+
+    assert.deepStrictEqual(await changedFilesReader.getChangedFiles('owner/repo', pullRequestId), ['source/index.ts']);
+
+    const changedFilesByPullRequest = await fetchPullRequestChangedFiles({
+        githubRepo: 'owner/repo',
+        pullRequests,
+        pullRequestChangedFilesReader: { getChangedFiles: fake.resolves(['source/index.ts']) }
+    });
+
+    assert.deepStrictEqual(Array.from(changedFilesByPullRequest.entries()), [[pullRequestId, ['source/index.ts']]]);
+});
+
+test('exports changelog rendering', () => {
+    const changelog = renderChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: pullRequestId, title: 'title', label: 'bug' }],
+        githubRepo: 'owner/repo',
+        unreleased: false,
+        versionNumber: '1.0.0'
+    });
+
+    assert.ok(changelog.includes('## 1.0.0'));
+});

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,0 +1,81 @@
+import {
+    resolveLatestSemverTagBaseRef as resolveLatestSemverTagBaseRefValue,
+    type ChangelogBaseRef as ChangelogBaseRefValue,
+    type LatestSemverTagBaseRefInput as LatestSemverTagBaseRefInputValue
+} from './lib/changelog-base-ref.ts';
+import {
+    collectMergedPullRequests as collectMergedPullRequestsValue,
+    type CollectMergedPullRequestsInput as CollectMergedPullRequestsInputValue,
+    type GitRangeReader as GitRangeReaderValue,
+    type MergeCommitLogEntry as MergeCommitLogEntryValue,
+    type PullRequest as PullRequestValue,
+    type PullRequestTitleReader as PullRequestTitleReaderValue
+} from './lib/collect-merged-pull-requests.ts';
+import * as githubChangedFiles from './lib/github-pull-request-changed-files.ts';
+import {
+    fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
+    type FetchPullRequestChangedFilesInput as FetchPullRequestChangedFilesInputValue,
+    type PullRequestChangedFilesReader as PullRequestChangedFilesReaderValue
+} from './lib/pull-request-changed-files.ts';
+import {
+    resolvePullRequestLabels as resolvePullRequestLabelsValue,
+    type PullRequestLabelReader as PullRequestLabelReaderValue,
+    type PullRequestWithLabel as PullRequestWithLabelValue,
+    type ResolvePullRequestLabelsInput as ResolvePullRequestLabelsInputValue
+} from './lib/resolve-pull-request-labels.ts';
+import {
+    renderChangelogMarkdown as renderChangelogMarkdownValue,
+    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue
+} from './lib/render-changelog-markdown.ts';
+
+export async function collectMergedPullRequests(
+    input: CollectMergedPullRequestsInputValue
+): Promise<readonly PullRequestValue[]> {
+    const pullRequests = await collectMergedPullRequestsValue(input);
+    return pullRequests;
+}
+
+export function createGitHubPullRequestChangedFilesReader(
+    githubClient: Parameters<typeof githubChangedFiles.createGitHubPullRequestChangedFilesReader>[0]
+): PullRequestChangedFilesReaderValue {
+    const changedFilesReader = githubChangedFiles.createGitHubPullRequestChangedFilesReader(githubClient);
+    return changedFilesReader;
+}
+
+export async function fetchPullRequestChangedFiles(
+    input: FetchPullRequestChangedFilesInputValue
+): Promise<ReadonlyMap<number, readonly string[]>> {
+    const changedFiles = await fetchPullRequestChangedFilesValue(input);
+    return changedFiles;
+}
+
+export function renderChangelogMarkdown(input: RenderChangelogMarkdownInputValue): string {
+    const changelog = renderChangelogMarkdownValue(input);
+    return changelog;
+}
+
+export function resolveLatestSemverTagBaseRef(input: LatestSemverTagBaseRefInputValue): ChangelogBaseRefValue {
+    const baseRef = resolveLatestSemverTagBaseRefValue(input);
+    return baseRef;
+}
+
+export async function resolvePullRequestLabels(
+    input: ResolvePullRequestLabelsInputValue
+): Promise<readonly PullRequestWithLabelValue[]> {
+    const pullRequests = await resolvePullRequestLabelsValue(input);
+    return pullRequests;
+}
+
+export type ChangelogBaseRef = ChangelogBaseRefValue;
+export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue;
+export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
+export type GitRangeReader = GitRangeReaderValue;
+export type LatestSemverTagBaseRefInput = LatestSemverTagBaseRefInputValue;
+export type MergeCommitLogEntry = MergeCommitLogEntryValue;
+export type PullRequest = PullRequestValue;
+export type PullRequestChangedFilesReader = PullRequestChangedFilesReaderValue;
+export type PullRequestLabelReader = PullRequestLabelReaderValue;
+export type PullRequestTitleReader = PullRequestTitleReaderValue;
+export type PullRequestWithLabel = PullRequestWithLabelValue;
+export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
+export type ResolvePullRequestLabelsInput = ResolvePullRequestLabelsInputValue;

--- a/source/lib/changelog-base-ref.test.ts
+++ b/source/lib/changelog-base-ref.test.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import { resolveLatestSemverTagBaseRef } from './changelog-base-ref.ts';
+
+test('resolves the latest semver tag base ref', () => {
+    assert.deepStrictEqual(resolveLatestSemverTagBaseRef({ tags: ['1.0.0', '2.0.0-alpha.1', '1.2.0'] }), {
+        ref: '1.2.0'
+    });
+});

--- a/source/lib/changelog-base-ref.ts
+++ b/source/lib/changelog-base-ref.ts
@@ -1,0 +1,13 @@
+import { determineLatestVersionTag } from './latest-version-tag.ts';
+
+export type ChangelogBaseRef = {
+    readonly ref: string;
+};
+
+export type LatestSemverTagBaseRefInput = {
+    readonly tags: readonly string[];
+};
+
+export function resolveLatestSemverTagBaseRef(input: LatestSemverTagBaseRefInput): ChangelogBaseRef {
+    return { ref: determineLatestVersionTag(input.tags) };
+}

--- a/source/lib/collect-merged-pull-requests.test.ts
+++ b/source/lib/collect-merged-pull-requests.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert';
+import { fake } from 'sinon';
+import { collectMergedPullRequests } from './collect-merged-pull-requests.ts';
+
+const secondPullRequestId = 2;
+
+test('collects merged pull requests for a base ref', async () => {
+    const getMergeCommitLogs = fake.resolves([
+        { subject: 'Merge pull request #1 from branch', body: 'Use commit body title' },
+        { subject: 'Merge pull request #2 from other', body: undefined }
+    ]);
+    const getTitle = fake.resolves('Use GitHub title');
+
+    const pullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base-ref',
+        git: { getMergeCommitLogs },
+        pullRequestTitleReader: { getTitle }
+    });
+
+    assert.deepStrictEqual(getMergeCommitLogs.firstCall.args, ['base-ref']);
+    assert.deepStrictEqual(getTitle.firstCall.args, ['owner/repo', secondPullRequestId]);
+    assert.deepStrictEqual(pullRequests, [
+        { id: 1, title: 'Use commit body title' },
+        { id: secondPullRequestId, title: 'Use GitHub title' }
+    ]);
+});

--- a/source/lib/collect-merged-pull-requests.ts
+++ b/source/lib/collect-merged-pull-requests.ts
@@ -1,0 +1,59 @@
+import { isUndefined } from '@sindresorhus/is';
+
+export type PullRequest = {
+    readonly id: number;
+    readonly title: string;
+};
+
+export type MergeCommitLogEntry = {
+    readonly subject: string;
+    readonly body: string | undefined;
+};
+
+export type GitRangeReader = {
+    getMergeCommitLogs(baseRef: string): Promise<readonly MergeCommitLogEntry[]>;
+};
+
+export type PullRequestTitleReader = {
+    getTitle(githubRepo: string, pullRequestId: number): Promise<string>;
+};
+
+export type CollectMergedPullRequestsInput = {
+    readonly githubRepo: string;
+    readonly baseRef: string;
+    readonly git: GitRangeReader;
+    readonly pullRequestTitleReader: PullRequestTitleReader;
+};
+
+function extractPullRequestId(subject: string): number {
+    const matches = /^Merge pull request #(?<id>\d+) from .*$/u.exec(subject);
+    const pullRequestIdentifier = matches?.groups?.id;
+
+    if (isUndefined(pullRequestIdentifier)) {
+        throw new TypeError('Failed to extract pull request id from merge commit log');
+    }
+
+    return Number.parseInt(pullRequestIdentifier, 10);
+}
+
+async function createPullRequest(
+    input: Pick<CollectMergedPullRequestsInput, 'githubRepo' | 'pullRequestTitleReader'>,
+    mergeCommitLog: MergeCommitLogEntry
+): Promise<PullRequest> {
+    const pullRequestId = extractPullRequestId(mergeCommitLog.subject);
+    const title = mergeCommitLog.body ?? (await input.pullRequestTitleReader.getTitle(input.githubRepo, pullRequestId));
+
+    return { id: pullRequestId, title };
+}
+
+export async function collectMergedPullRequests(
+    input: CollectMergedPullRequestsInput
+): Promise<readonly PullRequest[]> {
+    const mergeCommits = await input.git.getMergeCommitLogs(input.baseRef);
+
+    return Promise.all(
+        mergeCommits.map(async (log) => {
+            return createPullRequest(input, log);
+        })
+    );
+}

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -2,7 +2,7 @@ import { format as formatDate } from 'date-fns';
 import { isPlainObject, isArray, isString } from '@sindresorhus/is';
 import { enUS as enLocale } from 'date-fns/locale/en-US';
 import type { Just, Nothing } from 'true-myth/maybe';
-import type { PullRequestWithLabel } from './get-merged-pull-requests.ts';
+import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
 
 function formatLinkToPullRequest(pullRequestId: number, repo: string): string {
     return `[#${pullRequestId}](https://github.com/${repo}/pull/${pullRequestId})`;

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -1,17 +1,19 @@
 import type { Octokit } from '@octokit/rest';
-import { isUndefined } from '@sindresorhus/is';
 import type { GetPullRequestLabel } from './get-pull-request-label.ts';
 import type { GitCommandRunner } from './git-command-runner.ts';
-import { determineLatestVersionTag } from './latest-version-tag.ts';
+import { resolveLatestSemverTagBaseRef } from './changelog-base-ref.ts';
+import {
+    collectMergedPullRequests,
+    type PullRequest as PullRequestValue,
+    type PullRequestTitleReader
+} from './collect-merged-pull-requests.ts';
+import {
+    resolvePullRequestLabels,
+    type PullRequestWithLabel as PullRequestWithLabelValue
+} from './resolve-pull-request-labels.ts';
 
-export type PullRequest = {
-    readonly id: number;
-    readonly title: string;
-};
-
-export type PullRequestWithLabel = PullRequest & {
-    readonly label: string;
-};
+export type PullRequest = PullRequestValue;
+export type PullRequestWithLabel = PullRequestWithLabelValue;
 
 export type GetMergedPullRequestsDependencies = {
     readonly gitCommandRunner: GitCommandRunner;
@@ -40,17 +42,6 @@ function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo
     return [owner, repo];
 }
 
-function extractPullRequestId(subject: string): number {
-    const matches = /^Merge pull request #(?<id>\d+) from .*$/u.exec(subject);
-    const pullRequestIdentifier = matches?.groups?.id;
-
-    if (isUndefined(pullRequestIdentifier)) {
-        throw new TypeError('Failed to extract pull request id from merge commit log');
-    }
-
-    return Number.parseInt(pullRequestIdentifier, 10);
-}
-
 async function fetchPullRequestTitle(
     githubClient: Readonly<Octokit>,
     githubRepo: string,
@@ -66,17 +57,6 @@ async function fetchPullRequestTitle(
     return (pullRequest as PullRequestData).title;
 }
 
-async function createPullRequest(
-    githubClient: Readonly<Octokit>,
-    githubRepo: string,
-    mergeCommitLog: { readonly subject: string; readonly body: string | undefined }
-): Promise<PullRequest> {
-    const pullRequestId = extractPullRequestId(mergeCommitLog.subject);
-    const title = mergeCommitLog.body ?? (await fetchPullRequestTitle(githubClient, githubRepo, pullRequestId));
-
-    return { id: pullRequestId, title };
-}
-
 export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequestsDependencies): GetMergedPullRequests {
     const {
         gitCommandRunner,
@@ -88,47 +68,39 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
 
     async function getLatestVersionTag(): Promise<string> {
         const tags = await gitCommandRunner.listTags();
-        return determineLatestVersionTag(tags);
+        return resolveLatestSemverTagBaseRef({ tags }).ref;
     }
 
     async function getPullRequests(fromTag: string, githubRepo: string): Promise<readonly PullRequest[]> {
-        const mergeCommits = await gitCommandRunner.getMergeCommitLogs(fromTag);
-
-        return Promise.all(
-            mergeCommits.map(async (log) => {
-                return createPullRequest(githubClient, githubRepo, log);
-            })
-        );
-    }
-
-    async function extendWithLabel(
-        githubRepo: string,
-        validLabels: ReadonlyMap<string, string>,
-        pullRequests: readonly PullRequest[]
-    ): Promise<readonly PullRequestWithLabel[]> {
-        const pullRequestsWithLabels: PullRequestWithLabel[] = [];
-
-        for (const [pullRequestIndex, pullRequest] of pullRequests.entries()) {
-            if (pullRequestIndex > 0 && labelLookupIntervalMilliseconds > 0) {
-                await waitForMilliseconds(labelLookupIntervalMilliseconds);
+        const pullRequestTitleReader: PullRequestTitleReader = {
+            async getTitle(repo, pullRequestId) {
+                return fetchPullRequestTitle(githubClient, repo, pullRequestId);
             }
+        };
 
-            const label = await getPullRequestLabel(githubRepo, validLabels, pullRequest.id, dependencies);
-
-            pullRequestsWithLabels.push({
-                id: pullRequest.id,
-                title: pullRequest.title,
-                label
-            });
-        }
-
-        return pullRequestsWithLabels;
+        return collectMergedPullRequests({
+            githubRepo,
+            baseRef: fromTag,
+            git: gitCommandRunner,
+            pullRequestTitleReader
+        });
     }
 
     return async function getMergedPullRequests(githubRepo: string, validLabels: ReadonlyMap<string, string>) {
         const latestVersionTag = await getLatestVersionTag();
         const pullRequests = await getPullRequests(latestVersionTag, githubRepo);
-        const pullRequestsWithLabels = await extendWithLabel(githubRepo, validLabels, pullRequests);
+        const pullRequestsWithLabels = await resolvePullRequestLabels({
+            githubRepo,
+            validLabels,
+            pullRequests,
+            waitForMilliseconds,
+            labelLookupIntervalMilliseconds,
+            pullRequestLabelReader: {
+                async getLabel(repo, labels, pullRequestId) {
+                    return getPullRequestLabel(repo, labels, pullRequestId, dependencies);
+                }
+            }
+        });
 
         return pullRequestsWithLabels;
     };

--- a/source/lib/github-pull-request-changed-files.test.ts
+++ b/source/lib/github-pull-request-changed-files.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import type { Octokit } from '@octokit/rest';
+import { fake } from 'sinon';
+import { createGitHubPullRequestChangedFilesReader } from './github-pull-request-changed-files.ts';
+
+const pullRequestId = 123;
+
+test('creates a GitHub changed files reader', async () => {
+    const listFiles = fake();
+    const paginate = fake.resolves([{ filename: 'source/a.ts' }, { filename: 'README.md' }]);
+    const githubClient = {
+        paginate,
+        pulls: { listFiles }
+    } as unknown as Octokit;
+    const changedFilesReader = createGitHubPullRequestChangedFilesReader(githubClient);
+
+    const changedFiles = await changedFilesReader.getChangedFiles('owner/repo', pullRequestId);
+
+    assert.deepStrictEqual(paginate.firstCall.args, [
+        listFiles,
+        { owner: 'owner', repo: 'repo', pull_number: pullRequestId }
+    ]);
+    assert.deepStrictEqual(changedFiles, ['source/a.ts', 'README.md']);
+});
+
+test('throws when the GitHub repo cannot be split', async () => {
+    const githubClient = { paginate: fake.resolves([]), pulls: { listFiles: fake() } } as unknown as Octokit;
+    const changedFilesReader = createGitHubPullRequestChangedFilesReader(githubClient);
+
+    await assert.rejects(changedFilesReader.getChangedFiles('invalid-repo', pullRequestId), {
+        message: 'Could not find a repository'
+    });
+});

--- a/source/lib/github-pull-request-changed-files.ts
+++ b/source/lib/github-pull-request-changed-files.ts
@@ -1,0 +1,42 @@
+import type { Octokit } from '@octokit/rest';
+import { splitByString } from './split.ts';
+import type { PullRequestChangedFilesReader } from './pull-request-changed-files.ts';
+
+type PullRequestFile = Readonly<Awaited<ReturnType<Octokit['pulls']['listFiles']>>['data'][number]>;
+
+function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo: string]> {
+    const [owner, repo] = splitByString(githubRepo, '/');
+
+    if (repo === undefined) {
+        throw new TypeError('Could not find a repository');
+    }
+
+    return [owner, repo];
+}
+
+async function getPullRequestChangedFiles(
+    githubClient: Readonly<Octokit>,
+    githubRepo: string,
+    pullRequestId: number
+): Promise<readonly string[]> {
+    const [owner, repo] = determineRepoDetails(githubRepo);
+    const files = (await githubClient.paginate(githubClient.pulls.listFiles, {
+        owner,
+        repo,
+        pull_number: pullRequestId
+    })) as PullRequestFile[];
+
+    return files.map((file) => {
+        return file.filename;
+    });
+}
+
+export function createGitHubPullRequestChangedFilesReader(
+    githubClient: Readonly<Octokit>
+): PullRequestChangedFilesReader {
+    return {
+        async getChangedFiles(githubRepo, pullRequestId) {
+            return getPullRequestChangedFiles(githubClient, githubRepo, pullRequestId);
+        }
+    };
+}

--- a/source/lib/pull-request-changed-files.test.ts
+++ b/source/lib/pull-request-changed-files.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { fake } from 'sinon';
+import { fetchPullRequestChangedFiles } from './pull-request-changed-files.ts';
+
+const secondPullRequestId = 2;
+
+test('fetches changed files for pull requests', async () => {
+    const getChangedFiles = fake(async (_githubRepo, pullRequestId: number) => {
+        return pullRequestId === 1 ? ['source/a.ts'] : ['source/b.ts'];
+    });
+
+    const changedFiles = await fetchPullRequestChangedFiles({
+        githubRepo: 'owner/repo',
+        pullRequests: [
+            { id: 1, title: 'Change a' },
+            { id: secondPullRequestId, title: 'Change b' }
+        ],
+        pullRequestChangedFilesReader: { getChangedFiles }
+    });
+
+    assert.deepStrictEqual(Array.from(changedFiles.entries()), [
+        [1, ['source/a.ts']],
+        [secondPullRequestId, ['source/b.ts']]
+    ]);
+});

--- a/source/lib/pull-request-changed-files.ts
+++ b/source/lib/pull-request-changed-files.ts
@@ -1,0 +1,26 @@
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+
+export type PullRequestChangedFilesReader = {
+    getChangedFiles(githubRepo: string, pullRequestId: number): Promise<readonly string[]>;
+};
+
+export type FetchPullRequestChangedFilesInput = {
+    readonly githubRepo: string;
+    readonly pullRequests: readonly PullRequest[];
+    readonly pullRequestChangedFilesReader: PullRequestChangedFilesReader;
+};
+
+export async function fetchPullRequestChangedFiles(
+    input: FetchPullRequestChangedFilesInput
+): Promise<ReadonlyMap<number, readonly string[]>> {
+    const filesByPullRequest = new Map<number, readonly string[]>();
+
+    for (const pullRequest of input.pullRequests) {
+        filesByPullRequest.set(
+            pullRequest.id,
+            await input.pullRequestChangedFilesReader.getChangedFiles(input.githubRepo, pullRequest.id)
+        );
+    }
+
+    return filesByPullRequest;
+}

--- a/source/lib/render-changelog-markdown.test.ts
+++ b/source/lib/render-changelog-markdown.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { renderChangelogMarkdown } from './render-changelog-markdown.ts';
+import { defaultValidLabels } from './valid-labels.ts';
+
+test('renders released changelog markdown', () => {
+    const changelog = renderChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }],
+        githubRepo: 'owner/repo',
+        unreleased: false,
+        versionNumber: '1.2.3'
+    });
+
+    assert.ok(changelog.includes('## 1.2.3 (January 1, 1970)'));
+    assert.ok(changelog.includes('* Fix bug ([#1](https://github.com/owner/repo/pull/1))'));
+});
+
+test('renders unreleased changelog markdown without a title', () => {
+    const changelog = renderChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }],
+        githubRepo: 'owner/repo',
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(!changelog.startsWith('## '));
+    assert.ok(changelog.includes('* Fix bug ([#1](https://github.com/owner/repo/pull/1))'));
+});

--- a/source/lib/render-changelog-markdown.ts
+++ b/source/lib/render-changelog-markdown.ts
@@ -1,0 +1,52 @@
+import Maybe, { type Just } from 'true-myth/maybe';
+import { createChangelogFactory } from './create-changelog.ts';
+import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
+
+type RenderChangelogMarkdownInputBase = {
+    readonly packageInfo: Record<string, unknown>;
+    readonly currentDate: Readonly<Date>;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly mergedPullRequests: readonly PullRequestWithLabel[];
+    readonly githubRepo: string;
+};
+
+type RenderReleasedChangelogMarkdownInput = RenderChangelogMarkdownInputBase & {
+    readonly unreleased: false;
+    readonly versionNumber: string;
+};
+
+type RenderUnreleasedChangelogMarkdownInput = RenderChangelogMarkdownInputBase & {
+    readonly unreleased: true;
+    readonly versionNumber: undefined;
+};
+
+export type RenderChangelogMarkdownInput =
+    | RenderReleasedChangelogMarkdownInput
+    | RenderUnreleasedChangelogMarkdownInput;
+
+export function renderChangelogMarkdown(input: RenderChangelogMarkdownInput): string {
+    const createChangelog = createChangelogFactory({
+        packageInfo: input.packageInfo,
+        getCurrentDate: () => {
+            return input.currentDate;
+        }
+    });
+
+    if (input.unreleased) {
+        return createChangelog({
+            validLabels: input.validLabels,
+            mergedPullRequests: input.mergedPullRequests,
+            githubRepo: input.githubRepo,
+            unreleased: true,
+            versionNumber: Maybe.nothing()
+        });
+    }
+
+    return createChangelog({
+        validLabels: input.validLabels,
+        mergedPullRequests: input.mergedPullRequests,
+        githubRepo: input.githubRepo,
+        unreleased: false,
+        versionNumber: Maybe.just(input.versionNumber) as Just<string>
+    });
+}

--- a/source/lib/resolve-pull-request-labels.test.ts
+++ b/source/lib/resolve-pull-request-labels.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { fake } from 'sinon';
+import { resolvePullRequestLabels } from './resolve-pull-request-labels.ts';
+import { defaultValidLabels } from './valid-labels.ts';
+
+const labelLookupIntervalMilliseconds = 250;
+const secondPullRequestId = 2;
+
+test('resolves labels for pull requests sequentially', async () => {
+    const getLabel = fake(async (_githubRepo, _validLabels, pullRequestId: number) => {
+        return pullRequestId === 1 ? 'bug' : 'documentation';
+    });
+    const waitForMilliseconds = fake.resolves(undefined);
+
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [
+            { id: 1, title: 'Fix bug' },
+            { id: secondPullRequestId, title: 'Update docs' }
+        ],
+        pullRequestLabelReader: { getLabel },
+        waitForMilliseconds,
+        labelLookupIntervalMilliseconds
+    });
+
+    assert.strictEqual(waitForMilliseconds.callCount, 1);
+    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [labelLookupIntervalMilliseconds]);
+    assert.deepStrictEqual(pullRequests, [
+        { id: 1, title: 'Fix bug', label: 'bug' },
+        { id: secondPullRequestId, title: 'Update docs', label: 'documentation' }
+    ]);
+});

--- a/source/lib/resolve-pull-request-labels.ts
+++ b/source/lib/resolve-pull-request-labels.ts
@@ -1,0 +1,40 @@
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+
+export type PullRequestWithLabel = PullRequest & {
+    readonly label: string;
+};
+
+export type PullRequestLabelReader = {
+    getLabel(githubRepo: string, validLabels: ReadonlyMap<string, string>, pullRequestId: number): Promise<string>;
+};
+
+export type ResolvePullRequestLabelsInput = {
+    readonly githubRepo: string;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly pullRequests: readonly PullRequest[];
+    readonly pullRequestLabelReader: PullRequestLabelReader;
+    readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
+    readonly labelLookupIntervalMilliseconds: number;
+};
+
+export async function resolvePullRequestLabels(
+    input: ResolvePullRequestLabelsInput
+): Promise<readonly PullRequestWithLabel[]> {
+    const pullRequestsWithLabels: PullRequestWithLabel[] = [];
+
+    for (const [pullRequestIndex, pullRequest] of input.pullRequests.entries()) {
+        if (pullRequestIndex > 0 && input.labelLookupIntervalMilliseconds > 0) {
+            await input.waitForMilliseconds(input.labelLookupIntervalMilliseconds);
+        }
+
+        const label = await input.pullRequestLabelReader.getLabel(input.githubRepo, input.validLabels, pullRequest.id);
+
+        pullRequestsWithLabels.push({
+            id: pullRequest.id,
+            title: pullRequest.title,
+            label
+        });
+    }
+
+    return pullRequestsWithLabels;
+}


### PR DESCRIPTION
Introduces `@pr-log/core` as the public library surface for changelog base resolution, merged PR collection, changed file lookup, label resolution, and markdown rendering. The existing `pr-log` CLI now composes that API, and Packtory publishes `pr-log` and `@pr-log/core` with manual versions without npm workspaces.