### PR TITLE
Add target file attribution

### DIFF
--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -9,6 +9,7 @@ import { createPrLogEngineWithDependencies } from './pr-log-engine.ts';
 
 const githubRepo = 'owner/repo';
 const pullRequestId = 1;
+const documentationPullRequestId = 2;
 const waitDurationMilliseconds = 25;
 
 function createEngine(
@@ -131,6 +132,27 @@ test('reads pull request changed files', async () => {
             pullRequests: [{ id: pullRequestId, title: 'Fix bug' }]
         }),
         new Map([[pullRequestId, ['source/index.ts']]])
+    );
+});
+
+test('filters pull requests by target files', () => {
+    const engine = createEngine();
+
+    assert.deepStrictEqual(
+        engine.filterPullRequestsByTargetFiles({
+            targetName: 'pkg',
+            targetSourceFiles: ['source/index.ts'],
+            pullRequests: [
+                { id: pullRequestId, title: 'Fix bug' },
+                { id: documentationPullRequestId, title: 'Add docs' }
+            ],
+            changedFilesByPullRequest: new Map([
+                [pullRequestId, ['source/index.ts']],
+                [documentationPullRequestId, ['README.md']]
+            ]),
+            ignoredAttributionPaths: []
+        }),
+        [{ id: pullRequestId, title: 'Fix bug' }]
     );
 });
 

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -12,6 +12,10 @@ import {
     type PullRequest as PullRequestValue,
     type PullRequestTitleReader
 } from '../lib/collect-merged-pull-requests.ts';
+import {
+    filterPullRequestsByTargetFiles as filterPullRequestsByTargetFilesValue,
+    type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue
+} from '../lib/filter-pull-requests-by-target-files.ts';
 import type { GitCommandRunner } from '../lib/git-command-runner.ts';
 import type { GetPullRequestLabels } from '../lib/get-pull-request-label.ts';
 import {
@@ -58,6 +62,7 @@ export type PrLogEngine = {
         input: ReadPullRequestChangedFilesOptions
     ): Promise<ReadonlyMap<number, readonly string[]>>;
     readPullRequestLabels(input: ReadPullRequestLabelsOptions): Promise<ReadonlyMap<number, readonly string[]>>;
+    filterPullRequestsByTargetFiles(input: FilterPullRequestsByTargetFilesInputValue): readonly PullRequestValue[];
     resolvePullRequestLabels(input: ResolvePullRequestLabelsOptions): Promise<readonly PullRequestWithLabelValue[]>;
     renderChangelog(input: RenderChangelogMarkdownInputValue): string;
 };
@@ -177,6 +182,8 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
             return readPullRequestLabels(dependencies, input);
         },
 
+        filterPullRequestsByTargetFiles: filterPullRequestsByTargetFilesValue,
+
         async resolvePullRequestLabels(input) {
             return resolvePullRequestLabelsValue({
                 githubRepo: input.githubRepo,
@@ -195,6 +202,7 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
 }
 
 export type ChangelogBaseRef = ChangelogBaseRefValue;
+export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PullRequest = PullRequestValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -9,6 +9,7 @@ import {
     createPrLogEngineWithDependencies,
     type ChangelogBaseRef as ChangelogBaseRefValue,
     type CollectMergedPullRequestsOptions as CollectMergedPullRequestsOptionsValue,
+    type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue,
     type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue,
     type PrLogEngine as PrLogEngineValue,
     type PullRequest as PullRequestValue,
@@ -57,6 +58,7 @@ export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultVa
 
 export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollectMergedPullRequestsOptions = CollectMergedPullRequestsOptionsValue;
+export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PrLogEngine = PrLogEngineValue;
 export type PullRequest = PullRequestValue;


### PR DESCRIPTION
Adds core support for filtering pull requests by the files changed for a target. This lets consumers pass target source files without making `pr-log` own release planning.