### PR TITLE
Fetch raw pull request labels

### DIFF
--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -15,6 +15,8 @@ function createEngine(
         readonly gitCommandRunner?: GitCommandRunner;
         readonly githubClient?: Octokit;
         readonly pullRequestChangedFilesReader?: PullRequestChangedFilesReader;
+        readonly waitForMilliseconds?: (durationMilliseconds: number) => Promise<void>;
+        readonly labelLookupIntervalMilliseconds?: number;
     } = {}
 ): ReturnType<typeof createPrLogEngineWithDependencies> {
     const gitCommandRunner =
@@ -43,10 +45,10 @@ function createEngine(
         gitCommandRunner,
         githubClient,
         pullRequestChangedFilesReader,
-        getPullRequestLabel: fake.resolves('bug'),
-        waitForMilliseconds: fake.resolves(undefined),
+        getPullRequestLabels: fake.resolves(['bug']),
+        waitForMilliseconds: overrides.waitForMilliseconds ?? fake.resolves(undefined),
         getCurrentDate: fake.returns(new Date(0)),
-        labelLookupIntervalMilliseconds: waitDurationMilliseconds,
+        labelLookupIntervalMilliseconds: overrides.labelLookupIntervalMilliseconds ?? waitDurationMilliseconds,
         maximumRateLimitRetryCount: 0
     });
 }
@@ -128,6 +130,33 @@ test('reads pull request changed files', async () => {
         }),
         new Map([[pullRequestId, ['source/index.ts']]])
     );
+});
+
+test('reads pull request labels', async () => {
+    const engine = createEngine();
+
+    assert.deepStrictEqual(
+        await engine.readPullRequestLabels({
+            githubRepo,
+            pullRequests: [{ id: pullRequestId, title: 'Fix bug' }]
+        }),
+        new Map([[pullRequestId, ['bug']]])
+    );
+});
+
+test('waits between raw pull request label reads', async () => {
+    const waitForMilliseconds = fake.resolves(undefined);
+    const engine = createEngine({ waitForMilliseconds, labelLookupIntervalMilliseconds: waitDurationMilliseconds });
+
+    await engine.readPullRequestLabels({
+        githubRepo,
+        pullRequests: [
+            { id: pullRequestId, title: 'Fix bug' },
+            { id: 2, title: 'Add feature' }
+        ]
+    });
+
+    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [waitDurationMilliseconds]);
 });
 
 test('resolves pull request labels', async () => {

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -13,7 +13,7 @@ import {
     type PullRequestTitleReader
 } from '../lib/collect-merged-pull-requests.ts';
 import type { GitCommandRunner } from '../lib/git-command-runner.ts';
-import type { GetPullRequestLabel } from '../lib/get-pull-request-label.ts';
+import type { GetPullRequestLabels } from '../lib/get-pull-request-label.ts';
 import {
     fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
     type PullRequestChangedFilesReader
@@ -37,6 +37,11 @@ export type ReadPullRequestChangedFilesOptions = {
     readonly pullRequests: readonly PullRequestValue[];
 };
 
+export type ReadPullRequestLabelsOptions = {
+    readonly githubRepo: string;
+    readonly pullRequests: readonly PullRequestValue[];
+};
+
 export type ResolvePullRequestLabelsOptions = {
     readonly githubRepo: string;
     readonly validLabels: ReadonlyMap<string, string>;
@@ -50,6 +55,7 @@ export type PrLogEngine = {
     readPullRequestChangedFiles(
         input: ReadPullRequestChangedFilesOptions
     ): Promise<ReadonlyMap<number, readonly string[]>>;
+    readPullRequestLabels(input: ReadPullRequestLabelsOptions): Promise<ReadonlyMap<number, readonly string[]>>;
     resolvePullRequestLabels(input: ResolvePullRequestLabelsOptions): Promise<readonly PullRequestWithLabelValue[]>;
     renderChangelog(input: RenderChangelogMarkdownInputValue): string;
 };
@@ -60,7 +66,7 @@ export type PrLogEngineDependencies = {
     readonly gitCommandRunner: GitCommandRunner;
     readonly githubClient: Octokit;
     readonly pullRequestChangedFilesReader: PullRequestChangedFilesReader;
-    readonly getPullRequestLabel: GetPullRequestLabel;
+    readonly getPullRequestLabels: GetPullRequestLabels;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
     readonly getCurrentDate: () => Readonly<Date>;
     readonly labelLookupIntervalMilliseconds: number;
@@ -104,16 +110,34 @@ type EnginePullRequestLabelReader = {
     getLabels(githubRepo: string, pullRequestId: number): Promise<readonly string[]>;
 };
 
-function createPullRequestLabelReader(
-    dependencies: PrLogEngineDependencies,
-    validLabels: ReadonlyMap<string, string>
-): EnginePullRequestLabelReader {
+function createPullRequestLabelReader(dependencies: PrLogEngineDependencies): EnginePullRequestLabelReader {
     return {
         async getLabels(githubRepo: string, pullRequestId: number) {
-            const label = await dependencies.getPullRequestLabel(githubRepo, validLabels, pullRequestId, dependencies);
-            return [label];
+            const labels = await dependencies.getPullRequestLabels(githubRepo, pullRequestId, dependencies);
+            return labels;
         }
     };
+}
+
+async function waitBetweenLabelReads(dependencies: PrLogEngineDependencies, pullRequestIndex: number): Promise<void> {
+    if (pullRequestIndex > 0 && dependencies.labelLookupIntervalMilliseconds > 0) {
+        await dependencies.waitForMilliseconds(dependencies.labelLookupIntervalMilliseconds);
+    }
+}
+
+async function readPullRequestLabels(
+    dependencies: PrLogEngineDependencies,
+    input: ReadPullRequestLabelsOptions
+): Promise<ReadonlyMap<number, readonly string[]>> {
+    const pullRequestLabels = new Map<number, readonly string[]>();
+    const pullRequestLabelReader = createPullRequestLabelReader(dependencies);
+
+    for (const [pullRequestIndex, pullRequest] of input.pullRequests.entries()) {
+        await waitBetweenLabelReads(dependencies, pullRequestIndex);
+        pullRequestLabels.set(pullRequest.id, await pullRequestLabelReader.getLabels(input.githubRepo, pullRequest.id));
+    }
+
+    return pullRequestLabels;
 }
 
 export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDependencies): PrLogEngine {
@@ -147,12 +171,16 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
             });
         },
 
+        async readPullRequestLabels(input) {
+            return readPullRequestLabels(dependencies, input);
+        },
+
         async resolvePullRequestLabels(input) {
             return resolvePullRequestLabelsValue({
                 githubRepo: input.githubRepo,
                 validLabels: input.validLabels,
                 pullRequests: input.pullRequests,
-                pullRequestLabelReader: createPullRequestLabelReader(dependencies, input.validLabels),
+                pullRequestLabelReader: createPullRequestLabelReader(dependencies),
                 waitForMilliseconds: dependencies.waitForMilliseconds,
                 labelLookupIntervalMilliseconds: dependencies.labelLookupIntervalMilliseconds,
                 targetName: undefined,

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -3,7 +3,7 @@ import { Octokit } from '@octokit/rest';
 import { execaCommand } from 'execa';
 import { createGitHubPullRequestChangedFilesReader } from '../../lib/github-pull-request-changed-files.ts';
 import { createGitCommandRunner, type GitCommandExecutor } from '../../lib/git-command-runner.ts';
-import { getPullRequestLabel } from '../../lib/get-pull-request-label.ts';
+import { getPullRequestLabels } from '../../lib/get-pull-request-label.ts';
 import { defaultValidLabels as defaultValidLabelsValue } from '../../lib/valid-labels.ts';
 import {
     createPrLogEngineWithDependencies,
@@ -14,6 +14,7 @@ import {
     type PullRequest as PullRequestValue,
     type PullRequestWithLabel as PullRequestWithLabelValue,
     type ReadPullRequestChangedFilesOptions as ReadPullRequestChangedFilesOptionsValue,
+    type ReadPullRequestLabelsOptions as ReadPullRequestLabelsOptionsValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
     type ResolvePullRequestLabelsOptions as ResolvePullRequestLabelsOptionsValue
 } from '../../core/pr-log-engine.ts';
@@ -44,7 +45,7 @@ export function createPrLogEngine(options: Readonly<PrLogEngineOptions>): PrLogE
         githubClient,
         gitCommandRunner,
         pullRequestChangedFilesReader: createGitHubPullRequestChangedFilesReader(githubClient),
-        getPullRequestLabel,
+        getPullRequestLabels,
         waitForMilliseconds: waitForTimeout,
         getCurrentDate: createCurrentDate,
         labelLookupIntervalMilliseconds: options.labelLookupIntervalMilliseconds,
@@ -61,5 +62,6 @@ export type PrLogEngine = PrLogEngineValue;
 export type PullRequest = PullRequestValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;
 export type ReadPullRequestChangedFilesOptions = ReadPullRequestChangedFilesOptionsValue;
+export type ReadPullRequestLabelsOptions = ReadPullRequestLabelsOptionsValue;
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
 export type ResolvePullRequestLabelsOptions = ResolvePullRequestLabelsOptionsValue;


### PR DESCRIPTION
Adds raw pull request label reads to the core engine so later target-aware resolution can inspect all labels. Existing changelog label resolution remains unchanged for non-target usage.