### PR TITLE
Add target-scoped PR label resolution

### DIFF
--- a/source/bin/pr-log.ts
+++ b/source/bin/pr-log.ts
@@ -15,7 +15,7 @@ import { ensureCleanLocalGitStateFactory } from '../lib/ensure-clean-local-git-s
 import { getMergedPullRequestsFactory } from '../lib/get-merged-pull-requests.ts';
 import { createChangelogFactory } from '../lib/create-changelog.ts';
 import { findRemoteAliasFactory } from '../lib/find-remote-alias.ts';
-import { getPullRequestLabel } from '../lib/get-pull-request-label.ts';
+import { getPullRequestLabels } from '../lib/get-pull-request-label.ts';
 import { createGitCommandRunner } from '../lib/git-command-runner.ts';
 import { determineLatestVersionTag } from '../lib/latest-version-tag.ts';
 
@@ -46,7 +46,7 @@ const findRemoteAlias = findRemoteAliasFactory({ gitCommandRunner });
 const getMergedPullRequests = getMergedPullRequestsFactory({
     githubClient,
     gitCommandRunner,
-    getPullRequestLabel,
+    getPullRequestLabels,
     waitForMilliseconds: async (durationMilliseconds) => {
         await waitForTimeout(durationMilliseconds);
     },

--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -3,6 +3,8 @@ import { fake } from 'sinon';
 import {
     collectMergedPullRequests,
     createGitHubPullRequestChangedFilesReader,
+    createGitHubPullRequestLabelReader,
+    defaultValidLabels as exportedDefaultValidLabels,
     fetchPullRequestChangedFiles,
     formatPackageVersionTag,
     renderChangelogMarkdown,
@@ -54,12 +56,29 @@ test('exports pull request collection and label resolution', async () => {
             githubRepo: 'owner/repo',
             validLabels: defaultValidLabels,
             pullRequests,
-            pullRequestLabelReader: { getLabel: fake.resolves('bug') },
+            pullRequestLabelReader: { getLabels: fake.resolves(['bug']) },
             waitForMilliseconds: fake.resolves(undefined),
-            labelLookupIntervalMilliseconds: 0
+            labelLookupIntervalMilliseconds: 0,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined
         }),
         [{ id: pullRequestId, title: 'title', label: 'bug' }]
     );
+});
+
+test('exports pull request label collection', async () => {
+    const listLabelsOnIssue = fake.resolves({ data: [{ name: 'bug' }] });
+    const pullRequestLabelReader = createGitHubPullRequestLabelReader({
+        githubClient: {
+            issues: { listLabelsOnIssue }
+        } as never,
+        waitForMilliseconds: fake.resolves(undefined),
+        getCurrentDate: fake.returns(new Date(0)),
+        maximumRateLimitRetryCount: 0
+    });
+
+    assert.deepStrictEqual(await pullRequestLabelReader.getLabels('owner/repo', pullRequestId), ['bug']);
+    assert.strictEqual(exportedDefaultValidLabels.get('bug'), 'Bug Fixes');
 });
 
 test('exports changed file collection', async () => {

--- a/source/index.ts
+++ b/source/index.ts
@@ -19,6 +19,11 @@ import {
 } from './lib/collect-merged-pull-requests.ts';
 import * as githubChangedFiles from './lib/github-pull-request-changed-files.ts';
 import {
+    createGitHubPullRequestLabelReader as createGitHubPullRequestLabelReaderValue,
+    getPullRequestLabels as getPullRequestLabelsValue,
+    type GitHubPullRequestLabelReaderDependencies as GitHubPullRequestLabelReaderDependenciesValue
+} from './lib/get-pull-request-label.ts';
+import {
     fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
     type FetchPullRequestChangedFilesInput as FetchPullRequestChangedFilesInputValue,
     type PullRequestChangedFilesReader as PullRequestChangedFilesReaderValue
@@ -33,6 +38,7 @@ import {
     renderChangelogMarkdown as renderChangelogMarkdownValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue
 } from './lib/render-changelog-markdown.ts';
+import { defaultValidLabels as defaultValidLabelsValue } from './lib/valid-labels.ts';
 
 export async function collectMergedPullRequests(
     input: CollectMergedPullRequestsInputValue
@@ -46,6 +52,13 @@ export function createGitHubPullRequestChangedFilesReader(
 ): PullRequestChangedFilesReaderValue {
     const changedFilesReader = githubChangedFiles.createGitHubPullRequestChangedFilesReader(githubClient);
     return changedFilesReader;
+}
+
+export function createGitHubPullRequestLabelReader(
+    dependencies: GitHubPullRequestLabelReaderDependenciesValue
+): PullRequestLabelReaderValue {
+    const pullRequestLabelReader = createGitHubPullRequestLabelReaderValue(dependencies);
+    return pullRequestLabelReader;
 }
 
 export async function fetchPullRequestChangedFiles(
@@ -89,11 +102,22 @@ export async function resolvePullRequestLabels(
     return pullRequests;
 }
 
+export async function getPullRequestLabels(
+    githubRepo: string,
+    pullRequestId: number,
+    dependencies: GitHubPullRequestLabelReaderDependenciesValue
+): Promise<readonly string[]> {
+    const labels = await getPullRequestLabelsValue(githubRepo, pullRequestId, dependencies);
+    return labels;
+}
+
 export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue;
+export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultValidLabelsValue);
 export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
 export type GitRangeReader = GitRangeReaderValue;
 export type GitRefReader = GitRefReaderValue;
+export type GitHubPullRequestLabelReaderDependencies = GitHubPullRequestLabelReaderDependenciesValue;
 export type LatestSemverTagBaseRefInput = LatestSemverTagBaseRefInputValue;
 export type MergeCommitLogEntry = MergeCommitLogEntryValue;
 export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;

--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -12,28 +12,28 @@ const anyRepo = 'any/repo';
 const latestVersion = '1.2.3';
 const expectedPullRequestLabelCallCount = 2;
 const expectedWaitForMillisecondsCallCount = 2;
-const comparedArgumentCount = 3;
+const comparedArgumentCount = 2;
 
 type Overrides = {
     readonly listTags?: SinonSpy;
     readonly getMergeCommitLogs?: SinonSpy;
-    readonly getPullRequestLabel?: SinonSpy;
+    readonly getPullRequestLabels?: SinonSpy;
     readonly githubClient?: Octokit;
     readonly waitForMilliseconds?: SinonSpy;
     readonly labelLookupIntervalMilliseconds?: number;
 };
 
 type ControlledLabelLookup = {
-    readonly getPullRequestLabel: SinonSpy;
+    readonly getPullRequestLabels: SinonSpy;
     readonly firstLabelLookupStarted: Promise<void>;
-    resolveFirstLabelLookup(label: string): void;
+    resolveFirstLabelLookup(labels: readonly string[]): void;
 };
 
 function factory(overrides: Overrides = {}): GetMergedPullRequests {
     const {
         listTags = fake.resolves([latestVersion]),
         getMergeCommitLogs = fake.resolves([]),
-        getPullRequestLabel = fake.resolves('bug'),
+        getPullRequestLabels = fake.resolves(['bug']),
         githubClient = {
             pulls: {
                 get: fake.resolves({ data: { title: 'pull-request-title' } })
@@ -44,7 +44,7 @@ function factory(overrides: Overrides = {}): GetMergedPullRequests {
     } = overrides;
 
     const dependencies = {
-        getPullRequestLabel,
+        getPullRequestLabels,
         githubClient,
         gitCommandRunner: { listTags, getMergeCommitLogs },
         waitForMilliseconds,
@@ -59,34 +59,34 @@ function failUninitializedControlledLabelLookupResolver(): never {
 }
 
 function createControlledLabelLookup(): ControlledLabelLookup {
-    let resolveFirstLabelLookup: (label: string) => void = failUninitializedControlledLabelLookupResolver;
-    const firstLabelLookup = new Promise<string>((resolve) => {
+    let resolveFirstLabelLookup: (labels: readonly string[]) => void = failUninitializedControlledLabelLookupResolver;
+    const firstLabelLookup = new Promise<readonly string[]>((resolve) => {
         resolveFirstLabelLookup = resolve;
     });
     let resolveFirstLabelLookupStarted: () => void = failUninitializedControlledLabelLookupResolver;
     const firstLabelLookupStarted = new Promise<void>((resolve) => {
         resolveFirstLabelLookupStarted = resolve;
     });
-    const getPullRequestLabel = spy(async (_githubRepo, _validLabels, pullRequestId: number): Promise<string> => {
+    const getPullRequestLabels = spy(async (_githubRepo, pullRequestId: number): Promise<readonly string[]> => {
         if (pullRequestId === 1) {
             resolveFirstLabelLookupStarted();
             return firstLabelLookup;
         }
 
-        return 'documentation';
+        return ['documentation'];
     });
 
-    return { getPullRequestLabel, firstLabelLookupStarted, resolveFirstLabelLookup };
+    return { getPullRequestLabels, firstLabelLookupStarted, resolveFirstLabelLookup };
 }
 
 function assertFirstPullRequestLabelLookup(callCount: number, comparedArguments: readonly unknown[]): void {
     assert.strictEqual(callCount, 1);
-    assert.deepStrictEqual(comparedArguments, ['any/repo', defaultValidLabels, 1]);
+    assert.deepStrictEqual(comparedArguments, ['any/repo', 1]);
 }
 
 function assertSecondPullRequestLabelLookup(callCount: number, comparedArguments: readonly unknown[]): void {
     assert.strictEqual(callCount, expectedPullRequestLabelCallCount);
-    assert.deepStrictEqual(comparedArguments, ['any/repo', defaultValidLabels, expectedPullRequestLabelCallCount]);
+    assert.deepStrictEqual(comparedArguments, ['any/repo', expectedPullRequestLabelCallCount]);
 }
 
 test('throws when there is no tag at all', async () => {
@@ -208,7 +208,7 @@ test('throws when the title is missing in the commit log and the repo is invalid
 test('extracts id, title and label for merged pull requests', async () => {
     const firstExpectedPullRequest = { id: 1, title: 'pr-1 message', label: 'bug' };
     const secondExpectedPullRequest = { id: 2, title: 'pr-2 message', label: 'bug' };
-    const getPullRequestLabel = fake.resolves('bug');
+    const getPullRequestLabels = fake.resolves(['bug']);
     const getMergeCommitLogs = fake.resolves([
         {
             subject: 'Merge pull request #1 from branch',
@@ -216,19 +216,17 @@ test('extracts id, title and label for merged pull requests', async () => {
         },
         { subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
     ]);
-    const getMergedPullRequests = factory({ getMergeCommitLogs, getPullRequestLabel });
+    const getMergedPullRequests = factory({ getMergeCommitLogs, getPullRequestLabels });
 
     const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
 
-    assert.strictEqual(getPullRequestLabel.callCount, expectedPullRequestLabelCallCount);
-    assert.deepStrictEqual(getPullRequestLabel.firstCall.args.slice(0, comparedArgumentCount), [
+    assert.strictEqual(getPullRequestLabels.callCount, expectedPullRequestLabelCallCount);
+    assert.deepStrictEqual(getPullRequestLabels.firstCall.args.slice(0, comparedArgumentCount), [
         'any/repo',
-        defaultValidLabels,
         firstExpectedPullRequest.id
     ]);
-    assert.deepStrictEqual(getPullRequestLabel.secondCall.args.slice(0, comparedArgumentCount), [
+    assert.deepStrictEqual(getPullRequestLabels.secondCall.args.slice(0, comparedArgumentCount), [
         'any/repo',
-        defaultValidLabels,
         secondExpectedPullRequest.id
     ]);
 
@@ -243,23 +241,23 @@ test('looks up pull request labels sequentially', async () => {
         },
         { subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
     ]);
-    const { getPullRequestLabel, firstLabelLookupStarted, resolveFirstLabelLookup } = createControlledLabelLookup();
-    const getMergedPullRequests = factory({ getMergeCommitLogs, getPullRequestLabel });
+    const { getPullRequestLabels, firstLabelLookupStarted, resolveFirstLabelLookup } = createControlledLabelLookup();
+    const getMergedPullRequests = factory({ getMergeCommitLogs, getPullRequestLabels });
     const mergedPullRequests = getMergedPullRequests(anyRepo, defaultValidLabels);
 
     await firstLabelLookupStarted;
 
     assertFirstPullRequestLabelLookup(
-        getPullRequestLabel.callCount,
-        getPullRequestLabel.firstCall.args.slice(0, comparedArgumentCount)
+        getPullRequestLabels.callCount,
+        getPullRequestLabels.firstCall.args.slice(0, comparedArgumentCount)
     );
 
-    resolveFirstLabelLookup('bug');
+    resolveFirstLabelLookup(['bug']);
     const pullRequests = await mergedPullRequests;
 
     assertSecondPullRequestLabelLookup(
-        getPullRequestLabel.callCount,
-        getPullRequestLabel.secondCall.args.slice(0, comparedArgumentCount)
+        getPullRequestLabels.callCount,
+        getPullRequestLabels.secondCall.args.slice(0, comparedArgumentCount)
     );
     assert.deepStrictEqual(pullRequests, [
         { id: 1, title: 'pr-1 message', label: 'bug' },

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -1,5 +1,5 @@
 import type { Octokit } from '@octokit/rest';
-import type { GetPullRequestLabel } from './get-pull-request-label.ts';
+import type { GetPullRequestLabels } from './get-pull-request-label.ts';
 import type { GitCommandRunner } from './git-command-runner.ts';
 import { resolveLatestSemverTagBaseRef } from './changelog-base-ref.ts';
 import {
@@ -17,7 +17,7 @@ export type PullRequestWithLabel = PullRequestWithLabelValue;
 
 export type GetMergedPullRequestsDependencies = {
     readonly gitCommandRunner: GitCommandRunner;
-    readonly getPullRequestLabel: GetPullRequestLabel;
+    readonly getPullRequestLabels: GetPullRequestLabels;
     readonly githubClient: Octokit;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
     readonly labelLookupIntervalMilliseconds: number;
@@ -60,7 +60,7 @@ async function fetchPullRequestTitle(
 export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequestsDependencies): GetMergedPullRequests {
     const {
         gitCommandRunner,
-        getPullRequestLabel,
+        getPullRequestLabels,
         githubClient,
         waitForMilliseconds,
         labelLookupIntervalMilliseconds
@@ -95,9 +95,11 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
             pullRequests,
             waitForMilliseconds,
             labelLookupIntervalMilliseconds,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined,
             pullRequestLabelReader: {
-                async getLabel(repo, labels, pullRequestId) {
-                    return getPullRequestLabel(repo, labels, pullRequestId, dependencies);
+                async getLabels(repo, pullRequestId) {
+                    return getPullRequestLabels(repo, pullRequestId, dependencies);
                 }
             }
         });

--- a/source/lib/get-pull-request-label.test.ts
+++ b/source/lib/get-pull-request-label.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { fake, stub, type SinonSpy } from 'sinon';
 import { oneLine } from 'common-tags';
 import type { Octokit } from '@octokit/rest';
-import { getPullRequestLabel } from './get-pull-request-label.ts';
+import { getPullRequestLabel, getPullRequestLabels } from './get-pull-request-label.ts';
 import { defaultValidLabels } from './valid-labels.ts';
 
 type Overrides = {
@@ -141,6 +141,23 @@ test('fulfills with the correct label name', async () => {
             maximumRateLimitRetryCount
         }),
         expectedLabelName
+    );
+});
+
+test('fulfills with all label names', async () => {
+    const listLabelsOnIssue = fake.resolves({ data: [{ name: 'bug' }, { name: 'docs' }] });
+    const { githubClient, waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = createDependencies({
+        listLabelsOnIssue
+    });
+
+    assert.deepStrictEqual(
+        await getPullRequestLabels(anyRepo, anyPullRequestId, {
+            githubClient,
+            waitForMilliseconds,
+            getCurrentDate,
+            maximumRateLimitRetryCount
+        }),
+        ['bug', 'docs']
     );
 });
 

--- a/source/lib/get-pull-request-label.ts
+++ b/source/lib/get-pull-request-label.ts
@@ -2,8 +2,9 @@ import type { Octokit } from '@octokit/rest';
 import { isError, isFiniteNumber, isString } from '@sindresorhus/is';
 import Maybe from 'true-myth/maybe';
 import { splitByString } from './split.ts';
+import type { PullRequestLabelReader } from './resolve-pull-request-labels.ts';
 
-type Dependencies = {
+export type GitHubPullRequestLabelReaderDependencies = {
     readonly githubClient: Octokit;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
     readonly getCurrentDate: () => Readonly<Date>;
@@ -11,6 +12,7 @@ type Dependencies = {
 };
 
 export type GetPullRequestLabel = typeof getPullRequestLabel;
+export type GetPullRequestLabels = typeof getPullRequestLabels;
 type Headers = Readonly<Record<string, number | string | undefined>>;
 type GitHubClientError = {
     readonly message: string;
@@ -129,12 +131,12 @@ function getGitHubClientError(error: unknown): GitHubClientError | undefined {
 type FetchLabelsWithRateLimitRetryOptions = {
     readonly githubRepo: string;
     readonly pullRequestId: number;
-    readonly dependencies: Dependencies;
+    readonly dependencies: GitHubPullRequestLabelReaderDependencies;
 };
 
 async function waitForRateLimitResetIfRetryable(
     error: unknown,
-    dependencies: Dependencies,
+    dependencies: GitHubPullRequestLabelReaderDependencies,
     retryCount: number
 ): Promise<boolean> {
     const { waitForMilliseconds, getCurrentDate, maximumRateLimitRetryCount } = dependencies;
@@ -175,7 +177,7 @@ export async function getPullRequestLabel(
     githubRepo: string,
     validLabels: ReadonlyMap<string, string>,
     pullRequestId: number,
-    dependencies: Dependencies
+    dependencies: GitHubPullRequestLabelReaderDependencies
 ): Promise<string> {
     const validLabelNames = Array.from(validLabels.keys());
 
@@ -201,4 +203,33 @@ export async function getPullRequestLabel(
     }
 
     return firstLabel.name;
+}
+
+export async function getPullRequestLabels(
+    githubRepo: string,
+    pullRequestId: number,
+    dependencies: GitHubPullRequestLabelReaderDependencies
+): Promise<readonly string[]> {
+    const labels = await fetchLabelsWithRateLimitRetry(
+        {
+            githubRepo,
+            pullRequestId,
+            dependencies
+        },
+        0
+    );
+
+    return labels.map((label) => {
+        return label.name;
+    });
+}
+
+export function createGitHubPullRequestLabelReader(
+    dependencies: GitHubPullRequestLabelReaderDependencies
+): PullRequestLabelReader {
+    return {
+        async getLabels(githubRepo, pullRequestId) {
+            return getPullRequestLabels(githubRepo, pullRequestId, dependencies);
+        }
+    };
 }

--- a/source/lib/resolve-pull-request-labels.test.ts
+++ b/source/lib/resolve-pull-request-labels.test.ts
@@ -7,8 +7,8 @@ const labelLookupIntervalMilliseconds = 250;
 const secondPullRequestId = 2;
 
 test('resolves labels for pull requests sequentially', async () => {
-    const getLabel = fake(async (_githubRepo, _validLabels, pullRequestId: number) => {
-        return pullRequestId === 1 ? 'bug' : 'documentation';
+    const getLabels = fake(async (_githubRepo, pullRequestId: number) => {
+        return [pullRequestId === 1 ? 'bug' : 'documentation'];
     });
     const waitForMilliseconds = fake.resolves(undefined);
 
@@ -19,9 +19,11 @@ test('resolves labels for pull requests sequentially', async () => {
             { id: 1, title: 'Fix bug' },
             { id: secondPullRequestId, title: 'Update docs' }
         ],
-        pullRequestLabelReader: { getLabel },
+        pullRequestLabelReader: { getLabels },
         waitForMilliseconds,
-        labelLookupIntervalMilliseconds
+        labelLookupIntervalMilliseconds,
+        targetName: undefined,
+        targetScopedLabelPattern: undefined
     });
 
     assert.strictEqual(waitForMilliseconds.callCount, 1);
@@ -30,4 +32,134 @@ test('resolves labels for pull requests sequentially', async () => {
         { id: 1, title: 'Fix bug', label: 'bug' },
         { id: secondPullRequestId, title: 'Update docs', label: 'documentation' }
     ]);
+});
+
+test('applies target scoped labels over pull request level labels', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [{ id: 1, title: 'Fix bug' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: 'pkg-a',
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'breaking' }]);
+});
+
+test('ignores raw labels that are not valid labels', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [{ id: 1, title: 'Fix bug' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'not-for-changelog']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: undefined,
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'bug' }]);
+});
+
+test('rejects missing pull request level labels', async () => {
+    await assert.rejects(
+        resolvePullRequestLabels({
+            githubRepo: 'owner/repo',
+            validLabels: defaultValidLabels,
+            pullRequests: [{ id: 1, title: 'Fix bug' }],
+            pullRequestLabelReader: { getLabels: fake.resolves(['not-for-changelog']) },
+            waitForMilliseconds: fake.resolves(undefined),
+            labelLookupIntervalMilliseconds: 0,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined
+        }),
+        {
+            message:
+                'Pull Request #1 has no label of breaking, bug, feature, enhancement, documentation, upgrade, refactor, build'
+        }
+    );
+});
+
+test('rejects multiple pull request level labels', async () => {
+    await assert.rejects(
+        resolvePullRequestLabels({
+            githubRepo: 'owner/repo',
+            validLabels: defaultValidLabels,
+            pullRequests: [{ id: 1, title: 'Fix bug' }],
+            pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'documentation']) },
+            waitForMilliseconds: fake.resolves(undefined),
+            labelLookupIntervalMilliseconds: 0,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined
+        }),
+        {
+            message:
+                'Pull Request #1 has multiple labels of breaking, bug, feature, enhancement, documentation, upgrade, refactor, build'
+        }
+    );
+});
+
+test('ignores scoped labels for other targets', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [{ id: 1, title: 'Fix bug' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: 'pkg-b',
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'bug' }]);
+});
+
+test('rejects conflicting target scoped labels', async () => {
+    await assert.rejects(
+        resolvePullRequestLabels({
+            githubRepo: 'owner/repo',
+            validLabels: defaultValidLabels,
+            pullRequests: [{ id: 1, title: 'Fix bug' }],
+            pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking', 'pkg-a:feature']) },
+            waitForMilliseconds: fake.resolves(undefined),
+            labelLookupIntervalMilliseconds: 0,
+            targetName: 'pkg-a',
+            targetScopedLabelPattern: undefined
+        }),
+        { message: 'Pull Request #1 has multiple scoped labels for "pkg-a"' }
+    );
+});
+
+test('rejects unknown target scoped labels', async () => {
+    await assert.rejects(
+        resolvePullRequestLabels({
+            githubRepo: 'owner/repo',
+            validLabels: defaultValidLabels,
+            pullRequests: [{ id: 1, title: 'Fix bug' }],
+            pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:not-real']) },
+            waitForMilliseconds: fake.resolves(undefined),
+            labelLookupIntervalMilliseconds: 0,
+            targetName: 'pkg-a',
+            targetScopedLabelPattern: undefined
+        }),
+        { message: 'Pull Request #1 has unknown label "pkg-a:not-real"' }
+    );
+});
+
+test('supports scoped package names in target labels', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [{ id: 1, title: 'Fix bug' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['bug', '@scope/pkg:documentation']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: '@scope/pkg',
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'documentation' }]);
 });

--- a/source/lib/resolve-pull-request-labels.ts
+++ b/source/lib/resolve-pull-request-labels.ts
@@ -5,7 +5,7 @@ export type PullRequestWithLabel = PullRequest & {
 };
 
 export type PullRequestLabelReader = {
-    getLabel(githubRepo: string, validLabels: ReadonlyMap<string, string>, pullRequestId: number): Promise<string>;
+    getLabels(githubRepo: string, pullRequestId: number): Promise<readonly string[]>;
 };
 
 export type ResolvePullRequestLabelsInput = {
@@ -15,7 +15,105 @@ export type ResolvePullRequestLabelsInput = {
     readonly pullRequestLabelReader: PullRequestLabelReader;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
     readonly labelLookupIntervalMilliseconds: number;
+    readonly targetName: string | undefined;
+    readonly targetScopedLabelPattern: string | undefined;
 };
+
+const defaultTargetScopedLabelPattern = '{targetName}:{label}';
+
+function formatLabelList(validLabels: ReadonlyMap<string, string>): string {
+    return Array.from(validLabels.keys()).join(', ');
+}
+
+function resolvePullRequestLevelLabel(
+    validLabels: ReadonlyMap<string, string>,
+    pullRequestId: number,
+    labels: readonly string[]
+): string {
+    const validLabelNames = new Set(validLabels.keys());
+    const matchingLabels = labels.filter((label) => {
+        return validLabelNames.has(label);
+    });
+    const [label] = matchingLabels;
+    const listOfLabels = formatLabelList(validLabels);
+
+    if (matchingLabels.length > 1) {
+        throw new Error(`Pull Request #${pullRequestId} has multiple labels of ${listOfLabels}`);
+    }
+
+    if (label === undefined) {
+        throw new TypeError(`Pull Request #${pullRequestId} has no label of ${listOfLabels}`);
+    }
+
+    return label;
+}
+
+function escapeRegExp(value: string): string {
+    return value.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}
+
+function createTargetScopedLabelRegExp(targetName: string, pattern: string): Readonly<RegExp> {
+    const escapedPattern = escapeRegExp(pattern);
+    const source = escapedPattern
+        .replaceAll(escapeRegExp('{targetName}'), escapeRegExp(targetName))
+        .replaceAll(escapeRegExp('{label}'), '(?<label>.+)');
+
+    return new RegExp(`^${source}$`, 'u');
+}
+
+function resolveTargetScopedLabel(options: {
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly pullRequestId: number;
+    readonly labels: readonly string[];
+    readonly targetName: string;
+    readonly targetScopedLabelPattern: string;
+}): string | undefined {
+    const { validLabels, pullRequestId, labels, targetName, targetScopedLabelPattern } = options;
+    const targetScopedLabelRegExp = createTargetScopedLabelRegExp(targetName, targetScopedLabelPattern);
+    const targetScopedLabels = labels.flatMap((label) => {
+        const match = targetScopedLabelRegExp.exec(label);
+        const targetLabel = match?.groups?.label;
+
+        if (targetLabel === undefined) {
+            return [];
+        }
+
+        if (!validLabels.has(targetLabel)) {
+            throw new TypeError(`Pull Request #${pullRequestId} has unknown label "${label}"`);
+        }
+
+        return [targetLabel];
+    });
+    const [targetScopedLabel] = targetScopedLabels;
+
+    if (targetScopedLabels.length > 1) {
+        throw new Error(`Pull Request #${pullRequestId} has multiple scoped labels for "${targetName}"`);
+    }
+
+    return targetScopedLabel;
+}
+
+function resolveLabel(
+    input: ResolvePullRequestLabelsInput,
+    pullRequest: PullRequest,
+    labels: readonly string[]
+): string {
+    const pullRequestLevelLabel = resolvePullRequestLevelLabel(input.validLabels, pullRequest.id, labels);
+
+    if (input.targetName === undefined) {
+        return pullRequestLevelLabel;
+    }
+
+    return (
+        resolveTargetScopedLabel({
+            validLabels: input.validLabels,
+            pullRequestId: pullRequest.id,
+            labels,
+            targetName: input.targetName,
+            targetScopedLabelPattern: input.targetScopedLabelPattern ?? defaultTargetScopedLabelPattern
+        }) ?? pullRequestLevelLabel
+    );
+}
 
 export async function resolvePullRequestLabels(
     input: ResolvePullRequestLabelsInput
@@ -27,7 +125,8 @@ export async function resolvePullRequestLabels(
             await input.waitForMilliseconds(input.labelLookupIntervalMilliseconds);
         }
 
-        const label = await input.pullRequestLabelReader.getLabel(input.githubRepo, input.validLabels, pullRequest.id);
+        const labels = await input.pullRequestLabelReader.getLabels(input.githubRepo, pullRequest.id);
+        const label = resolveLabel(input, pullRequest, labels);
 
         pullRequestsWithLabels.push({
             id: pullRequest.id,


### PR DESCRIPTION
Moves GitHub label fetching to return raw label names, then resolves changelog labels inside pr-log policy code. This keeps existing PR-level validation while allowing target-scoped labels such as `pkg-a:breaking` to override one target.