### PR TITLE
Add target Markdown rendering

### DIFF
--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -176,7 +176,7 @@ test('waits between raw pull request label reads', async () => {
         githubRepo,
         pullRequests: [
             { id: pullRequestId, title: 'Fix bug' },
-            { id: 2, title: 'Add feature' }
+            { id: documentationPullRequestId, title: 'Add feature' }
         ]
     });
 
@@ -229,4 +229,48 @@ test('renders changelog markdown', () => {
     });
 
     assert.ok(changelog.includes('## 1.0.0 (January 1, 1970)'));
+});
+test('renders target changelog markdown', () => {
+    const engine = createEngine();
+
+    const changelog = engine.renderTargetChangelog({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targetName: 'pkg-a',
+        mergedPullRequests: [{ id: pullRequestId, title: 'Fix bug', label: 'bug' }],
+        githubRepo,
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(changelog.includes('### Bug Fixes'));
+});
+
+test('renders grouped target changelog markdown', () => {
+    const engine = createEngine();
+
+    const changelog = engine.renderGroupedTargetChangelog({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            {
+                targetName: 'pkg-a',
+                mergedPullRequests: [{ id: pullRequestId, title: 'Fix bug', label: 'bug' }],
+                unreleased: false,
+                versionNumber: '1.0.0'
+            },
+            {
+                targetName: 'pkg-b',
+                mergedPullRequests: [{ id: documentationPullRequestId, title: 'Add docs', label: 'documentation' }],
+                unreleased: false,
+                versionNumber: '2.0.0'
+            }
+        ],
+        githubRepo
+    });
+
+    assert.ok(changelog.includes('## pkg-a 1.0.0 (January 1, 1970)'));
+    assert.ok(changelog.includes('## pkg-b 2.0.0 (January 1, 1970)'));
 });

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -27,8 +27,13 @@ import {
     type PullRequestWithLabel as PullRequestWithLabelValue
 } from '../lib/resolve-pull-request-labels.ts';
 import {
+    renderGroupedTargetChangelogMarkdown,
     renderChangelogMarkdown,
-    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue
+    renderTargetChangelogMarkdown,
+    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
+    type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
+    type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
+    type TargetChangelogSection as TargetChangelogSectionValue
 } from '../lib/render-changelog-markdown.ts';
 
 export type CollectMergedPullRequestsOptions = {
@@ -65,6 +70,8 @@ export type PrLogEngine = {
     filterPullRequestsByTargetFiles(input: FilterPullRequestsByTargetFilesInputValue): readonly PullRequestValue[];
     resolvePullRequestLabels(input: ResolvePullRequestLabelsOptions): Promise<readonly PullRequestWithLabelValue[]>;
     renderChangelog(input: RenderChangelogMarkdownInputValue): string;
+    renderTargetChangelog(input: RenderTargetChangelogMarkdownInputValue): string;
+    renderGroupedTargetChangelog(input: RenderGroupedTargetChangelogMarkdownInputValue): string;
 };
 
 type PullRequestData = Readonly<Awaited<ReturnType<Octokit['pulls']['get']>>['data']>;
@@ -197,7 +204,9 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
             });
         },
 
-        renderChangelog: renderChangelogMarkdown
+        renderChangelog: renderChangelogMarkdown,
+        renderTargetChangelog: renderTargetChangelogMarkdown,
+        renderGroupedTargetChangelog: renderGroupedTargetChangelogMarkdown
     };
 }
 
@@ -206,4 +215,7 @@ export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFil
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PullRequest = PullRequestValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;
+export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
+export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
+export type TargetChangelogSection = TargetChangelogSectionValue;

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -16,8 +16,11 @@ import {
     type PullRequestWithLabel as PullRequestWithLabelValue,
     type ReadPullRequestChangedFilesOptions as ReadPullRequestChangedFilesOptionsValue,
     type ReadPullRequestLabelsOptions as ReadPullRequestLabelsOptionsValue,
+    type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
-    type ResolvePullRequestLabelsOptions as ResolvePullRequestLabelsOptionsValue
+    type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
+    type ResolvePullRequestLabelsOptions as ResolvePullRequestLabelsOptionsValue,
+    type TargetChangelogSection as TargetChangelogSectionValue
 } from '../../core/pr-log-engine.ts';
 
 export type PrLogEngineOptions = {
@@ -65,5 +68,8 @@ export type PullRequest = PullRequestValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;
 export type ReadPullRequestChangedFilesOptions = ReadPullRequestChangedFilesOptionsValue;
 export type ReadPullRequestLabelsOptions = ReadPullRequestLabelsOptionsValue;
+export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
+export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
 export type ResolvePullRequestLabelsOptions = ResolvePullRequestLabelsOptionsValue;
+export type TargetChangelogSection = TargetChangelogSectionValue;


### PR DESCRIPTION
Adds Markdown rendering for a single target and grouped target sections. Consumers can render per-target output or one grouped release text from the same resolved pull requests.