### PR TITLE
Add `PrLogEngine.updateChangelog()`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,7 +21,7 @@ const prLogEngine = createPrLogEngine({
 });
 ```
 
-`@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, and changelog rendering.
+`@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, changelog rendering, and changelog Markdown merging.
 Target impact and release planning stay outside pr-log. Consumers pass target source files into pr-log when they need target-specific changelogs.
 
 A target-aware integration usually follows this flow:
@@ -33,6 +33,9 @@ A target-aware integration usually follows this flow:
 5. Filter pull requests by target source files.
 6. Resolve labels for each target.
 7. Render one Markdown string per target, or one grouped Markdown string for all targets.
+8. Read the existing changelog outside pr-log.
+9. Pass the existing and generated Markdown to `prLogEngine.updateChangelog()`.
+10. Write the returned Markdown outside pr-log.
 
 Target-scoped labels can override the pull request level label for one target. The default pattern is `{targetName}:{label}`.
 For example, `pkg-a:breaking` overrides a `bug` pull request label when rendering `pkg-a`, while other targets still use `bug`.
@@ -40,5 +43,5 @@ For example, `pkg-a:breaking` overrides a `bug` pull request label when renderin
 Package-aware release tags use `<packageName>@<version>` by default, for example `@scope/package@1.2.3`.
 Consumers can pass a package tag format with `{packageName}` and `{version}` placeholders.
 Missing package base refs reject with `MissingChangelogBaseRefError`.
-pr-log renders changelog text only. Consumers decide whether that text is written to one file, separate target files, release notes, or another destination.
+pr-log renders and merges Markdown only. Consumers decide whether that text is written to one file, separate target files, release notes, or another destination.
 pr-log does not compute target impact, map build artifacts to source files, publish packages, commit files, create tags, or create releases.

--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -274,3 +274,14 @@ test('renders grouped target changelog markdown', () => {
     assert.ok(changelog.includes('## pkg-a 1.0.0 (January 1, 1970)'));
     assert.ok(changelog.includes('## pkg-b 2.0.0 (January 1, 1970)'));
 });
+
+test('updates changelog markdown', () => {
+    const engine = createEngine();
+
+    const changelog = engine.updateChangelog({
+        existingChangelogMarkdown: '## 0.9.0\n\n* Older change\n',
+        generatedChangelogMarkdown: '## 1.0.0\n\n* New change\n'
+    });
+
+    assert.strictEqual(changelog, '## 1.0.0\n\n* New change\n\n## 0.9.0\n\n* Older change\n');
+});

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -33,7 +33,9 @@ import {
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
     type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
     type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
-    type TargetChangelogSection as TargetChangelogSectionValue
+    updateChangelogMarkdown,
+    type TargetChangelogSection as TargetChangelogSectionValue,
+    type UpdateChangelogMarkdownInput as UpdateChangelogMarkdownInputValue
 } from '../lib/render-changelog-markdown.ts';
 
 export type CollectMergedPullRequestsOptions = {
@@ -72,6 +74,7 @@ export type PrLogEngine = {
     renderChangelog(input: RenderChangelogMarkdownInputValue): string;
     renderTargetChangelog(input: RenderTargetChangelogMarkdownInputValue): string;
     renderGroupedTargetChangelog(input: RenderGroupedTargetChangelogMarkdownInputValue): string;
+    updateChangelog(input: UpdateChangelogMarkdownInputValue): string;
 };
 
 type PullRequestData = Readonly<Awaited<ReturnType<Octokit['pulls']['get']>>['data']>;
@@ -206,7 +209,8 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
 
         renderChangelog: renderChangelogMarkdown,
         renderTargetChangelog: renderTargetChangelogMarkdown,
-        renderGroupedTargetChangelog: renderGroupedTargetChangelogMarkdown
+        renderGroupedTargetChangelog: renderGroupedTargetChangelogMarkdown,
+        updateChangelog: updateChangelogMarkdown
     };
 }
 
@@ -219,3 +223,4 @@ export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChang
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
 export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
 export type TargetChangelogSection = TargetChangelogSectionValue;
+export type UpdateChangelogInput = UpdateChangelogMarkdownInputValue;

--- a/source/lib/render-changelog-markdown.ts
+++ b/source/lib/render-changelog-markdown.ts
@@ -51,6 +51,11 @@ export type RenderGroupedTargetChangelogMarkdownInput = {
 
 export type RenderTargetChangelogMarkdownInput = RenderChangelogMarkdownInputBase & TargetChangelogSection;
 
+export type UpdateChangelogMarkdownInput = {
+    readonly existingChangelogMarkdown: string;
+    readonly generatedChangelogMarkdown: string;
+};
+
 export function renderChangelogMarkdown(input: RenderChangelogMarkdownInput): string {
     const createChangelog = createChangelogFactory({
         packageInfo: input.packageInfo,
@@ -119,4 +124,10 @@ export function renderGroupedTargetChangelogMarkdown(input: RenderGroupedTargetC
         .join('');
 
     return sections;
+}
+
+export function updateChangelogMarkdown(input: UpdateChangelogMarkdownInput): string {
+    const generatedChangelogMarkdown = input.generatedChangelogMarkdown.trim();
+
+    return `${generatedChangelogMarkdown}\n\n${input.existingChangelogMarkdown}`;
 }

--- a/source/lib/update-changelog-markdown.test.ts
+++ b/source/lib/update-changelog-markdown.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert';
+import { renderGroupedTargetChangelogMarkdown, updateChangelogMarkdown } from './render-changelog-markdown.ts';
+import { defaultValidLabels } from './valid-labels.ts';
+
+test('updates an empty changelog', () => {
+    const changelog = updateChangelogMarkdown({
+        existingChangelogMarkdown: '',
+        generatedChangelogMarkdown: '## 1.0.0\n\n### Bug Fixes\n\n* Fix bug\n'
+    });
+
+    assert.strictEqual(changelog, '## 1.0.0\n\n### Bug Fixes\n\n* Fix bug\n\n');
+});
+
+test('preserves existing changelog history', () => {
+    const existingChangelogMarkdown = '## 0.9.0\n\n### Features\n\n* Add old feature\n';
+
+    const changelog = updateChangelogMarkdown({
+        existingChangelogMarkdown,
+        generatedChangelogMarkdown: '## 1.0.0\n\n### Bug Fixes\n\n* Fix bug\n'
+    });
+
+    assert.strictEqual(
+        changelog,
+        '## 1.0.0\n\n### Bug Fixes\n\n* Fix bug\n\n## 0.9.0\n\n### Features\n\n* Add old feature\n'
+    );
+});
+
+test('prepends repeated generated changelog sections', () => {
+    const generatedChangelogMarkdown = '## 1.0.0\n\n### Bug Fixes\n\n* Fix bug\n';
+    const firstChangelog = updateChangelogMarkdown({
+        existingChangelogMarkdown: '',
+        generatedChangelogMarkdown
+    });
+
+    const secondChangelog = updateChangelogMarkdown({
+        existingChangelogMarkdown: firstChangelog,
+        generatedChangelogMarkdown
+    });
+
+    assert.strictEqual(
+        secondChangelog,
+        '## 1.0.0\n\n### Bug Fixes\n\n* Fix bug\n\n## 1.0.0\n\n### Bug Fixes\n\n* Fix bug\n\n'
+    );
+});
+
+test('updates a changelog with grouped target sections', () => {
+    const generatedChangelogMarkdown = renderGroupedTargetChangelogMarkdown({
+        packageInfo: {},
+        currentDate: new Date(0),
+        validLabels: defaultValidLabels,
+        targets: [
+            {
+                targetName: 'pkg-a',
+                unreleased: false,
+                versionNumber: '1.0.0',
+                mergedPullRequests: [{ id: 1, title: 'Fix bug', label: 'bug' }]
+            },
+            {
+                targetName: 'pkg-b',
+                unreleased: false,
+                versionNumber: '2.0.0',
+                mergedPullRequests: [{ id: 2, title: 'Add feature', label: 'feature' }]
+            }
+        ],
+        githubRepo: 'owner/repo'
+    });
+
+    const changelog = updateChangelogMarkdown({
+        existingChangelogMarkdown: '## Older\n\n* Keep history\n',
+        generatedChangelogMarkdown
+    });
+
+    assert.ok(changelog.startsWith('## pkg-a 1.0.0 (January 1, 1970)'));
+    assert.ok(changelog.includes('## pkg-b 2.0.0 (January 1, 1970)'));
+    assert.ok(changelog.endsWith('\n\n## Older\n\n* Keep history\n'));
+});

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -24,7 +24,8 @@ import {
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
     type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
     type ResolvePullRequestLabelsOptions as ResolvePullRequestLabelsOptionsValue,
-    type TargetChangelogSection as TargetChangelogSectionValue
+    type TargetChangelogSection as TargetChangelogSectionValue,
+    type UpdateChangelogInput as UpdateChangelogInputValue
 } from '../../core/pr-log-engine.ts';
 
 export type PrLogEngineOptions = {
@@ -79,3 +80,4 @@ export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
 export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
 export type ResolvePullRequestLabelsOptions = ResolvePullRequestLabelsOptionsValue;
 export type TargetChangelogSection = TargetChangelogSectionValue;
+export type UpdateChangelogInput = UpdateChangelogInputValue;


### PR DESCRIPTION
`@pr-log/core` now exposes changelog Markdown merging through `PrLogEngine.updateChangelog()`, so Packtory can reuse pr-log prepend semantics without file IO in core. The method preserves existing content after the generated block and documents the caller-owned read/write flow for target changelogs.