### PR TITLE
Add package-aware changelog base refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ import {
 ```
 
 `@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, and changelog rendering.
-Package impact and release planning stay outside pr-log.
+Package impact and release planning stay outside pr-log; consumers can pass release-plan package data into the package-aware base-ref resolver.
+
+Package-aware release tags use `<packageName>@<version>` by default, for example `@scope/package@1.2.3`.
+Consumers can pass a package tag format with `{packageName}` and `{version}` placeholders.
 
 ## Publishing
 

--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -4,18 +4,38 @@ import {
     collectMergedPullRequests,
     createGitHubPullRequestChangedFilesReader,
     fetchPullRequestChangedFiles,
+    formatPackageVersionTag,
     renderChangelogMarkdown,
+    resolveChangelogBaseRef,
     resolveLatestSemverTagBaseRef,
     resolvePullRequestLabels,
-    type PullRequest
+    type PullRequest,
+    type ReleasePlanPackage
 } from './index.ts';
 import { defaultValidLabels } from './lib/valid-labels.ts';
 
 const pullRequestId = 1;
 const pullRequests: readonly PullRequest[] = [{ id: pullRequestId, title: 'title' }];
 
-test('exports base ref resolvers', () => {
+test('exports base ref resolvers', async () => {
     assert.deepStrictEqual(resolveLatestSemverTagBaseRef({ tags: ['1.0.0'] }), { ref: '1.0.0' });
+    assert.strictEqual(
+        formatPackageVersionTag({ packageName: 'pkg', version: '1.0.0', packageTagFormat: undefined }),
+        'pkg@1.0.0'
+    );
+
+    const baseRef = await resolveChangelogBaseRef(
+        {
+            packageName: 'pkg',
+            previousVersion: undefined,
+            previousGitHead: undefined,
+            packageTagFormat: undefined,
+            explicitBaseRef: 'base'
+        },
+        { hasRef: fake.resolves(true) }
+    );
+
+    assert.deepStrictEqual(baseRef, { ref: 'base' });
 });
 
 test('exports pull request collection and label resolution', async () => {
@@ -71,4 +91,19 @@ test('exports changelog rendering', () => {
     });
 
     assert.ok(changelog.includes('## 1.0.0'));
+});
+
+test('exports the release plan package type', () => {
+    const releasePlanPackage: ReleasePlanPackage = {
+        name: 'pkg',
+        previousVersion: undefined,
+        nextVersion: '1.0.0',
+        changed: true,
+        previousGitHead: undefined,
+        currentGitHead: 'abc123',
+        sourceFiles: ['source/index.ts'],
+        changedArtifactFiles: ['target/index.js']
+    };
+
+    assert.strictEqual(releasePlanPackage.name, 'pkg');
 });

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,7 +1,13 @@
 import {
+    formatPackageVersionTag as formatPackageVersionTagValue,
+    resolveChangelogBaseRef as resolveChangelogBaseRefValue,
     resolveLatestSemverTagBaseRef as resolveLatestSemverTagBaseRefValue,
     type ChangelogBaseRef as ChangelogBaseRefValue,
-    type LatestSemverTagBaseRefInput as LatestSemverTagBaseRefInputValue
+    type GitRefReader as GitRefReaderValue,
+    type LatestSemverTagBaseRefInput as LatestSemverTagBaseRefInputValue,
+    type MissingChangelogBaseRefError as MissingChangelogBaseRefErrorValue,
+    type MissingChangelogBaseRefReason as MissingChangelogBaseRefReasonValue,
+    type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue
 } from './lib/changelog-base-ref.ts';
 import {
     collectMergedPullRequests as collectMergedPullRequestsValue,
@@ -49,9 +55,26 @@ export async function fetchPullRequestChangedFiles(
     return changedFiles;
 }
 
+export function formatPackageVersionTag(options: {
+    readonly packageName: string;
+    readonly version: string;
+    readonly packageTagFormat: string | undefined;
+}): string {
+    const packageVersionTag = formatPackageVersionTagValue(options);
+    return packageVersionTag;
+}
+
 export function renderChangelogMarkdown(input: RenderChangelogMarkdownInputValue): string {
     const changelog = renderChangelogMarkdownValue(input);
     return changelog;
+}
+
+export async function resolveChangelogBaseRef(
+    input: PackageChangelogBaseRefInputValue,
+    gitRefReader: GitRefReaderValue
+): Promise<ChangelogBaseRefValue> {
+    const baseRef = await resolveChangelogBaseRefValue(input, gitRefReader);
+    return baseRef;
 }
 
 export function resolveLatestSemverTagBaseRef(input: LatestSemverTagBaseRefInputValue): ChangelogBaseRefValue {
@@ -70,12 +93,26 @@ export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue;
 export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
 export type GitRangeReader = GitRangeReaderValue;
+export type GitRefReader = GitRefReaderValue;
 export type LatestSemverTagBaseRefInput = LatestSemverTagBaseRefInputValue;
 export type MergeCommitLogEntry = MergeCommitLogEntryValue;
+export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
+export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
+export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PullRequest = PullRequestValue;
 export type PullRequestChangedFilesReader = PullRequestChangedFilesReaderValue;
 export type PullRequestLabelReader = PullRequestLabelReaderValue;
 export type PullRequestTitleReader = PullRequestTitleReaderValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;
+export type ReleasePlanPackage = {
+    readonly name: string;
+    readonly previousVersion: string | undefined;
+    readonly nextVersion: string;
+    readonly changed: boolean;
+    readonly previousGitHead: string | undefined;
+    readonly currentGitHead: string | undefined;
+    readonly sourceFiles: readonly string[];
+    readonly changedArtifactFiles: readonly string[];
+};
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
 export type ResolvePullRequestLabelsInput = ResolvePullRequestLabelsInputValue;

--- a/source/lib/changelog-base-ref.test.ts
+++ b/source/lib/changelog-base-ref.test.ts
@@ -1,8 +1,105 @@
 import assert from 'node:assert';
-import { resolveLatestSemverTagBaseRef } from './changelog-base-ref.ts';
+import { fake } from 'sinon';
+import {
+    formatPackageVersionTag,
+    resolveChangelogBaseRef,
+    resolveLatestSemverTagBaseRef,
+    type GitRefReader,
+    type MissingChangelogBaseRefError
+} from './changelog-base-ref.ts';
+
+function gitRefReaderFactory(existingRefs: readonly string[]): GitRefReader {
+    return {
+        async hasRef(ref) {
+            return existingRefs.includes(ref);
+        }
+    };
+}
+
+const packageInput = {
+    packageName: '@scope/package',
+    previousVersion: '1.2.3',
+    previousGitHead: 'abc123',
+    packageTagFormat: undefined,
+    explicitBaseRef: 'explicit-ref'
+};
 
 test('resolves the latest semver tag base ref', () => {
     assert.deepStrictEqual(resolveLatestSemverTagBaseRef({ tags: ['1.0.0', '2.0.0-alpha.1', '1.2.0'] }), {
         ref: '1.2.0'
     });
+});
+
+test('formats package version tags', () => {
+    assert.strictEqual(
+        formatPackageVersionTag({ packageName: '@scope/package', version: '1.2.3', packageTagFormat: undefined }),
+        '@scope/package@1.2.3'
+    );
+});
+
+test('formats package version tags with a custom format', () => {
+    assert.strictEqual(
+        formatPackageVersionTag({
+            packageName: '@scope/package',
+            version: '1.2.3',
+            packageTagFormat: 'release/{packageName}/v{version}'
+        }),
+        'release/@scope/package/v1.2.3'
+    );
+});
+
+test('uses the explicit base ref first', async () => {
+    const hasRef = fake.resolves(true);
+    const gitRefReader = { hasRef };
+
+    const baseRef = await resolveChangelogBaseRef(packageInput, gitRefReader);
+
+    assert.deepStrictEqual(baseRef, { ref: 'explicit-ref' });
+    assert.deepStrictEqual(hasRef.firstCall.args, ['explicit-ref']);
+});
+
+test('uses the previous git head before the package version tag', async () => {
+    const baseRef = await resolveChangelogBaseRef(
+        { ...packageInput, explicitBaseRef: undefined },
+        gitRefReaderFactory(['abc123', '@scope/package@1.2.3'])
+    );
+
+    assert.deepStrictEqual(baseRef, { ref: 'abc123' });
+});
+
+test('uses the package version tag when no git head was provided', async () => {
+    const baseRef = await resolveChangelogBaseRef(
+        { ...packageInput, explicitBaseRef: undefined, previousGitHead: undefined },
+        gitRefReaderFactory(['@scope/package@1.2.3'])
+    );
+
+    assert.deepStrictEqual(baseRef, { ref: '@scope/package@1.2.3' });
+});
+
+test('throws when the selected base ref is missing', async () => {
+    await assert.rejects(resolveChangelogBaseRef(packageInput, gitRefReaderFactory([])), (error: unknown) => {
+        const missingBaseRefError = error as MissingChangelogBaseRefError;
+
+        assert.strictEqual(missingBaseRefError.name, 'MissingChangelogBaseRefError');
+        assert.strictEqual(missingBaseRefError.packageName, '@scope/package');
+        assert.strictEqual(missingBaseRefError.ref, 'explicit-ref');
+        assert.strictEqual(missingBaseRefError.reason, 'explicit-base-ref');
+        return true;
+    });
+});
+
+test('throws when no package base ref can be determined', async () => {
+    await assert.rejects(
+        resolveChangelogBaseRef(
+            {
+                packageName: '@scope/package',
+                previousVersion: undefined,
+                previousGitHead: undefined,
+                packageTagFormat: undefined,
+                explicitBaseRef: undefined
+            },
+            gitRefReaderFactory([])
+        ),
+        { message: 'No base ref could be determined for package "@scope/package" using package-version-tag' }
+    );
 });

--- a/source/lib/changelog-base-ref.ts
+++ b/source/lib/changelog-base-ref.ts
@@ -4,10 +4,99 @@ export type ChangelogBaseRef = {
     readonly ref: string;
 };
 
+export type GitRefReader = {
+    hasRef(ref: string): Promise<boolean>;
+};
+
 export type LatestSemverTagBaseRefInput = {
     readonly tags: readonly string[];
 };
 
+export type PackageChangelogBaseRefInput = {
+    readonly packageName: string;
+    readonly previousVersion: string | undefined;
+    readonly previousGitHead: string | undefined;
+    readonly packageTagFormat: string | undefined;
+    readonly explicitBaseRef: string | undefined;
+};
+
+export type MissingChangelogBaseRefReason = 'explicit-base-ref' | 'package-version-tag' | 'previous-git-head';
+
+export type MissingChangelogBaseRefError = {
+    readonly name: 'MissingChangelogBaseRefError';
+    readonly message: string;
+    readonly packageName: string;
+    readonly ref: string | undefined;
+    readonly reason: MissingChangelogBaseRefReason;
+    readonly stack: string | undefined;
+};
+
+function throwMissingChangelogBaseRefError(options: {
+    readonly packageName: string;
+    readonly ref: string | undefined;
+    readonly reason: MissingChangelogBaseRefReason;
+}): never {
+    const { packageName, ref, reason } = options;
+    const refDescription = ref === undefined ? 'No base ref could be determined' : `Base ref "${ref}" does not exist`;
+    const error: Error = Object.assign(new Error(`${refDescription} for package "${packageName}" using ${reason}`), {
+        name: 'MissingChangelogBaseRefError',
+        packageName,
+        ref,
+        reason
+    });
+
+    throw error;
+}
+
 export function resolveLatestSemverTagBaseRef(input: LatestSemverTagBaseRefInput): ChangelogBaseRef {
     return { ref: determineLatestVersionTag(input.tags) };
+}
+
+export function formatPackageVersionTag(options: {
+    readonly packageName: string;
+    readonly version: string;
+    readonly packageTagFormat: string | undefined;
+}): string {
+    const tagFormat = options.packageTagFormat ?? '{packageName}@{version}';
+
+    return tagFormat.replaceAll('{packageName}', options.packageName).replaceAll('{version}', options.version);
+}
+
+async function requireExistingBaseRef(
+    gitRefReader: GitRefReader,
+    packageName: string,
+    ref: string,
+    reason: MissingChangelogBaseRefReason
+): Promise<ChangelogBaseRef> {
+    if (await gitRefReader.hasRef(ref)) {
+        return { ref };
+    }
+
+    return throwMissingChangelogBaseRefError({ packageName, ref, reason });
+}
+
+export async function resolveChangelogBaseRef(
+    input: PackageChangelogBaseRefInput,
+    gitRefReader: GitRefReader
+): Promise<ChangelogBaseRef> {
+    const { packageName, explicitBaseRef, previousGitHead, previousVersion, packageTagFormat } = input;
+
+    if (explicitBaseRef !== undefined) {
+        return requireExistingBaseRef(gitRefReader, packageName, explicitBaseRef, 'explicit-base-ref');
+    }
+
+    if (previousGitHead !== undefined) {
+        return requireExistingBaseRef(gitRefReader, packageName, previousGitHead, 'previous-git-head');
+    }
+
+    if (previousVersion !== undefined) {
+        return requireExistingBaseRef(
+            gitRefReader,
+            packageName,
+            formatPackageVersionTag({ packageName, version: previousVersion, packageTagFormat }),
+            'package-version-tag'
+        );
+    }
+
+    return throwMissingChangelogBaseRefError({ packageName, ref: undefined, reason: 'package-version-tag' });
 }

--- a/source/lib/git-command-runner.test.ts
+++ b/source/lib/git-command-runner.test.ts
@@ -134,6 +134,34 @@ test('listTags() returns the command output splitted as individual lines', async
     assert.deepStrictEqual(result, ['a', 'b', 'c']);
 });
 
+test('hasRef() executes "git rev-parse" with the given ref', async () => {
+    const execute = fake.resolves({ stdout: '' });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    await runner.hasRef('foo');
+
+    assert.strictEqual(execute.callCount, 1);
+    assert.deepStrictEqual(execute.firstCall.args, ['git rev-parse --verify --quiet foo^{commit}']);
+});
+
+test('hasRef() returns true when git finds the ref', async () => {
+    const execute = fake.resolves({ stdout: '' });
+    const runner = gitCommandRunnerFactory({ execute });
+
+    const result = await runner.hasRef('foo');
+
+    assert.strictEqual(result, true);
+});
+
+test('hasRef() returns false when git cannot find the ref', async () => {
+    const execute = fake.rejects(new Error('missing ref'));
+    const runner = gitCommandRunnerFactory({ execute });
+
+    const result = await runner.hasRef('foo');
+
+    assert.strictEqual(result, false);
+});
+
 test('getMergeCommitLogs() executes "git log" with the correct options', async () => {
     const execute = fake.resolves({ stdout: '' });
     const runner = gitCommandRunnerFactory({ execute });

--- a/source/lib/git-command-runner.ts
+++ b/source/lib/git-command-runner.ts
@@ -19,6 +19,7 @@ export type GitCommandRunner = {
     getSymmetricDifferencesBetweenBranches(branchA: string, branchB: string): Promise<readonly string[]>;
     getRemoteAliases(): Promise<readonly RemoteAlias[]>;
     listTags(): Promise<readonly string[]>;
+    hasRef(ref: string): Promise<boolean>;
     getMergeCommitLogs(from: string): Promise<readonly MergeCommitLogEntry[]>;
 };
 
@@ -47,6 +48,15 @@ function createParsableGitLogFormat(): string {
     const fields = [subjectPlaceholder, bodyPlaceholder];
 
     return `${fields.join(fieldSeparator)}${lineSeparator}`;
+}
+
+async function hasExistingRef(execute: typeof execaCommand, ref: string): Promise<boolean> {
+    try {
+        await execute(`git rev-parse --verify --quiet ${ref}^{commit}`);
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 export function createGitCommandRunner(dependencies: GitCommandRunnerDependencies): GitCommandRunner {
@@ -90,6 +100,10 @@ export function createGitCommandRunner(dependencies: GitCommandRunnerDependencie
         async listTags() {
             const result = await execute('git tag --list');
             return splitLines(result.stdout);
+        },
+
+        async hasRef(ref) {
+            return hasExistingRef(execute, ref);
         },
 
         async getMergeCommitLogs(from) {


### PR DESCRIPTION
Extends the `@pr-log/core` base-ref API for release-plan consumers. Package-aware resolution now accepts package names, previous versions, registry `gitHead` metadata, custom package tag formats, and explicit refs, while missing selected refs fail instead of falling back silently.