### PR TITLE
Add target-scoped label overrides

### DIFF
--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -62,7 +62,9 @@ test('exports pull request collection and label resolution', async () => {
             pullRequests,
             pullRequestLabelReader: { getLabels: fake.resolves(['bug']) },
             waitForMilliseconds: fake.resolves(undefined),
-            labelLookupIntervalMilliseconds: 0
+            labelLookupIntervalMilliseconds: 0,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined
         }),
         [{ id: pullRequestId, title: 'title', label: 'bug' }]
     );

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -95,6 +95,8 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
             pullRequests,
             waitForMilliseconds,
             labelLookupIntervalMilliseconds,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined,
             pullRequestLabelReader: {
                 async getLabels(repo, pullRequestId) {
                     return getPullRequestLabels(repo, pullRequestId, dependencies);

--- a/source/lib/resolve-pull-request-labels.test.ts
+++ b/source/lib/resolve-pull-request-labels.test.ts
@@ -21,7 +21,9 @@ test('resolves labels for pull requests sequentially', async () => {
         ],
         pullRequestLabelReader: { getLabels },
         waitForMilliseconds,
-        labelLookupIntervalMilliseconds
+        labelLookupIntervalMilliseconds,
+        targetName: undefined,
+        targetScopedLabelPattern: undefined
     });
 
     assert.strictEqual(waitForMilliseconds.callCount, 1);
@@ -32,6 +34,21 @@ test('resolves labels for pull requests sequentially', async () => {
     ]);
 });
 
+test('applies target scoped labels over pull request level labels', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [{ id: 1, title: 'Fix bug' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: 'pkg-a',
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'breaking' }]);
+});
+
 test('ignores raw labels that are not valid labels', async () => {
     const pullRequests = await resolvePullRequestLabels({
         githubRepo: 'owner/repo',
@@ -39,7 +56,9 @@ test('ignores raw labels that are not valid labels', async () => {
         pullRequests: [{ id: 1, title: 'Fix bug' }],
         pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'not-for-changelog']) },
         waitForMilliseconds: fake.resolves(undefined),
-        labelLookupIntervalMilliseconds: 0
+        labelLookupIntervalMilliseconds: 0,
+        targetName: undefined,
+        targetScopedLabelPattern: undefined
     });
 
     assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'bug' }]);
@@ -53,7 +72,9 @@ test('rejects missing pull request level labels', async () => {
             pullRequests: [{ id: 1, title: 'Fix bug' }],
             pullRequestLabelReader: { getLabels: fake.resolves(['not-for-changelog']) },
             waitForMilliseconds: fake.resolves(undefined),
-            labelLookupIntervalMilliseconds: 0
+            labelLookupIntervalMilliseconds: 0,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined
         }),
         {
             message:
@@ -70,11 +91,75 @@ test('rejects multiple pull request level labels', async () => {
             pullRequests: [{ id: 1, title: 'Fix bug' }],
             pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'documentation']) },
             waitForMilliseconds: fake.resolves(undefined),
-            labelLookupIntervalMilliseconds: 0
+            labelLookupIntervalMilliseconds: 0,
+            targetName: undefined,
+            targetScopedLabelPattern: undefined
         }),
         {
             message:
                 'Pull Request #1 has multiple labels of breaking, bug, feature, enhancement, documentation, upgrade, refactor, build'
         }
     );
+});
+
+test('ignores scoped labels for other targets', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [{ id: 1, title: 'Fix bug' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: 'pkg-b',
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'bug' }]);
+});
+
+test('rejects conflicting target scoped labels', async () => {
+    await assert.rejects(
+        resolvePullRequestLabels({
+            githubRepo: 'owner/repo',
+            validLabels: defaultValidLabels,
+            pullRequests: [{ id: 1, title: 'Fix bug' }],
+            pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking', 'pkg-a:feature']) },
+            waitForMilliseconds: fake.resolves(undefined),
+            labelLookupIntervalMilliseconds: 0,
+            targetName: 'pkg-a',
+            targetScopedLabelPattern: undefined
+        }),
+        { message: 'Pull Request #1 has multiple scoped labels for "pkg-a"' }
+    );
+});
+
+test('rejects unknown target scoped labels', async () => {
+    await assert.rejects(
+        resolvePullRequestLabels({
+            githubRepo: 'owner/repo',
+            validLabels: defaultValidLabels,
+            pullRequests: [{ id: 1, title: 'Fix bug' }],
+            pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:not-real']) },
+            waitForMilliseconds: fake.resolves(undefined),
+            labelLookupIntervalMilliseconds: 0,
+            targetName: 'pkg-a',
+            targetScopedLabelPattern: undefined
+        }),
+        { message: 'Pull Request #1 has unknown label "pkg-a:not-real"' }
+    );
+});
+
+test('supports scoped package names in target labels', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        pullRequests: [{ id: 1, title: 'Fix bug' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['bug', '@scope/pkg:documentation']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: '@scope/pkg',
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'documentation' }]);
 });

--- a/source/lib/resolve-pull-request-labels.ts
+++ b/source/lib/resolve-pull-request-labels.ts
@@ -15,7 +15,11 @@ export type ResolvePullRequestLabelsInput = {
     readonly pullRequestLabelReader: PullRequestLabelReader;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
     readonly labelLookupIntervalMilliseconds: number;
+    readonly targetName: string | undefined;
+    readonly targetScopedLabelPattern: string | undefined;
 };
+
+const defaultTargetScopedLabelPattern = '{targetName}:{label}';
 
 function formatLabelList(validLabels: ReadonlyMap<string, string>): string {
     return Array.from(validLabels.keys()).join(', ');
@@ -44,6 +48,73 @@ function resolvePullRequestLevelLabel(
     return label;
 }
 
+function escapeRegExp(value: string): string {
+    return value.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}
+
+function createTargetScopedLabelRegExp(targetName: string, pattern: string): Readonly<RegExp> {
+    const escapedPattern = escapeRegExp(pattern);
+    const source = escapedPattern
+        .replaceAll(escapeRegExp('{targetName}'), escapeRegExp(targetName))
+        .replaceAll(escapeRegExp('{label}'), '(?<label>.+)');
+
+    return new RegExp(`^${source}$`, 'u');
+}
+
+function resolveTargetScopedLabel(options: {
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly pullRequestId: number;
+    readonly labels: readonly string[];
+    readonly targetName: string;
+    readonly targetScopedLabelPattern: string;
+}): string | undefined {
+    const { validLabels, pullRequestId, labels, targetName, targetScopedLabelPattern } = options;
+    const targetScopedLabelRegExp = createTargetScopedLabelRegExp(targetName, targetScopedLabelPattern);
+    const targetScopedLabels = labels.flatMap((label) => {
+        const match = targetScopedLabelRegExp.exec(label);
+        const targetLabel = match?.groups?.label;
+
+        if (targetLabel === undefined) {
+            return [];
+        }
+
+        if (!validLabels.has(targetLabel)) {
+            throw new TypeError(`Pull Request #${pullRequestId} has unknown label "${label}"`);
+        }
+
+        return [targetLabel];
+    });
+    const [targetScopedLabel] = targetScopedLabels;
+
+    if (targetScopedLabels.length > 1) {
+        throw new Error(`Pull Request #${pullRequestId} has multiple scoped labels for "${targetName}"`);
+    }
+
+    return targetScopedLabel;
+}
+
+function resolveLabel(
+    input: ResolvePullRequestLabelsInput,
+    pullRequest: PullRequest,
+    labels: readonly string[]
+): string {
+    const pullRequestLevelLabel = resolvePullRequestLevelLabel(input.validLabels, pullRequest.id, labels);
+
+    if (input.targetName === undefined) {
+        return pullRequestLevelLabel;
+    }
+
+    return (
+        resolveTargetScopedLabel({
+            validLabels: input.validLabels,
+            pullRequestId: pullRequest.id,
+            labels,
+            targetName: input.targetName,
+            targetScopedLabelPattern: input.targetScopedLabelPattern ?? defaultTargetScopedLabelPattern
+        }) ?? pullRequestLevelLabel
+    );
+}
+
 export async function resolvePullRequestLabels(
     input: ResolvePullRequestLabelsInput
 ): Promise<readonly PullRequestWithLabel[]> {
@@ -55,7 +126,7 @@ export async function resolvePullRequestLabels(
         }
 
         const labels = await input.pullRequestLabelReader.getLabels(input.githubRepo, pullRequest.id);
-        const label = resolvePullRequestLevelLabel(input.validLabels, pullRequest.id, labels);
+        const label = resolveLabel(input, pullRequest, labels);
 
         pullRequestsWithLabels.push({
             id: pullRequest.id,


### PR DESCRIPTION
Stacked on #540. Adds target-aware label resolution so labels such as `pkg-a:breaking` can override a PR-level category for one target while keeping existing validation strict.