### PR TITLE
Export `defaultValidLabels` from `@pr-log/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8030,6 +8030,19 @@
             "optional": true,
             "peer": true
         },
+        "node_modules/packtory/node_modules/semver": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",

--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -3,6 +3,7 @@ import { fake } from 'sinon';
 import {
     collectMergedPullRequests,
     createGitHubPullRequestChangedFilesReader,
+    defaultValidLabels as exportedDefaultValidLabels,
     fetchPullRequestChangedFiles,
     formatPackageVersionTag,
     renderChangelogMarkdown,
@@ -106,4 +107,8 @@ test('exports the release plan package type', () => {
     };
 
     assert.strictEqual(releasePlanPackage.name, 'pkg');
+});
+
+test('exports default valid labels', () => {
+    assert.strictEqual(exportedDefaultValidLabels.get('bug'), 'Bug Fixes');
 });

--- a/source/index.ts
+++ b/source/index.ts
@@ -33,6 +33,7 @@ import {
     renderChangelogMarkdown as renderChangelogMarkdownValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue
 } from './lib/render-changelog-markdown.ts';
+import { defaultValidLabels as defaultValidLabelsValue } from './lib/valid-labels.ts';
 
 export async function collectMergedPullRequests(
     input: CollectMergedPullRequestsInputValue
@@ -91,6 +92,7 @@ export async function resolvePullRequestLabels(
 
 export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue;
+export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultValidLabelsValue);
 export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
 export type GitRangeReader = GitRangeReaderValue;
 export type GitRefReader = GitRefReaderValue;


### PR DESCRIPTION
Exports the default changelog label map from the core package so library consumers can use the built-in categories without duplicating them.