### PR TITLE
Add `createPrLogEngine()` API

### DIFF
--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert';
+import type { Octokit } from '@octokit/rest';
+import { fake } from 'sinon';
+import { defaultValidLabels } from '../lib/valid-labels.ts';
+import type { GitCommandRunner } from '../lib/git-command-runner.ts';
+import type { PullRequestChangedFilesReader } from '../lib/pull-request-changed-files.ts';
+import { createPrLogEngineWithDependencies } from './pr-log-engine.ts';
+
+const githubRepo = 'owner/repo';
+const pullRequestId = 1;
+const waitDurationMilliseconds = 25;
+
+function createEngine(
+    overrides: {
+        readonly gitCommandRunner?: GitCommandRunner;
+        readonly githubClient?: Octokit;
+        readonly pullRequestChangedFilesReader?: PullRequestChangedFilesReader;
+    } = {}
+): ReturnType<typeof createPrLogEngineWithDependencies> {
+    const gitCommandRunner =
+        overrides.gitCommandRunner ??
+        ({
+            listTags: fake.resolves(['1.0.0']),
+            hasRef: fake.resolves(true),
+            getFirstParentCommitLogs: fake.resolves([
+                { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: 'Fix bug' }
+            ])
+        } as unknown as GitCommandRunner);
+    const githubClient =
+        overrides.githubClient ??
+        ({
+            pulls: {
+                get: fake.resolves({ data: { title: 'GitHub title' } })
+            }
+        } as unknown as Octokit);
+    const pullRequestChangedFilesReader =
+        overrides.pullRequestChangedFilesReader ??
+        ({
+            getChangedFiles: fake.resolves(['source/index.ts'])
+        } satisfies PullRequestChangedFilesReader);
+
+    return createPrLogEngineWithDependencies({
+        gitCommandRunner,
+        githubClient,
+        pullRequestChangedFilesReader,
+        getPullRequestLabel: fake.resolves('bug'),
+        waitForMilliseconds: fake.resolves(undefined),
+        getCurrentDate: fake.returns(new Date(0)),
+        labelLookupIntervalMilliseconds: waitDurationMilliseconds,
+        maximumRateLimitRetryCount: 0
+    });
+}
+
+test('resolves the latest semver changelog base ref', async () => {
+    const engine = createEngine();
+
+    assert.deepStrictEqual(await engine.resolveLatestSemverChangelogBaseRef(), { ref: '1.0.0' });
+});
+
+test('resolves package changelog base refs', async () => {
+    const engine = createEngine();
+
+    assert.deepStrictEqual(
+        await engine.resolveChangelogBaseRef({
+            packageName: 'pkg',
+            previousVersion: undefined,
+            previousGitHead: 'abc123',
+            packageTagFormat: undefined,
+            explicitBaseRef: undefined
+        }),
+        { ref: 'abc123' }
+    );
+});
+
+test('collects merged pull requests', async () => {
+    const engine = createEngine();
+
+    assert.deepStrictEqual(await engine.collectMergedPullRequests({ githubRepo, baseRef: '1.0.0' }), [
+        { id: pullRequestId, title: 'Fix bug' }
+    ]);
+});
+
+test('reads fallback pull request titles from github', async () => {
+    const getPullRequest = fake.resolves({ data: { title: 'GitHub title' } });
+    const githubClient = {
+        pulls: {
+            get: getPullRequest
+        }
+    } as unknown as Octokit;
+    const engine = createEngine({
+        githubClient,
+        gitCommandRunner: {
+            getFirstParentCommitLogs: fake.resolves([
+                { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: undefined }
+            ])
+        } as unknown as GitCommandRunner
+    });
+
+    assert.deepStrictEqual(await engine.collectMergedPullRequests({ githubRepo, baseRef: '1.0.0' }), [
+        { id: pullRequestId, title: 'GitHub title' }
+    ]);
+    assert.deepStrictEqual(getPullRequest.firstCall.args, [
+        { owner: 'owner', repo: 'repo', pull_number: pullRequestId }
+    ]);
+});
+
+test('rejects fallback pull request titles without repo details', async () => {
+    const engine = createEngine({
+        gitCommandRunner: {
+            getFirstParentCommitLogs: fake.resolves([
+                { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: undefined }
+            ])
+        } as unknown as GitCommandRunner
+    });
+
+    await assert.rejects(engine.collectMergedPullRequests({ githubRepo: 'repo', baseRef: '1.0.0' }), {
+        message: 'Could not find a repository'
+    });
+});
+
+test('reads pull request changed files', async () => {
+    const engine = createEngine();
+
+    assert.deepStrictEqual(
+        await engine.readPullRequestChangedFiles({
+            githubRepo,
+            pullRequests: [{ id: pullRequestId, title: 'Fix bug' }]
+        }),
+        new Map([[pullRequestId, ['source/index.ts']]])
+    );
+});
+
+test('resolves pull request labels', async () => {
+    const engine = createEngine();
+
+    assert.deepStrictEqual(
+        await engine.resolvePullRequestLabels({
+            githubRepo,
+            validLabels: defaultValidLabels,
+            pullRequests: [{ id: pullRequestId, title: 'Fix bug' }]
+        }),
+        [{ id: pullRequestId, title: 'Fix bug', label: 'bug' }]
+    );
+});
+
+test('renders changelog markdown', () => {
+    const engine = createEngine();
+
+    const changelog = engine.renderChangelog({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        mergedPullRequests: [{ id: pullRequestId, title: 'Fix bug', label: 'bug' }],
+        githubRepo,
+        unreleased: false,
+        versionNumber: '1.0.0'
+    });
+
+    assert.ok(changelog.includes('## 1.0.0 (January 1, 1970)'));
+});

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -1,0 +1,171 @@
+import type { Octokit } from '@octokit/rest';
+import { splitByString } from '../lib/split.ts';
+import {
+    resolveChangelogBaseRef as resolveChangelogBaseRefValue,
+    resolveLatestSemverTagBaseRef as resolveLatestSemverTagBaseRefValue,
+    type ChangelogBaseRef as ChangelogBaseRefValue,
+    type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue
+} from '../lib/changelog-base-ref.ts';
+import {
+    collectMergedPullRequests as collectMergedPullRequestsValue,
+    type GitRangeReader,
+    type PullRequest as PullRequestValue,
+    type PullRequestTitleReader
+} from '../lib/collect-merged-pull-requests.ts';
+import type { GitCommandRunner } from '../lib/git-command-runner.ts';
+import type { GetPullRequestLabel } from '../lib/get-pull-request-label.ts';
+import {
+    fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
+    type PullRequestChangedFilesReader
+} from '../lib/pull-request-changed-files.ts';
+import {
+    resolvePullRequestLabels as resolvePullRequestLabelsValue,
+    type PullRequestWithLabel as PullRequestWithLabelValue
+} from '../lib/resolve-pull-request-labels.ts';
+import {
+    renderChangelogMarkdown,
+    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue
+} from '../lib/render-changelog-markdown.ts';
+
+export type CollectMergedPullRequestsOptions = {
+    readonly githubRepo: string;
+    readonly baseRef: string;
+};
+
+export type ReadPullRequestChangedFilesOptions = {
+    readonly githubRepo: string;
+    readonly pullRequests: readonly PullRequestValue[];
+};
+
+export type ResolvePullRequestLabelsOptions = {
+    readonly githubRepo: string;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly pullRequests: readonly PullRequestValue[];
+};
+
+export type PrLogEngine = {
+    resolveLatestSemverChangelogBaseRef(): Promise<ChangelogBaseRefValue>;
+    resolveChangelogBaseRef(input: PackageChangelogBaseRefInputValue): Promise<ChangelogBaseRefValue>;
+    collectMergedPullRequests(input: CollectMergedPullRequestsOptions): Promise<readonly PullRequestValue[]>;
+    readPullRequestChangedFiles(
+        input: ReadPullRequestChangedFilesOptions
+    ): Promise<ReadonlyMap<number, readonly string[]>>;
+    resolvePullRequestLabels(input: ResolvePullRequestLabelsOptions): Promise<readonly PullRequestWithLabelValue[]>;
+    renderChangelog(input: RenderChangelogMarkdownInputValue): string;
+};
+
+type PullRequestData = Readonly<Awaited<ReturnType<Octokit['pulls']['get']>>['data']>;
+
+export type PrLogEngineDependencies = {
+    readonly gitCommandRunner: GitCommandRunner;
+    readonly githubClient: Octokit;
+    readonly pullRequestChangedFilesReader: PullRequestChangedFilesReader;
+    readonly getPullRequestLabel: GetPullRequestLabel;
+    readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
+    readonly getCurrentDate: () => Readonly<Date>;
+    readonly labelLookupIntervalMilliseconds: number;
+    readonly maximumRateLimitRetryCount: number;
+};
+
+function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo: string]> {
+    const [owner, repo] = splitByString(githubRepo, '/');
+
+    if (repo === undefined) {
+        throw new TypeError('Could not find a repository');
+    }
+
+    return [owner, repo];
+}
+
+async function fetchPullRequestTitle(
+    githubClient: Readonly<Octokit>,
+    githubRepo: string,
+    pullRequestId: number
+): Promise<string> {
+    const [owner, repo] = determineRepoDetails(githubRepo);
+    const { data: pullRequest } = await githubClient.pulls.get({
+        owner,
+        repo,
+        pull_number: pullRequestId
+    });
+
+    return (pullRequest as PullRequestData).title;
+}
+
+function createPullRequestTitleReader(githubClient: Readonly<Octokit>): PullRequestTitleReader {
+    return {
+        async getTitle(githubRepo, pullRequestId) {
+            return fetchPullRequestTitle(githubClient, githubRepo, pullRequestId);
+        }
+    };
+}
+
+type EnginePullRequestLabelReader = {
+    getLabels(githubRepo: string, pullRequestId: number): Promise<readonly string[]>;
+};
+
+function createPullRequestLabelReader(
+    dependencies: PrLogEngineDependencies,
+    validLabels: ReadonlyMap<string, string>
+): EnginePullRequestLabelReader {
+    return {
+        async getLabels(githubRepo: string, pullRequestId: number) {
+            const label = await dependencies.getPullRequestLabel(githubRepo, validLabels, pullRequestId, dependencies);
+            return [label];
+        }
+    };
+}
+
+export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDependencies): PrLogEngine {
+    const { gitCommandRunner, githubClient, pullRequestChangedFilesReader } = dependencies;
+    const gitRangeReader: GitRangeReader = gitCommandRunner;
+    const pullRequestTitleReader = createPullRequestTitleReader(githubClient);
+
+    return {
+        async resolveLatestSemverChangelogBaseRef() {
+            return resolveLatestSemverTagBaseRefValue({ tags: await gitCommandRunner.listTags() });
+        },
+
+        async resolveChangelogBaseRef(input) {
+            return resolveChangelogBaseRefValue(input, gitCommandRunner);
+        },
+
+        async collectMergedPullRequests(input) {
+            return collectMergedPullRequestsValue({
+                githubRepo: input.githubRepo,
+                baseRef: input.baseRef,
+                git: gitRangeReader,
+                pullRequestTitleReader
+            });
+        },
+
+        async readPullRequestChangedFiles(input) {
+            return fetchPullRequestChangedFilesValue({
+                githubRepo: input.githubRepo,
+                pullRequests: input.pullRequests,
+                pullRequestChangedFilesReader
+            });
+        },
+
+        async resolvePullRequestLabels(input) {
+            return resolvePullRequestLabelsValue({
+                githubRepo: input.githubRepo,
+                validLabels: input.validLabels,
+                pullRequests: input.pullRequests,
+                pullRequestLabelReader: createPullRequestLabelReader(dependencies, input.validLabels),
+                waitForMilliseconds: dependencies.waitForMilliseconds,
+                labelLookupIntervalMilliseconds: dependencies.labelLookupIntervalMilliseconds,
+                targetName: undefined,
+                targetScopedLabelPattern: undefined
+            });
+        },
+
+        renderChangelog: renderChangelogMarkdown
+    };
+}
+
+export type ChangelogBaseRef = ChangelogBaseRefValue;
+export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
+export type PullRequest = PullRequestValue;
+export type PullRequestWithLabel = PullRequestWithLabelValue;
+export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;

--- a/source/lib/git-command-runner.ts
+++ b/source/lib/git-command-runner.ts
@@ -1,4 +1,3 @@
-import type { execaCommand } from 'execa';
 import { oneLine } from 'common-tags';
 import { splitByString, splitByPattern } from './split.ts';
 
@@ -33,8 +32,14 @@ export type GitCommandRunner = {
     getFirstParentCommitLogs(from: string): Promise<readonly FirstParentCommitLogEntry[]>;
 };
 
+type GitCommandResult = {
+    readonly stdout: string;
+};
+
+export type GitCommandExecutor = (command: string) => Promise<GitCommandResult>;
+
 export type GitCommandRunnerDependencies = {
-    readonly execute: typeof execaCommand;
+    readonly execute: GitCommandExecutor;
 };
 
 function trim(value: string): string {
@@ -71,7 +76,7 @@ function createParsableFirstParentGitLogFormat(): string {
     return `${fields.join(fieldSeparator)}${lineSeparator}`;
 }
 
-async function hasExistingRef(execute: typeof execaCommand, ref: string): Promise<boolean> {
+async function hasExistingRef(execute: GitCommandExecutor, ref: string): Promise<boolean> {
     try {
         await execute(`git rev-parse --verify --quiet ${ref}^{commit}`);
         return true;
@@ -97,22 +102,22 @@ function parseFirstParentCommitLogFields(log: string): FirstParentCommitLogField
     return [hash, subject, body];
 }
 
-async function readShortStatus(execute: typeof execaCommand): Promise<string> {
+async function readShortStatus(execute: GitCommandExecutor): Promise<string> {
     const result = await execute('git status --short');
     return result.stdout.trim();
 }
 
-async function readCurrentBranchName(execute: typeof execaCommand): Promise<string> {
+async function readCurrentBranchName(execute: GitCommandExecutor): Promise<string> {
     const result = await execute('git rev-parse --abbrev-ref HEAD');
     return result.stdout.trim();
 }
 
-async function fetchRemoteByAlias(execute: typeof execaCommand, remoteAlias: string): Promise<void> {
+async function fetchRemoteByAlias(execute: GitCommandExecutor, remoteAlias: string): Promise<void> {
     await execute(`git fetch ${remoteAlias}`);
 }
 
 async function readSymmetricBranchDifferences(
-    execute: typeof execaCommand,
+    execute: GitCommandExecutor,
     branchA: string,
     branchB: string
 ): Promise<readonly string[]> {
@@ -120,7 +125,7 @@ async function readSymmetricBranchDifferences(
     return splitLines(result.stdout);
 }
 
-async function readRemoteAliases(execute: typeof execaCommand): Promise<readonly RemoteAlias[]> {
+async function readRemoteAliases(execute: GitCommandExecutor): Promise<readonly RemoteAlias[]> {
     const result = await execute('git remote -v');
 
     return splitLines(result.stdout).map((line: string) => {
@@ -135,15 +140,12 @@ async function readRemoteAliases(execute: typeof execaCommand): Promise<readonly
     });
 }
 
-async function readTags(execute: typeof execaCommand): Promise<readonly string[]> {
+async function readTags(execute: GitCommandExecutor): Promise<readonly string[]> {
     const result = await execute('git tag --list');
     return splitLines(result.stdout);
 }
 
-async function readMergeCommitLogs(
-    execute: typeof execaCommand,
-    from: string
-): Promise<readonly MergeCommitLogEntry[]> {
+async function readMergeCommitLogs(execute: GitCommandExecutor, from: string): Promise<readonly MergeCommitLogEntry[]> {
     const result = await execute(oneLine`git log --first-parent --no-color
         --pretty=format:${createParsableMergeGitLogFormat()} --merges ${from}..HEAD`);
 
@@ -157,7 +159,7 @@ async function readMergeCommitLogs(
 }
 
 async function readFirstParentCommitLogs(
-    execute: typeof execaCommand,
+    execute: GitCommandExecutor,
     from: string
 ): Promise<readonly FirstParentCommitLogEntry[]> {
     const result = await execute(

--- a/source/packages/command-line-interface/bin.entry-point.ts
+++ b/source/packages/command-line-interface/bin.entry-point.ts
@@ -2,7 +2,6 @@
 
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { setTimeout as waitForTimeout } from 'node:timers/promises';
 import { createCommand } from 'commander';
 import { Octokit } from '@octokit/rest';
 import prependFile from 'prepend-file';
@@ -12,12 +11,9 @@ import { isString } from '@sindresorhus/is';
 import { createCliRunOptions } from '../../lib/cli-run-options.ts';
 import { createCliRunner, type CliRunnerDependencies } from '../../lib/cli.ts';
 import { ensureCleanLocalGitStateFactory } from '../../lib/ensure-clean-local-git-state.ts';
-import { getMergedPullRequestsFactory } from '../../lib/get-merged-pull-requests.ts';
 import { findRemoteAliasFactory } from '../../lib/find-remote-alias.ts';
-import { getPullRequestLabels } from '../../lib/get-pull-request-label.ts';
 import { createGitCommandRunner } from '../../lib/git-command-runner.ts';
-import { determineLatestVersionTag } from '../../lib/latest-version-tag.ts';
-import { renderChangelogMarkdown } from '../core/core.entry-point.ts';
+import { createPrLogEngine } from '../core/core.entry-point.ts';
 
 loglevel.enableAll();
 
@@ -43,19 +39,25 @@ let isTracingEnabled = false;
 const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
 const gitCommandRunner = createGitCommandRunner({ execute: execaCommand });
 const findRemoteAlias = findRemoteAliasFactory({ gitCommandRunner });
-const getMergedPullRequests = getMergedPullRequestsFactory({
-    githubClient,
-    gitCommandRunner,
-    getPullRequestLabels,
-    waitForMilliseconds: async (durationMilliseconds) => {
-        await waitForTimeout(durationMilliseconds);
-    },
+const prLogEngine = createPrLogEngine({
+    githubToken: GH_TOKEN,
+    workingDirectory: process.cwd(),
     labelLookupIntervalMilliseconds,
-    getCurrentDate,
     maximumRateLimitRetryCount
 });
 const getLatestVersionTag = async (): Promise<string> => {
-    return determineLatestVersionTag(await gitCommandRunner.listTags());
+    const baseRef = await prLogEngine.resolveLatestSemverChangelogBaseRef();
+    return baseRef.ref;
+};
+const getMergedPullRequests: CliRunnerDependencies['getMergedPullRequests'] = async (githubRepo, validLabels) => {
+    const baseRef = await prLogEngine.resolveLatestSemverChangelogBaseRef();
+    const pullRequests = await prLogEngine.collectMergedPullRequests({ githubRepo, baseRef: baseRef.ref });
+
+    return prLogEngine.resolvePullRequestLabels({
+        githubRepo,
+        validLabels,
+        pullRequests
+    });
 };
 
 const program = createCommand(config.name ?? '');
@@ -93,7 +95,9 @@ program
                     getLatestVersionTag,
                     getMergedPullRequests,
                     getCurrentDate,
-                    renderChangelogMarkdown
+                    renderChangelogMarkdown(input) {
+                        return prLogEngine.renderChangelog(input);
+                    }
                 };
                 const cliRunner = createCliRunner(dependencies);
                 await cliRunner.run(runOptions);

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -1,172 +1,65 @@
-import {
-    formatPackageVersionTag as formatPackageVersionTagValue,
-    resolveChangelogBaseRef as resolveChangelogBaseRefValue,
-    resolveLatestSemverTagBaseRef as resolveLatestSemverTagBaseRefValue,
-    type ChangelogBaseRef as ChangelogBaseRefValue,
-    type GitRefReader as GitRefReaderValue,
-    type LatestSemverTagBaseRefInput as LatestSemverTagBaseRefInputValue,
-    type MissingChangelogBaseRefError as MissingChangelogBaseRefErrorValue,
-    type MissingChangelogBaseRefReason as MissingChangelogBaseRefReasonValue,
-    type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue
-} from '../../lib/changelog-base-ref.ts';
-import {
-    collectMergedPullRequests as collectMergedPullRequestsValue,
-    type CollectMergedPullRequestsInput as CollectMergedPullRequestsInputValue,
-    type FirstParentCommitLogEntry as FirstParentCommitLogEntryValue,
-    type GitRangeReader as GitRangeReaderValue,
-    type PullRequest as PullRequestValue,
-    type PullRequestTitleReader as PullRequestTitleReaderValue
-} from '../../lib/collect-merged-pull-requests.ts';
-import * as githubChangedFiles from '../../lib/github-pull-request-changed-files.ts';
-import {
-    createGitHubPullRequestLabelReader as createGitHubPullRequestLabelReaderValue,
-    getPullRequestLabels as getPullRequestLabelsValue,
-    type GitHubPullRequestLabelReaderDependencies as GitHubPullRequestLabelReaderDependenciesValue
-} from '../../lib/get-pull-request-label.ts';
-import {
-    filterPullRequestsByTargetFiles as filterPullRequestsByTargetFilesValue,
-    type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue
-} from '../../lib/filter-pull-requests-by-target-files.ts';
-import {
-    fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
-    type FetchPullRequestChangedFilesInput as FetchPullRequestChangedFilesInputValue,
-    type PullRequestChangedFilesReader as PullRequestChangedFilesReaderValue
-} from '../../lib/pull-request-changed-files.ts';
-import {
-    resolvePullRequestLabels as resolvePullRequestLabelsValue,
-    type PullRequestLabelReader as PullRequestLabelReaderValue,
-    type PullRequestWithLabel as PullRequestWithLabelValue,
-    type ResolvePullRequestLabelsInput as ResolvePullRequestLabelsInputValue
-} from '../../lib/resolve-pull-request-labels.ts';
-import {
-    renderGroupedTargetChangelogMarkdown as renderGroupedTargetChangelogMarkdownValue,
-    renderChangelogMarkdown as renderChangelogMarkdownValue,
-    renderTargetChangelogMarkdown as renderTargetChangelogMarkdownValue,
-    type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
-    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
-    type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
-    type TargetChangelogSection as TargetChangelogSectionValue
-} from '../../lib/render-changelog-markdown.ts';
+import { setTimeout as waitForTimeout } from 'node:timers/promises';
+import { Octokit } from '@octokit/rest';
+import { execaCommand } from 'execa';
+import { createGitHubPullRequestChangedFilesReader } from '../../lib/github-pull-request-changed-files.ts';
+import { createGitCommandRunner, type GitCommandExecutor } from '../../lib/git-command-runner.ts';
+import { getPullRequestLabel } from '../../lib/get-pull-request-label.ts';
 import { defaultValidLabels as defaultValidLabelsValue } from '../../lib/valid-labels.ts';
+import {
+    createPrLogEngineWithDependencies,
+    type ChangelogBaseRef as ChangelogBaseRefValue,
+    type CollectMergedPullRequestsOptions as CollectMergedPullRequestsOptionsValue,
+    type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue,
+    type PrLogEngine as PrLogEngineValue,
+    type PullRequest as PullRequestValue,
+    type PullRequestWithLabel as PullRequestWithLabelValue,
+    type ReadPullRequestChangedFilesOptions as ReadPullRequestChangedFilesOptionsValue,
+    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
+    type ResolvePullRequestLabelsOptions as ResolvePullRequestLabelsOptionsValue
+} from '../../core/pr-log-engine.ts';
 
-export async function collectMergedPullRequests(
-    input: CollectMergedPullRequestsInputValue
-): Promise<readonly PullRequestValue[]> {
-    const pullRequests = await collectMergedPullRequestsValue(input);
-    return pullRequests;
+export type PrLogEngineOptions = {
+    readonly githubToken: string | undefined;
+    readonly workingDirectory: string;
+    readonly labelLookupIntervalMilliseconds: number;
+    readonly maximumRateLimitRetryCount: number;
+};
+
+function createCurrentDate(): Readonly<Date> {
+    return new Date();
 }
 
-export function createGitHubPullRequestChangedFilesReader(
-    githubClient: Parameters<typeof githubChangedFiles.createGitHubPullRequestChangedFilesReader>[0]
-): PullRequestChangedFilesReaderValue {
-    const changedFilesReader = githubChangedFiles.createGitHubPullRequestChangedFilesReader(githubClient);
-    return changedFilesReader;
+function createGitHubClient(options: Readonly<PrLogEngineOptions>): Readonly<Octokit> {
+    return new Octokit({ auth: options.githubToken });
 }
 
-export function createGitHubPullRequestLabelReader(
-    dependencies: GitHubPullRequestLabelReaderDependenciesValue
-): PullRequestLabelReaderValue {
-    const pullRequestLabelReader = createGitHubPullRequestLabelReaderValue(dependencies);
-    return pullRequestLabelReader;
+export function createPrLogEngine(options: Readonly<PrLogEngineOptions>): PrLogEngineValue {
+    const githubClient = createGitHubClient(options);
+    const execute: GitCommandExecutor = async (command) => {
+        return execaCommand(command, { cwd: options.workingDirectory });
+    };
+    const gitCommandRunner = createGitCommandRunner({ execute });
+
+    return createPrLogEngineWithDependencies({
+        githubClient,
+        gitCommandRunner,
+        pullRequestChangedFilesReader: createGitHubPullRequestChangedFilesReader(githubClient),
+        getPullRequestLabel,
+        waitForMilliseconds: waitForTimeout,
+        getCurrentDate: createCurrentDate,
+        labelLookupIntervalMilliseconds: options.labelLookupIntervalMilliseconds,
+        maximumRateLimitRetryCount: options.maximumRateLimitRetryCount
+    });
 }
 
-export async function fetchPullRequestChangedFiles(
-    input: FetchPullRequestChangedFilesInputValue
-): Promise<ReadonlyMap<number, readonly string[]>> {
-    const changedFiles = await fetchPullRequestChangedFilesValue(input);
-    return changedFiles;
-}
-
-export function filterPullRequestsByTargetFiles(
-    input: FilterPullRequestsByTargetFilesInputValue
-): readonly PullRequestValue[] {
-    const pullRequests = filterPullRequestsByTargetFilesValue(input);
-    return pullRequests;
-}
-
-export function formatPackageVersionTag(options: {
-    readonly packageName: string;
-    readonly version: string;
-    readonly packageTagFormat: string | undefined;
-}): string {
-    const packageVersionTag = formatPackageVersionTagValue(options);
-    return packageVersionTag;
-}
-
-export function renderChangelogMarkdown(input: RenderChangelogMarkdownInputValue): string {
-    const changelog = renderChangelogMarkdownValue(input);
-    return changelog;
-}
-
-export function renderGroupedTargetChangelogMarkdown(input: RenderGroupedTargetChangelogMarkdownInputValue): string {
-    const changelog = renderGroupedTargetChangelogMarkdownValue(input);
-    return changelog;
-}
-
-export function renderTargetChangelogMarkdown(input: RenderTargetChangelogMarkdownInputValue): string {
-    const changelog = renderTargetChangelogMarkdownValue(input);
-    return changelog;
-}
-
-export async function resolveChangelogBaseRef(
-    input: PackageChangelogBaseRefInputValue,
-    gitRefReader: GitRefReaderValue
-): Promise<ChangelogBaseRefValue> {
-    const baseRef = await resolveChangelogBaseRefValue(input, gitRefReader);
-    return baseRef;
-}
-
-export function resolveLatestSemverTagBaseRef(input: LatestSemverTagBaseRefInputValue): ChangelogBaseRefValue {
-    const baseRef = resolveLatestSemverTagBaseRefValue(input);
-    return baseRef;
-}
-
-export async function resolvePullRequestLabels(
-    input: ResolvePullRequestLabelsInputValue
-): Promise<readonly PullRequestWithLabelValue[]> {
-    const pullRequests = await resolvePullRequestLabelsValue(input);
-    return pullRequests;
-}
-
-export async function getPullRequestLabels(
-    githubRepo: string,
-    pullRequestId: number,
-    dependencies: GitHubPullRequestLabelReaderDependenciesValue
-): Promise<readonly string[]> {
-    const labels = await getPullRequestLabelsValue(githubRepo, pullRequestId, dependencies);
-    return labels;
-}
+export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultValidLabelsValue);
 
 export type ChangelogBaseRef = ChangelogBaseRefValue;
-export type CollectMergedPullRequestsInput = CollectMergedPullRequestsInputValue;
-export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultValidLabelsValue);
-export type FetchPullRequestChangedFilesInput = FetchPullRequestChangedFilesInputValue;
-export type FirstParentCommitLogEntry = FirstParentCommitLogEntryValue;
-export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
-export type GitRangeReader = GitRangeReaderValue;
-export type GitRefReader = GitRefReaderValue;
-export type GitHubPullRequestLabelReaderDependencies = GitHubPullRequestLabelReaderDependenciesValue;
-export type LatestSemverTagBaseRefInput = LatestSemverTagBaseRefInputValue;
-export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
-export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
+export type CollectMergedPullRequestsOptions = CollectMergedPullRequestsOptionsValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
+export type PrLogEngine = PrLogEngineValue;
 export type PullRequest = PullRequestValue;
-export type PullRequestChangedFilesReader = PullRequestChangedFilesReaderValue;
-export type PullRequestLabelReader = PullRequestLabelReaderValue;
-export type PullRequestTitleReader = PullRequestTitleReaderValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;
-export type ReleasePlanPackage = {
-    readonly name: string;
-    readonly previousVersion: string | undefined;
-    readonly nextVersion: string;
-    readonly changed: boolean;
-    readonly previousGitHead: string | undefined;
-    readonly currentGitHead: string | undefined;
-    readonly sourceFiles: readonly string[];
-    readonly changedArtifactFiles: readonly string[];
-};
+export type ReadPullRequestChangedFilesOptions = ReadPullRequestChangedFilesOptionsValue;
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
-export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
-export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
-export type ResolvePullRequestLabelsInput = ResolvePullRequestLabelsInputValue;
-export type TargetChangelogSection = TargetChangelogSectionValue;
+export type ResolvePullRequestLabelsOptions = ResolvePullRequestLabelsOptionsValue;


### PR DESCRIPTION
Introduces `createPrLogEngine()` as the public core API. Dependency wiring stays inside `@pr-log/core`, while consumers configure only runtime options.