### PR TITLE
Update root `README.md` badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![NPM Version](https://img.shields.io/npm/v/pr-log.svg?style=flat)](https://www.npmjs.org/package/pr-log)
-[![GitHub Actions status](https://github.com/lo1tuma/pr-log/workflows/CI/badge.svg)](https://github.com/lo1tuma/pr-log/actions)
+[![GitHub Actions status](https://github.com/enormora/pr-log/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/enormora/pr-log/actions/workflows/continuous-integration.yml)
 [![Coverage Status](https://img.shields.io/coveralls/lo1tuma/pr-log/main.svg?style=flat)](https://coveralls.io/r/lo1tuma/pr-log)
 
 # pr-log
@@ -8,5 +7,5 @@
 
 ## Packages
 
-- [`pr-log`](packages/pr-log/README.md): command-line changelog generator.
-- [`@pr-log/core`](packages/core/README.md): reusable changelog generation API.
+- [`pr-log`](packages/pr-log/README.md) [![NPM Version](https://img.shields.io/npm/v/pr-log.svg?style=flat)](https://www.npmjs.org/package/pr-log): command-line changelog generator.
+- [`@pr-log/core`](packages/core/README.md) [![NPM Version](https://img.shields.io/npm/v/%40pr-log%2Fcore.svg?style=flat)](https://www.npmjs.org/package/@pr-log/core): reusable changelog generation API.


### PR DESCRIPTION
This moves npm version badges from the root badge block to the published package list so each package has its own npm status. It also updates the CI badge to the current `enormora/pr-log` workflow URL.