### PR TITLE
Add target Markdown rendering

### DIFF
--- a/source/index.test.ts
+++ b/source/index.test.ts
@@ -9,13 +9,16 @@ import {
     filterPullRequestsByTargetFiles,
     formatPackageVersionTag,
     getPullRequestLabels,
+    renderGroupedTargetChangelogMarkdown,
     renderChangelogMarkdown,
+    renderTargetChangelogMarkdown,
     resolveChangelogBaseRef,
     resolveLatestSemverTagBaseRef,
     resolvePullRequestLabels,
     type GitHubPullRequestLabelReaderDependencies,
     type PullRequest,
-    type ReleasePlanPackage
+    type ReleasePlanPackage,
+    type TargetChangelogSection
 } from './index.ts';
 import { defaultValidLabels } from './lib/valid-labels.ts';
 
@@ -130,6 +133,37 @@ test('exports changelog rendering', () => {
     });
 
     assert.ok(changelog.includes('## 1.0.0'));
+
+    const targetChangelog = renderTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targetName: 'pkg-a',
+        mergedPullRequests: [{ id: pullRequestId, title: 'title', label: 'bug' }],
+        githubRepo: 'owner/repo',
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(targetChangelog.includes('### Bug Fixes'));
+
+    const groupedChangelog = renderGroupedTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            {
+                targetName: 'pkg-a',
+                unreleased: false,
+                versionNumber: '1.0.0',
+                mergedPullRequests: [{ id: pullRequestId, title: 'title', label: 'bug' }]
+            }
+        ],
+        githubRepo: 'owner/repo'
+    });
+
+    assert.ok(groupedChangelog.includes('## pkg-a 1.0.0'));
+    assert.ok(groupedChangelog.includes('### Bug Fixes'));
 });
 
 test('exports the release plan package type', () => {
@@ -149,4 +183,15 @@ test('exports the release plan package type', () => {
 
 test('exports default valid labels', () => {
     assert.strictEqual(exportedDefaultValidLabels.get('bug'), 'Bug Fixes');
+});
+
+test('exports the target changelog section type', () => {
+    const targetChangelogSection: TargetChangelogSection = {
+        targetName: 'pkg',
+        unreleased: false,
+        versionNumber: '1.0.0',
+        mergedPullRequests: [{ id: pullRequestId, title: 'title', label: 'bug' }]
+    };
+
+    assert.strictEqual(targetChangelogSection.versionNumber, '1.0.0');
 });

--- a/source/index.ts
+++ b/source/index.ts
@@ -39,8 +39,13 @@ import {
     type ResolvePullRequestLabelsInput as ResolvePullRequestLabelsInputValue
 } from './lib/resolve-pull-request-labels.ts';
 import {
+    renderGroupedTargetChangelogMarkdown as renderGroupedTargetChangelogMarkdownValue,
     renderChangelogMarkdown as renderChangelogMarkdownValue,
-    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue
+    renderTargetChangelogMarkdown as renderTargetChangelogMarkdownValue,
+    type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
+    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
+    type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
+    type TargetChangelogSection as TargetChangelogSectionValue
 } from './lib/render-changelog-markdown.ts';
 import { defaultValidLabels as defaultValidLabelsValue } from './lib/valid-labels.ts';
 
@@ -90,6 +95,16 @@ export function formatPackageVersionTag(options: {
 
 export function renderChangelogMarkdown(input: RenderChangelogMarkdownInputValue): string {
     const changelog = renderChangelogMarkdownValue(input);
+    return changelog;
+}
+
+export function renderGroupedTargetChangelogMarkdown(input: RenderGroupedTargetChangelogMarkdownInputValue): string {
+    const changelog = renderGroupedTargetChangelogMarkdownValue(input);
+    return changelog;
+}
+
+export function renderTargetChangelogMarkdown(input: RenderTargetChangelogMarkdownInputValue): string {
+    const changelog = renderTargetChangelogMarkdownValue(input);
     return changelog;
 }
 
@@ -151,4 +166,7 @@ export type ReleasePlanPackage = {
     readonly changedArtifactFiles: readonly string[];
 };
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
+export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
+export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
 export type ResolvePullRequestLabelsInput = ResolvePullRequestLabelsInputValue;
+export type TargetChangelogSection = TargetChangelogSectionValue;

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -37,6 +37,8 @@ export type CreateChangelog = (options: ChangelogOptions) => string;
 
 type PackageInfo = Record<string, unknown>;
 
+const defaultDateFormat = 'MMMM d, yyyy';
+
 function getConfigValueFromPackageInfo(packageInfo: PackageInfo, fieldName: string, fallback: string): string {
     const prLogConfig = packageInfo['pr-log'];
 
@@ -48,6 +50,11 @@ function getConfigValueFromPackageInfo(packageInfo: PackageInfo, fieldName: stri
     }
 
     return fallback;
+}
+
+export function formatChangelogDate(packageInfo: PackageInfo, date: Readonly<Date>): string {
+    const dateFormat = getConfigValueFromPackageInfo(packageInfo, 'dateFormat', defaultDateFormat);
+    return formatDate(date, dateFormat, { locale: enLocale });
 }
 
 type CollapseRule = {
@@ -348,11 +355,8 @@ type ChangelogOptionsReleased = {
 
 export type ChangelogOptions = ChangelogOptionsReleased | ChangelogOptionsUnreleased;
 
-const defaultDateFormat = 'MMMM d, yyyy';
-
 export function createChangelogFactory(dependencies: Dependencies): CreateChangelog {
     const { getCurrentDate, packageInfo } = dependencies;
-    const dateFormat = getConfigValueFromPackageInfo(packageInfo, 'dateFormat', defaultDateFormat);
     const collapseRules = getCollapseRules(packageInfo);
 
     function createChangelogTitle(options: ChangelogOptions): string {
@@ -362,7 +366,7 @@ export function createChangelogFactory(dependencies: Dependencies): CreateChange
             return '';
         }
 
-        const date = formatDate(getCurrentDate(), dateFormat, { locale: enLocale });
+        const date = formatChangelogDate(packageInfo, getCurrentDate());
         const title = `## ${options.versionNumber.value} (${date})`;
 
         return `${title}\n\n`;

--- a/source/lib/render-changelog-markdown.test.ts
+++ b/source/lib/render-changelog-markdown.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert';
-import { renderChangelogMarkdown } from './render-changelog-markdown.ts';
+import {
+    renderChangelogMarkdown,
+    renderGroupedTargetChangelogMarkdown,
+    renderTargetChangelogMarkdown
+} from './render-changelog-markdown.ts';
 import { defaultValidLabels } from './valid-labels.ts';
 
 test('renders released changelog markdown', () => {
@@ -30,4 +34,88 @@ test('renders unreleased changelog markdown without a title', () => {
 
     assert.ok(!changelog.startsWith('## '));
     assert.ok(changelog.includes('* Fix bug ([#1](https://github.com/owner/repo/pull/1))'));
+});
+
+test('renders target changelog markdown', () => {
+    const changelog = renderTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targetName: 'pkg-a',
+        mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }],
+        githubRepo: 'owner/repo',
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(changelog.includes('### Bug Fixes'));
+    assert.ok(changelog.includes('* Fix bug ([#1](https://github.com/owner/repo/pull/1))'));
+});
+
+test('renders grouped target changelog markdown', () => {
+    const changelog = renderGroupedTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            {
+                targetName: 'pkg-a',
+                unreleased: false,
+                versionNumber: '1.2.3',
+                mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }]
+            },
+            {
+                targetName: 'pkg-b',
+                unreleased: false,
+                versionNumber: '2.0.0',
+                mergedPullRequests: [{ id: 2, title: 'Add feature', label: 'feature' }]
+            }
+        ],
+        githubRepo: 'owner/repo'
+    });
+
+    assert.ok(changelog.includes('## pkg-a 1.2.3 (January 1, 1970)'));
+    assert.ok(changelog.includes('### Bug Fixes'));
+    assert.ok(changelog.includes('## pkg-b 2.0.0 (January 1, 1970)'));
+    assert.ok(changelog.includes('### Features'));
+});
+
+test('does not render empty target sections', () => {
+    const changelog = renderGroupedTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            { targetName: 'pkg-a', unreleased: true, versionNumber: undefined, mergedPullRequests: [] },
+            {
+                targetName: 'pkg-b',
+                unreleased: true,
+                versionNumber: undefined,
+                mergedPullRequests: [{ id: 2, title: 'Add feature', label: 'feature' }]
+            }
+        ],
+        githubRepo: 'owner/repo'
+    });
+
+    assert.ok(!changelog.includes('## pkg-a'));
+    assert.ok(changelog.includes('## pkg-b'));
+});
+
+test('renders grouped target changelog markdown with custom date formatting', () => {
+    const changelog = renderGroupedTargetChangelogMarkdown({
+        packageInfo: { 'pr-log': { dateFormat: 'dd.MM.yyyy' } },
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            {
+                targetName: 'pkg-a',
+                unreleased: false,
+                versionNumber: '1.2.3',
+                mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }]
+            }
+        ],
+        githubRepo: 'owner/repo'
+    });
+
+    assert.ok(changelog.includes('## pkg-a 1.2.3 (01.01.1970)'));
 });

--- a/source/lib/render-changelog-markdown.ts
+++ b/source/lib/render-changelog-markdown.ts
@@ -1,5 +1,5 @@
 import Maybe, { type Just } from 'true-myth/maybe';
-import { createChangelogFactory } from './create-changelog.ts';
+import { createChangelogFactory, formatChangelogDate } from './create-changelog.ts';
 import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
 
 type RenderChangelogMarkdownInputBase = {
@@ -23,6 +23,33 @@ type RenderUnreleasedChangelogMarkdownInput = RenderChangelogMarkdownInputBase &
 export type RenderChangelogMarkdownInput =
     | RenderReleasedChangelogMarkdownInput
     | RenderUnreleasedChangelogMarkdownInput;
+
+type TargetChangelogSectionBase = {
+    readonly targetName: string;
+    readonly mergedPullRequests: readonly PullRequestWithLabel[];
+};
+
+type ReleasedTargetChangelogSection = TargetChangelogSectionBase & {
+    readonly unreleased: false;
+    readonly versionNumber: string;
+};
+
+type UnreleasedTargetChangelogSection = TargetChangelogSectionBase & {
+    readonly unreleased: true;
+    readonly versionNumber: undefined;
+};
+
+export type TargetChangelogSection = ReleasedTargetChangelogSection | UnreleasedTargetChangelogSection;
+
+export type RenderGroupedTargetChangelogMarkdownInput = {
+    readonly packageInfo: Record<string, unknown>;
+    readonly currentDate: Readonly<Date>;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly githubRepo: string;
+    readonly targets: readonly TargetChangelogSection[];
+};
+
+export type RenderTargetChangelogMarkdownInput = RenderChangelogMarkdownInputBase & TargetChangelogSection;
 
 export function renderChangelogMarkdown(input: RenderChangelogMarkdownInput): string {
     const createChangelog = createChangelogFactory({
@@ -49,4 +76,47 @@ export function renderChangelogMarkdown(input: RenderChangelogMarkdownInput): st
         unreleased: false,
         versionNumber: Maybe.just(input.versionNumber) as Just<string>
     });
+}
+
+export const renderTargetChangelogMarkdown: (input: RenderTargetChangelogMarkdownInput) => string =
+    renderChangelogMarkdown;
+
+function renderTargetSectionTitle(
+    input: RenderGroupedTargetChangelogMarkdownInput,
+    target: TargetChangelogSection
+): string {
+    if (target.unreleased) {
+        return `## ${target.targetName}`;
+    }
+
+    const date = formatChangelogDate(input.packageInfo, input.currentDate);
+    return `## ${target.targetName} ${target.versionNumber} (${date})`;
+}
+
+function renderTargetSection(input: RenderGroupedTargetChangelogMarkdownInput, target: TargetChangelogSection): string {
+    if (target.mergedPullRequests.length === 0) {
+        return '';
+    }
+
+    const targetBody = renderChangelogMarkdown({
+        packageInfo: input.packageInfo,
+        currentDate: input.currentDate,
+        validLabels: input.validLabels,
+        mergedPullRequests: target.mergedPullRequests,
+        githubRepo: input.githubRepo,
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    return `${renderTargetSectionTitle(input, target)}\n\n${targetBody}`;
+}
+
+export function renderGroupedTargetChangelogMarkdown(input: RenderGroupedTargetChangelogMarkdownInput): string {
+    const sections = input.targets
+        .map((target) => {
+            return renderTargetSection(input, target);
+        })
+        .join('');
+
+    return sections;
 }


### PR DESCRIPTION
Stacked on #542. Adds target-only rendering for separate destinations and grouped target Markdown where each target carries its own release state.