### PR TITLE
Add target changelog rendering APIs

### DIFF
--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -3,11 +3,13 @@ import { fake } from 'sinon';
 import {
     collectMergedPullRequests,
     createGitHubPullRequestChangedFilesReader,
-    createGitHubPullRequestLabelReader,
     defaultValidLabels as exportedDefaultValidLabels,
     fetchPullRequestChangedFiles,
+    filterPullRequestsByTargetFiles,
     formatPackageVersionTag,
+    renderGroupedTargetChangelogMarkdown,
     renderChangelogMarkdown,
+    renderTargetChangelogMarkdown,
     resolveChangelogBaseRef,
     resolveLatestSemverTagBaseRef,
     resolvePullRequestLabels,
@@ -66,21 +68,6 @@ test('exports pull request collection and label resolution', async () => {
     );
 });
 
-test('exports pull request label collection', async () => {
-    const listLabelsOnIssue = fake.resolves({ data: [{ name: 'bug' }] });
-    const pullRequestLabelReader = createGitHubPullRequestLabelReader({
-        githubClient: {
-            issues: { listLabelsOnIssue }
-        } as never,
-        waitForMilliseconds: fake.resolves(undefined),
-        getCurrentDate: fake.returns(new Date(0)),
-        maximumRateLimitRetryCount: 0
-    });
-
-    assert.deepStrictEqual(await pullRequestLabelReader.getLabels('owner/repo', pullRequestId), ['bug']);
-    assert.strictEqual(exportedDefaultValidLabels.get('bug'), 'Bug Fixes');
-});
-
 test('exports changed file collection', async () => {
     const changedFilesReader = createGitHubPullRequestChangedFilesReader({
         paginate: fake.resolves([{ filename: 'source/index.ts' }]),
@@ -110,6 +97,47 @@ test('exports changelog rendering', () => {
     });
 
     assert.ok(changelog.includes('## 1.0.0'));
+
+    const targetChangelog = renderTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: pullRequestId, title: 'title', label: 'bug' }],
+        githubRepo: 'owner/repo',
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(targetChangelog.includes('### Bug Fixes'));
+
+    const groupedChangelog = renderGroupedTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [{ targetName: 'pkg-a', mergedPullRequests: [{ id: pullRequestId, title: 'title', label: 'bug' }] }],
+        githubRepo: 'owner/repo',
+        unreleased: false,
+        versionNumber: '1.0.0'
+    });
+
+    assert.ok(groupedChangelog.includes('### pkg-a'));
+    assert.ok(groupedChangelog.includes('#### Bug Fixes'));
+});
+
+test('exports target file filtering and default labels', () => {
+    const changedFilesByPullRequest = new Map([[pullRequestId, ['source/index.ts']]]);
+
+    assert.deepStrictEqual(
+        filterPullRequestsByTargetFiles({
+            targetName: 'pkg',
+            targetSourceFiles: ['source/index.ts'],
+            pullRequests,
+            changedFilesByPullRequest,
+            ignoredAttributionPaths: []
+        }),
+        pullRequests
+    );
+    assert.strictEqual(exportedDefaultValidLabels.get('bug'), 'Bug Fixes');
 });
 
 test('exports the release plan package type', () => {

--- a/source/index.ts
+++ b/source/index.ts
@@ -24,6 +24,10 @@ import {
     type GitHubPullRequestLabelReaderDependencies as GitHubPullRequestLabelReaderDependenciesValue
 } from './lib/get-pull-request-label.ts';
 import {
+    filterPullRequestsByTargetFiles as filterPullRequestsByTargetFilesValue,
+    type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue
+} from './lib/filter-pull-requests-by-target-files.ts';
+import {
     fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
     type FetchPullRequestChangedFilesInput as FetchPullRequestChangedFilesInputValue,
     type PullRequestChangedFilesReader as PullRequestChangedFilesReaderValue
@@ -35,7 +39,10 @@ import {
     type ResolvePullRequestLabelsInput as ResolvePullRequestLabelsInputValue
 } from './lib/resolve-pull-request-labels.ts';
 import {
+    renderGroupedTargetChangelogMarkdown as renderGroupedTargetChangelogMarkdownValue,
     renderChangelogMarkdown as renderChangelogMarkdownValue,
+    renderTargetChangelogMarkdown as renderTargetChangelogMarkdownValue,
+    type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue
 } from './lib/render-changelog-markdown.ts';
 import { defaultValidLabels as defaultValidLabelsValue } from './lib/valid-labels.ts';
@@ -68,6 +75,13 @@ export async function fetchPullRequestChangedFiles(
     return changedFiles;
 }
 
+export function filterPullRequestsByTargetFiles(
+    input: FilterPullRequestsByTargetFilesInputValue
+): readonly PullRequestValue[] {
+    const pullRequests = filterPullRequestsByTargetFilesValue(input);
+    return pullRequests;
+}
+
 export function formatPackageVersionTag(options: {
     readonly packageName: string;
     readonly version: string;
@@ -79,6 +93,16 @@ export function formatPackageVersionTag(options: {
 
 export function renderChangelogMarkdown(input: RenderChangelogMarkdownInputValue): string {
     const changelog = renderChangelogMarkdownValue(input);
+    return changelog;
+}
+
+export function renderGroupedTargetChangelogMarkdown(input: RenderGroupedTargetChangelogMarkdownInputValue): string {
+    const changelog = renderGroupedTargetChangelogMarkdownValue(input);
+    return changelog;
+}
+
+export function renderTargetChangelogMarkdown(input: RenderChangelogMarkdownInputValue): string {
+    const changelog = renderTargetChangelogMarkdownValue(input);
     return changelog;
 }
 
@@ -115,6 +139,7 @@ export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue;
 export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultValidLabelsValue);
 export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
+export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
 export type GitRangeReader = GitRangeReaderValue;
 export type GitRefReader = GitRefReaderValue;
 export type GitHubPullRequestLabelReaderDependencies = GitHubPullRequestLabelReaderDependenciesValue;
@@ -139,4 +164,5 @@ export type ReleasePlanPackage = {
     readonly changedArtifactFiles: readonly string[];
 };
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
+export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
 export type ResolvePullRequestLabelsInput = ResolvePullRequestLabelsInputValue;

--- a/source/lib/filter-pull-requests-by-target-files.test.ts
+++ b/source/lib/filter-pull-requests-by-target-files.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert';
+import { filterPullRequestsByTargetFiles } from './filter-pull-requests-by-target-files.ts';
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+
+const pullRequests: readonly PullRequest[] = [
+    { id: 1, title: 'Fix target' },
+    { id: 2, title: 'Fix unrelated' },
+    { id: 3, title: 'Update changelog' }
+];
+const unrelatedPullRequestId = 2;
+const changelogPullRequestId = 3;
+
+test('keeps pull requests that changed target source files', () => {
+    const changedFilesByPullRequest = new Map<number, readonly string[]>([
+        [1, ['source/index.ts']],
+        [unrelatedPullRequestId, ['test/index.test.ts']]
+    ]);
+
+    const filteredPullRequests = filterPullRequestsByTargetFiles({
+        targetName: 'target',
+        targetSourceFiles: ['source/index.ts'],
+        pullRequests,
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: []
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [{ id: 1, title: 'Fix target' }]);
+});
+
+test('normalizes repository paths before matching target files', () => {
+    const changedFilesByPullRequest = new Map<number, readonly string[]>([[1, ['.\\source\\index.ts']]]);
+
+    const filteredPullRequests = filterPullRequestsByTargetFiles({
+        targetName: 'target',
+        targetSourceFiles: ['./source/index.ts'],
+        pullRequests: [{ id: 1, title: 'Fix target' }],
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: []
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [{ id: 1, title: 'Fix target' }]);
+});
+
+test('ignores supplied attribution paths', () => {
+    const changedFilesByPullRequest = new Map<number, readonly string[]>([
+        [1, ['source/index.ts']],
+        [changelogPullRequestId, ['CHANGELOG.md']]
+    ]);
+
+    const filteredPullRequests = filterPullRequestsByTargetFiles({
+        targetName: 'target',
+        targetSourceFiles: ['source/index.ts', 'CHANGELOG.md'],
+        pullRequests,
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: ['CHANGELOG.md']
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [{ id: 1, title: 'Fix target' }]);
+});

--- a/source/lib/filter-pull-requests-by-target-files.ts
+++ b/source/lib/filter-pull-requests-by-target-files.ts
@@ -1,0 +1,42 @@
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+
+export type FilterPullRequestsByTargetFilesInput = {
+    readonly targetName: string;
+    readonly targetSourceFiles: readonly string[];
+    readonly pullRequests: readonly PullRequest[];
+    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly string[]>;
+    readonly ignoredAttributionPaths: readonly string[];
+};
+
+function normalizeRepositoryPath(filePath: string): string {
+    return filePath.replaceAll('\\', '/').replace(/^\.?\//u, '');
+}
+
+function createNormalizedPathSet(paths: readonly string[]): ReadonlySet<string> {
+    return new Set(paths.map(normalizeRepositoryPath));
+}
+
+function hasTargetFileChange(options: {
+    readonly changedFiles: readonly string[];
+    readonly targetSourceFiles: ReadonlySet<string>;
+    readonly ignoredAttributionPaths: ReadonlySet<string>;
+}): boolean {
+    const { changedFiles, targetSourceFiles, ignoredAttributionPaths } = options;
+
+    return changedFiles.some((changedFile) => {
+        const normalizedChangedFile = normalizeRepositoryPath(changedFile);
+
+        return targetSourceFiles.has(normalizedChangedFile) && !ignoredAttributionPaths.has(normalizedChangedFile);
+    });
+}
+
+export function filterPullRequestsByTargetFiles(input: FilterPullRequestsByTargetFilesInput): readonly PullRequest[] {
+    const targetSourceFiles = createNormalizedPathSet(input.targetSourceFiles);
+    const ignoredAttributionPaths = createNormalizedPathSet(input.ignoredAttributionPaths);
+
+    return input.pullRequests.filter((pullRequest) => {
+        const changedFiles = input.changedFilesByPullRequest.get(pullRequest.id) ?? [];
+
+        return hasTargetFileChange({ changedFiles, targetSourceFiles, ignoredAttributionPaths });
+    });
+}

--- a/source/lib/render-changelog-markdown.test.ts
+++ b/source/lib/render-changelog-markdown.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert';
-import { renderChangelogMarkdown } from './render-changelog-markdown.ts';
+import {
+    renderChangelogMarkdown,
+    renderGroupedTargetChangelogMarkdown,
+    renderTargetChangelogMarkdown
+} from './render-changelog-markdown.ts';
 import { defaultValidLabels } from './valid-labels.ts';
 
 test('renders released changelog markdown', () => {
@@ -30,4 +34,58 @@ test('renders unreleased changelog markdown without a title', () => {
 
     assert.ok(!changelog.startsWith('## '));
     assert.ok(changelog.includes('* Fix bug ([#1](https://github.com/owner/repo/pull/1))'));
+});
+
+test('renders target changelog markdown', () => {
+    const changelog = renderTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }],
+        githubRepo: 'owner/repo',
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(changelog.includes('### Bug Fixes'));
+    assert.ok(changelog.includes('* Fix bug ([#1](https://github.com/owner/repo/pull/1))'));
+});
+
+test('renders grouped target changelog markdown', () => {
+    const changelog = renderGroupedTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            { targetName: 'pkg-a', mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }] },
+            { targetName: 'pkg-b', mergedPullRequests: [{ id: 2, title: 'Add feature', label: 'feature' }] }
+        ],
+        githubRepo: 'owner/repo',
+        unreleased: false,
+        versionNumber: '1.2.3'
+    });
+
+    assert.ok(changelog.includes('## 1.2.3 (January 1, 1970)'));
+    assert.ok(changelog.includes('### pkg-a'));
+    assert.ok(changelog.includes('#### Bug Fixes'));
+    assert.ok(changelog.includes('### pkg-b'));
+    assert.ok(changelog.includes('#### Features'));
+});
+
+test('does not render empty target sections', () => {
+    const changelog = renderGroupedTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            { targetName: 'pkg-a', mergedPullRequests: [] },
+            { targetName: 'pkg-b', mergedPullRequests: [{ id: 2, title: 'Add feature', label: 'feature' }] }
+        ],
+        githubRepo: 'owner/repo',
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(!changelog.includes('### pkg-a'));
+    assert.ok(changelog.includes('### pkg-b'));
 });

--- a/source/lib/render-changelog-markdown.ts
+++ b/source/lib/render-changelog-markdown.ts
@@ -24,6 +24,33 @@ export type RenderChangelogMarkdownInput =
     | RenderReleasedChangelogMarkdownInput
     | RenderUnreleasedChangelogMarkdownInput;
 
+export type TargetChangelogEntries = {
+    readonly targetName: string;
+    readonly mergedPullRequests: readonly PullRequestWithLabel[];
+};
+
+type RenderGroupedTargetChangelogMarkdownInputBase = {
+    readonly packageInfo: Record<string, unknown>;
+    readonly currentDate: Readonly<Date>;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly githubRepo: string;
+    readonly targets: readonly TargetChangelogEntries[];
+};
+
+type RenderReleasedGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputBase & {
+    readonly unreleased: false;
+    readonly versionNumber: string;
+};
+
+type RenderUnreleasedGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputBase & {
+    readonly unreleased: true;
+    readonly versionNumber: undefined;
+};
+
+export type RenderGroupedTargetChangelogMarkdownInput =
+    | RenderReleasedGroupedTargetChangelogMarkdownInput
+    | RenderUnreleasedGroupedTargetChangelogMarkdownInput;
+
 export function renderChangelogMarkdown(input: RenderChangelogMarkdownInput): string {
     const createChangelog = createChangelogFactory({
         packageInfo: input.packageInfo,
@@ -49,4 +76,57 @@ export function renderChangelogMarkdown(input: RenderChangelogMarkdownInput): st
         unreleased: false,
         versionNumber: Maybe.just(input.versionNumber) as Just<string>
     });
+}
+
+export const renderTargetChangelogMarkdown = renderChangelogMarkdown;
+
+function demoteLabelHeadings(changelog: string): string {
+    return changelog.replaceAll(/^### /gmu, '#### ');
+}
+
+function renderGroupedChangelogTitle(input: RenderGroupedTargetChangelogMarkdownInput): string {
+    if (input.unreleased) {
+        return '';
+    }
+
+    return renderChangelogMarkdown({
+        packageInfo: input.packageInfo,
+        currentDate: input.currentDate,
+        validLabels: input.validLabels,
+        mergedPullRequests: [],
+        githubRepo: input.githubRepo,
+        unreleased: false,
+        versionNumber: input.versionNumber
+    });
+}
+
+function renderTargetSection(input: RenderGroupedTargetChangelogMarkdownInput, target: TargetChangelogEntries): string {
+    if (target.mergedPullRequests.length === 0) {
+        return '';
+    }
+
+    const targetBody = demoteLabelHeadings(
+        renderChangelogMarkdown({
+            packageInfo: input.packageInfo,
+            currentDate: input.currentDate,
+            validLabels: input.validLabels,
+            mergedPullRequests: target.mergedPullRequests,
+            githubRepo: input.githubRepo,
+            unreleased: true,
+            versionNumber: undefined
+        })
+    );
+
+    return `### ${target.targetName}\n\n${targetBody}`;
+}
+
+export function renderGroupedTargetChangelogMarkdown(input: RenderGroupedTargetChangelogMarkdownInput): string {
+    const title = renderGroupedChangelogTitle(input);
+    const sections = input.targets
+        .map((target) => {
+            return renderTargetSection(input, target);
+        })
+        .join('');
+
+    return `${title}${sections}`;
 }


### PR DESCRIPTION
Stacked on #535. Adds target file attribution and target/grouped Markdown rendering so consumers can classify already-collected pull requests without pr-log owning release planning.