### PR TITLE
Enable package checks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,9 @@ jobs:
               run: npx just compile
             - name: Run tests
               run: npx just test
+            - name: Check packages
+              if: matrix.node-version == 24
+              run: npx just publish-dry-run
             - name: Coveralls
               uses: coverallsapp/github-action@v2
               with:

--- a/justfile
+++ b/justfile
@@ -24,17 +24,18 @@ lint-fix: eslint-fix prettier-fix
 
 prepare-packtory-source: compile
     rm -rf target/packtory/source
+    mkdir -p target/packtory
     cp -R target/build/source target/packtory/source
     perl -pi -e 's/from ([\x22\x27])(\.[^\x22\x27]+)\.ts\1/from $1$2.js$1/g' $(find target/packtory/source -name '*.d.ts')
 
 pack PACKAGE VERSION OUTPUT: prepare-packtory-source
     mkdir -p target/packages
-    packtory pack {{PACKAGE}} --format tar --out {{OUTPUT}} --version {{VERSION}}
+    packtory pack {{PACKAGE}} --format tar --out {{OUTPUT}} --version {{VERSION}} --vendor-dependencies
 
 pack-all: prepare-packtory-source
     mkdir -p target/packages
-    packtory pack pr-log --format tar --out target/packages/pr-log-6.1.1.tgz --version 6.1.1
-    packtory pack @pr-log/core --format tar --out target/packages/@pr-log-core-0.1.0.tgz --version 0.1.0
+    packtory pack pr-log --format tar --out target/packages/pr-log-6.1.1.tgz --version 6.1.1 --vendor-dependencies
+    packtory pack @pr-log/core --format tar --out target/packages/@pr-log-core-0.1.0.tgz --version 0.1.0 --vendor-dependencies
 
 publish: prepare-packtory-source
     packtory publish --no-dry-run

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,14 +23,14 @@
                 "true-myth": "9.4.0"
             },
             "bin": {
-                "pr-log": "target/build/source/bin/pr-log.js"
+                "pr-log": "target/build/source/packages/command-line-interface/bin.entry-point.js"
             },
             "devDependencies": {
                 "@enormora/eslint-config-base": "0.0.31",
                 "@enormora/eslint-config-mocha": "0.0.26",
                 "@enormora/eslint-config-node": "0.0.26",
                 "@enormora/eslint-config-typescript": "0.0.36",
-                "@packtory/cli": "0.0.30",
+                "@packtory/cli": "0.0.33",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.1",
@@ -1920,16 +1920,16 @@
             "license": "MIT"
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.30.tgz",
-            "integrity": "sha512-DGjOB232XujyPVk5TGI77zJebXsR8aj5LqbiR54qYleSwlMECUR3qtJadp1yMnySndkeVrDTqpXqnfiipXiANw==",
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.33.tgz",
+            "integrity": "sha512-ls6yM3nqQc+fcMwwK5FB/Hdpg0BTnLQX7VTUs7R/U0epO7ChyEDVdpxriN4WUUIdUFDFf0ZNp4dOtb+yeOq9Pg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cmd-ts": "0.15.0",
                 "open": "11.0.0",
-                "packtory": "0.0.30",
-                "remeda": "2.37.0",
+                "packtory": "0.0.33",
+                "remeda": "2.38.0",
                 "ts-pattern": "5.9.0",
                 "yoctocolors": "2.1.2"
             },
@@ -3500,9 +3500,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-            "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+            "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3792,9 +3792,9 @@
             }
         },
         "node_modules/cacache": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-21.0.0.tgz",
-            "integrity": "sha512-ohgebHsACA1Q2Pc99Vn/NWqoFoFoxY5aOktQY5Og/uyIyTaOx81YdxvnzpMq8qurTDxPd+CU3I0SNFdJWDb8ig==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-21.0.1.tgz",
+            "integrity": "sha512-pTwz/uj3Jyp6WXdJ6fWhR+7LVxVs6RyroQSn7KJwHsSxXuyGSp0pcMVcwSwTpCFq1X2YG8QBe0W+vN+cr0SwzA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6039,28 +6039,30 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "9.0.0",
-                "debug": "^4.3.4"
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
                 "node": ">= 20"
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "9.0.0",
-                "debug": "^4.3.4"
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
                 "node": ">= 20"
@@ -7741,9 +7743,9 @@
             }
         },
         "node_modules/npm-registry-fetch": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-20.0.0.tgz",
-            "integrity": "sha512-Hqaz3bQd4rnC41fskRZ2yzemzsfEvoA3WAuW7xkDC2RHtQ/W+o6n1dz8SHm61wmFFZGBITFzZD7kUPjXmYaNbw==",
+            "version": "20.0.1",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-20.0.1.tgz",
+            "integrity": "sha512-vzc1svxw/kw1IRjFsLi6gaxe1Olqm88V0tIfu2u5raL0b1gChe6ZEXNkyUlKxUC7s/egt5NxZHkbY18tMKKLfQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -7909,14 +7911,14 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/packtory": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.30.tgz",
-            "integrity": "sha512-w63364UqtfHp87TSvLd9fDw4kX0s3YXBpQFzJgPL00vjKStCUsRdX5gw4RYx7uygyNGAamXqJDy6CEdrAdd4Hg==",
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.33.tgz",
+            "integrity": "sha512-WHKfRfzny0omQ0sAm5vct8JpteSVgOPDWXYOnZTQTrZru43UR2stJJU2CEW3y84A0+I0FEpVKes1hnpMKcmSJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@arethetypeswrong/core": "0.18.3",
-                "@cyclonedx/cyclonedx-library": "10.0.0",
+                "@cyclonedx/cyclonedx-library": "10.1.0",
                 "@jridgewell/gen-mapping": "0.3.13",
                 "@jridgewell/trace-mapping": "0.3.31",
                 "@schema-hub/zod-error-formatter": "0.0.11",
@@ -7928,15 +7930,15 @@
                 "hosted-git-info": "10.1.1",
                 "libnpmpublish": "11.2.0",
                 "npm-package-arg": "14.0.0",
-                "npm-registry-fetch": "20.0.0",
-                "remeda": "2.37.0",
-                "semver": "7.8.1",
+                "npm-registry-fetch": "20.0.1",
+                "remeda": "2.38.0",
+                "semver": "7.8.2",
                 "spdx-expression-parse": "4.0.0",
                 "tar-stream": "3.1.8",
                 "true-myth": "9.4.0",
                 "ts-morph": "27.0.2",
                 "ts-pattern": "5.9.0",
-                "type-fest": "5.6.0",
+                "type-fest": "5.7.0",
                 "unix-permissions": "6.0.1",
                 "zod": "4.4.3"
             },
@@ -7945,9 +7947,9 @@
             }
         },
         "node_modules/packtory/node_modules/@cyclonedx/cyclonedx-library": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-10.0.0.tgz",
-            "integrity": "sha512-xDXf2eqzeFHdjamj6oBV3duRSfrlmsJ5+2z9tXp7q5qxJP5Awmjf4ABSutS4qkVHHj7JzKFL/EM0V0Nihc7zPg==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-10.1.0.tgz",
+            "integrity": "sha512-4yq0KTQIA32UHJwFMDeY5xj2asp3Mk5lzx4JRVXLOb0YE8w1KeR61c1m/gJ4sjMXpiiEDfaITVQu8BLUuy7t3A==",
             "dev": true,
             "funding": [
                 {
@@ -8029,19 +8031,6 @@
             "license": "MIT",
             "optional": true,
             "peer": true
-        },
-        "node_modules/packtory/node_modules/semver": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -8303,6 +8292,24 @@
             "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
             "license": "MIT"
         },
+        "node_modules/proxy-agent-negotiate": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "kerberos": "^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "kerberos": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8543,9 +8550,9 @@
             }
         },
         "node_modules/remeda": {
-            "version": "2.37.0",
-            "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.37.0.tgz",
-            "integrity": "sha512-wN6BXWua0t4o7vDamqc27J3VRxnokG9cDezsFN2nOnt2JD/IkJQHTYqM6UvmEctAZETAoviwEFQZJO3kZ4Ohew==",
+            "version": "2.38.0",
+            "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.38.0.tgz",
+            "integrity": "sha512-yhZjp7dd+L0NWS8gn4caKOHI6ALfbN3/2H5WNBCnFyzPYcG5vOw5b30FVpDFdQ+7Ui62QiCWKubJhG9Y5SqF5A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8964,9 +8971,9 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.0.0.tgz",
-            "integrity": "sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+            "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9049,9 +9056,9 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.26.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
-            "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+            "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9770,9 +9777,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@enormora/eslint-config-mocha": "0.0.26",
         "@enormora/eslint-config-node": "0.0.26",
         "@enormora/eslint-config-typescript": "0.0.36",
-        "@packtory/cli": "0.0.30",
+        "@packtory/cli": "0.0.33",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.1",

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 const projectFolder = process.cwd();
 const sourcesFolder = path.join(projectFolder, 'target/packtory/source');
+const licensePath = path.join(projectFolder, 'LICENSE');
+const readmePath = path.join(projectFolder, 'README.md');
 
 async function readPackageInfo() {
     const packageJsonContent = await fs.readFile(path.join(projectFolder, 'package.json'), { encoding: 'utf8' });
@@ -25,8 +27,8 @@ function commonPackageSettings(packageInfo) {
         sourcesFolder,
         mainPackageJson: { type: 'module', dependencies: packageInfo.dependencies },
         additionalFiles: [
-            { sourceFilePath: path.join(projectFolder, 'LICENSE'), targetFilePath: 'LICENSE' },
-            { sourceFilePath: path.join(projectFolder, 'README.md'), targetFilePath: 'README.md' }
+            { sourceFilePath: licensePath, targetFilePath: 'LICENSE' },
+            { sourceFilePath: readmePath, targetFilePath: 'README.md' }
         ],
         deadCodeElimination: { enabled: false },
         publishSettings: {
@@ -45,9 +47,6 @@ function corePackage(sharedAttributes) {
                 js: 'packages/core/core.entry-point.js',
                 declarationFile: 'packages/core/core.entry-point.d.ts'
             }
-        },
-        packageInterface: {
-            modules: [{ root: 'main', export: '.' }]
         },
         additionalPackageJsonAttributes: {
             ...sharedAttributes,
@@ -73,7 +72,8 @@ function cliPackage(packageInfo, sharedAttributes) {
             ...sharedAttributes,
             description: packageInfo.description,
             keywords: packageInfo.keywords
-        }
+        },
+        bundleDependencies: ['@pr-log/core']
     };
 }
 
@@ -84,6 +84,12 @@ export async function buildConfig() {
 
     return {
         commonPackageSettings: commonPackageSettings(packageInfo),
+        checks: {
+            areTheTypesWrong: { enabled: true, profile: 'esm-only' },
+            noDuplicatedFiles: { enabled: true, allowList: [licensePath, readmePath] },
+            requiredFiles: { enabled: true, files: ['LICENSE', 'README.md'] },
+            uniqueTargetPaths: { enabled: true }
+        },
         packages: [corePackage(sharedAttributes), cliPackage(packageInfo, sharedAttributes)]
     };
 }


### PR DESCRIPTION
Enables package-level checks for type importability, required files, and unique target paths. The duplicate-file check stays out because `pr-log` intentionally bundles core code through relative imports.