### PR TITLE
Add target file attribution helper

### DIFF
--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -6,6 +6,7 @@ import {
     createGitHubPullRequestLabelReader,
     defaultValidLabels as exportedDefaultValidLabels,
     fetchPullRequestChangedFiles,
+    filterPullRequestsByTargetFiles,
     formatPackageVersionTag,
     getPullRequestLabels,
     renderChangelogMarkdown,
@@ -100,6 +101,21 @@ test('exports changed file collection', async () => {
     });
 
     assert.deepStrictEqual(Array.from(changedFilesByPullRequest.entries()), [[pullRequestId, ['source/index.ts']]]);
+});
+
+test('exports target file filtering', () => {
+    const changedFilesByPullRequest = new Map([[pullRequestId, ['source/index.ts']]]);
+
+    assert.deepStrictEqual(
+        filterPullRequestsByTargetFiles({
+            targetName: 'pkg',
+            targetSourceFiles: ['source/index.ts'],
+            pullRequests,
+            changedFilesByPullRequest,
+            ignoredAttributionPaths: []
+        }),
+        pullRequests
+    );
 });
 
 test('exports changelog rendering', () => {

--- a/source/index.ts
+++ b/source/index.ts
@@ -24,6 +24,10 @@ import {
     type GitHubPullRequestLabelReaderDependencies as GitHubPullRequestLabelReaderDependenciesValue
 } from './lib/get-pull-request-label.ts';
 import {
+    filterPullRequestsByTargetFiles as filterPullRequestsByTargetFilesValue,
+    type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue
+} from './lib/filter-pull-requests-by-target-files.ts';
+import {
     fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
     type FetchPullRequestChangedFilesInput as FetchPullRequestChangedFilesInputValue,
     type PullRequestChangedFilesReader as PullRequestChangedFilesReaderValue
@@ -66,6 +70,13 @@ export async function fetchPullRequestChangedFiles(
 ): Promise<ReadonlyMap<number, readonly string[]>> {
     const changedFiles = await fetchPullRequestChangedFilesValue(input);
     return changedFiles;
+}
+
+export function filterPullRequestsByTargetFiles(
+    input: FilterPullRequestsByTargetFilesInputValue
+): readonly PullRequestValue[] {
+    const pullRequests = filterPullRequestsByTargetFilesValue(input);
+    return pullRequests;
 }
 
 export function formatPackageVersionTag(options: {
@@ -116,6 +127,7 @@ export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue
 export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultValidLabelsValue);
 export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
 export type FirstParentCommitLogEntry = FirstParentCommitLogEntryValue;
+export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
 export type GitRangeReader = GitRangeReaderValue;
 export type GitRefReader = GitRefReaderValue;
 export type GitHubPullRequestLabelReaderDependencies = GitHubPullRequestLabelReaderDependenciesValue;

--- a/source/lib/filter-pull-requests-by-target-files.test.ts
+++ b/source/lib/filter-pull-requests-by-target-files.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert';
+import { filterPullRequestsByTargetFiles } from './filter-pull-requests-by-target-files.ts';
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+
+const pullRequests: readonly PullRequest[] = [
+    { id: 1, title: 'Fix target' },
+    { id: 2, title: 'Fix unrelated' },
+    { id: 3, title: 'Update changelog' }
+];
+const unrelatedPullRequestId = 2;
+const changelogPullRequestId = 3;
+
+test('keeps pull requests that changed target source files', () => {
+    const changedFilesByPullRequest = new Map<number, readonly string[]>([
+        [1, ['source/index.ts']],
+        [unrelatedPullRequestId, ['test/index.test.ts']]
+    ]);
+
+    const filteredPullRequests = filterPullRequestsByTargetFiles({
+        targetName: 'target',
+        targetSourceFiles: ['source/index.ts'],
+        pullRequests,
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: []
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [{ id: 1, title: 'Fix target' }]);
+});
+
+test('normalizes repository paths before matching target files', () => {
+    const changedFilesByPullRequest = new Map<number, readonly string[]>([[1, ['.\\source\\index.ts']]]);
+
+    const filteredPullRequests = filterPullRequestsByTargetFiles({
+        targetName: 'target',
+        targetSourceFiles: ['./source/index.ts'],
+        pullRequests: [{ id: 1, title: 'Fix target' }],
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: []
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [{ id: 1, title: 'Fix target' }]);
+});
+
+test('ignores supplied attribution paths', () => {
+    const changedFilesByPullRequest = new Map<number, readonly string[]>([
+        [1, ['source/index.ts']],
+        [changelogPullRequestId, ['CHANGELOG.md']]
+    ]);
+
+    const filteredPullRequests = filterPullRequestsByTargetFiles({
+        targetName: 'target',
+        targetSourceFiles: ['source/index.ts', 'CHANGELOG.md'],
+        pullRequests,
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: ['CHANGELOG.md']
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [{ id: 1, title: 'Fix target' }]);
+});

--- a/source/lib/filter-pull-requests-by-target-files.ts
+++ b/source/lib/filter-pull-requests-by-target-files.ts
@@ -1,0 +1,42 @@
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+
+export type FilterPullRequestsByTargetFilesInput = {
+    readonly targetName: string;
+    readonly targetSourceFiles: readonly string[];
+    readonly pullRequests: readonly PullRequest[];
+    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly string[]>;
+    readonly ignoredAttributionPaths: readonly string[];
+};
+
+function normalizeRepositoryPath(filePath: string): string {
+    return filePath.replaceAll('\\', '/').replace(/^\.?\//u, '');
+}
+
+function createNormalizedPathSet(paths: readonly string[]): ReadonlySet<string> {
+    return new Set(paths.map(normalizeRepositoryPath));
+}
+
+function hasTargetFileChange(options: {
+    readonly changedFiles: readonly string[];
+    readonly targetSourceFiles: ReadonlySet<string>;
+    readonly ignoredAttributionPaths: ReadonlySet<string>;
+}): boolean {
+    const { changedFiles, targetSourceFiles, ignoredAttributionPaths } = options;
+
+    return changedFiles.some((changedFile) => {
+        const normalizedChangedFile = normalizeRepositoryPath(changedFile);
+
+        return targetSourceFiles.has(normalizedChangedFile) && !ignoredAttributionPaths.has(normalizedChangedFile);
+    });
+}
+
+export function filterPullRequestsByTargetFiles(input: FilterPullRequestsByTargetFilesInput): readonly PullRequest[] {
+    const targetSourceFiles = createNormalizedPathSet(input.targetSourceFiles);
+    const ignoredAttributionPaths = createNormalizedPathSet(input.ignoredAttributionPaths);
+
+    return input.pullRequests.filter((pullRequest) => {
+        const changedFiles = input.changedFilesByPullRequest.get(pullRequest.id) ?? [];
+
+        return hasTargetFileChange({ changedFiles, targetSourceFiles, ignoredAttributionPaths });
+    });
+}


### PR DESCRIPTION
Stacked on #541. Adds a core helper that filters pull requests by intersecting changed files with caller-provided target source files.