### PR TITLE
Export `MissingChangelogBaseRefError` from `@pr-log/core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ For example, `pkg-a:breaking` overrides a `bug` pull request label when renderin
 
 Package-aware release tags use `<packageName>@<version>` by default, for example `@scope/package@1.2.3`.
 Consumers can pass a package tag format with `{packageName}` and `{version}` placeholders.
+Missing package base refs reject with `MissingChangelogBaseRefError`.
 pr-log renders changelog text only. Consumers decide whether that text is written to one file, separate target files, release notes, or another destination.
 pr-log does not compute target impact, map build artifacts to source files, publish packages, commit files, create tags, or create releases.
 

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -4,6 +4,10 @@ import { execaCommand } from 'execa';
 import { createGitHubPullRequestChangedFilesReader } from '../../lib/github-pull-request-changed-files.ts';
 import { createGitCommandRunner, type GitCommandExecutor } from '../../lib/git-command-runner.ts';
 import { getPullRequestLabels } from '../../lib/get-pull-request-label.ts';
+import type {
+    MissingChangelogBaseRefError as MissingChangelogBaseRefErrorValue,
+    MissingChangelogBaseRefReason as MissingChangelogBaseRefReasonValue
+} from '../../lib/changelog-base-ref.ts';
 import { defaultValidLabels as defaultValidLabelsValue } from '../../lib/valid-labels.ts';
 import {
     createPrLogEngineWithDependencies,
@@ -62,6 +66,8 @@ export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultVa
 export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollectMergedPullRequestsOptions = CollectMergedPullRequestsOptionsValue;
 export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
+export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
+export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PrLogEngine = PrLogEngineValue;
 export type PullRequest = PullRequestValue;


### PR DESCRIPTION
Expose the package base-ref failure types from `@pr-log/core` so consumers can type errors from `resolveChangelogBaseRef`. The README now names the rejection shape alongside the package-aware base-ref behavior.