### PR TITLE
Add manual `pr-log` publish workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,6 +7,11 @@ on:
     pull_request:
         types: [opened, reopened, synchronize]
     merge_group:
+    workflow_dispatch:
+        inputs:
+            release_commit_sha:
+                required: false
+                type: string
 
 jobs:
     build:
@@ -29,8 +34,33 @@ jobs:
               run: npx just compile
             - name: Run tests
               run: npx just test
+            - name: Read package check release version
+              id: package-check-release-version
+              if: >
+                  matrix.node-version == 24 &&
+                  github.event_name == 'workflow_dispatch' &&
+                  github.actor == 'github-actions[bot]' &&
+                  inputs.release_commit_sha != ''
+              run: |
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+                  import semver from 'semver';
+
+                  const changelogPath = 'source/packages/command-line-interface/CHANGELOG.md';
+                  const changelog = await fs.readFile(changelogPath, { encoding: 'utf8' });
+                  const match = /^## (?<version>\S+) \(/u.exec(changelog);
+                  const version = match?.groups?.version;
+
+                  if (version === undefined || semver.valid(version) === null) {
+                      throw new Error(`${changelogPath} does not start with a valid release version`);
+                  }
+
+                  await fs.appendFile(process.env.GITHUB_OUTPUT, `pr_log_version=${version}\n`, { encoding: 'utf8' });
+                  NODE
             - name: Check packages
               if: matrix.node-version == 24
+              env:
+                  PR_LOG_RELEASE_VERSION: ${{ steps.package-check-release-version.outputs.pr_log_version || '9.9.9' }}
               run: npx just publish-dry-run
             - name: Coveralls
               uses: coverallsapp/github-action@v2
@@ -38,6 +68,267 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   path-to-lcov: ./target/coverage/lcov.info
                   parallel: true
+
+    publish-release:
+        needs: build
+        runs-on: ubuntu-latest
+        if: >
+            github.event_name == 'workflow_dispatch' &&
+            github.actor == 'github-actions[bot]' &&
+            inputs.release_commit_sha != ''
+        permissions:
+            contents: write
+            id-token: write
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  ref: main
+                  fetch-depth: 0
+                  persist-credentials: true
+
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+
+            - name: Audit npm signatures and attestations
+              run: |
+                  mkdir -p target/release
+                  npm audit signatures --json --include-attestations > target/release/npm-audit-signatures.json
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+
+                  const report = JSON.parse(
+                      await fs.readFile('target/release/npm-audit-signatures.json', { encoding: 'utf8' })
+                  );
+                  const packtory = report.verified.find((entry) => {
+                      return entry.name === '@packtory/cli';
+                  });
+
+                  if (packtory?.attestations?.provenance?.predicateType !== 'https://slsa.dev/provenance/v1') {
+                      throw new Error('Missing npm provenance for @packtory/cli');
+                  }
+                  NODE
+
+            - name: Validate release commit
+              id: release-metadata
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_COMMIT_SHA: ${{ inputs.release_commit_sha }}
+              run: |
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+                  import { execFileSync } from 'node:child_process';
+                  import semver from 'semver';
+
+                  const cliChangelog = 'source/packages/command-line-interface/CHANGELOG.md';
+                  const coreChangelog = 'source/packages/core/CHANGELOG.md';
+
+                  function runGit(args) {
+                      return execFileSync('git', args, { encoding: 'utf8' }).trim();
+                  }
+
+                  function readChangelogVersion(changelog, changelogPath) {
+                      const match = /^## (?<version>\S+) \(/u.exec(changelog);
+                      const version = match?.groups?.version;
+
+                      if (version === undefined || semver.valid(version) === null) {
+                          throw new Error(`${changelogPath} does not start with a valid release version`);
+                      }
+
+                      return version;
+                  }
+
+                  function assertTagDoesNotExist(tagName) {
+                      try {
+                          runGit(['rev-parse', '--verify', `refs/tags/${tagName}`]);
+                      } catch {
+                          return;
+                      }
+
+                      throw new Error(`Release tag already exists: ${tagName}`);
+                  }
+
+                  async function writeOutput(name, value) {
+                      await fs.appendFile(process.env.GITHUB_OUTPUT, `${name}=${value}\n`, { encoding: 'utf8' });
+                  }
+
+                  async function githubApi(path) {
+                      const response = await fetch(`https://api.github.com${path}`, {
+                          headers: {
+                              Accept: 'application/vnd.github+json',
+                              Authorization: `Bearer ${process.env.GH_TOKEN}`,
+                              'X-GitHub-Api-Version': '2022-11-28'
+                          }
+                      });
+
+                      if (!response.ok) {
+                          const body = await response.text();
+                          throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}\n${body}`);
+                      }
+
+                      return response.json();
+                  }
+
+                  if (process.env.GITHUB_ACTOR !== 'github-actions[bot]') {
+                      throw new Error(`Unexpected workflow actor: ${process.env.GITHUB_ACTOR}`);
+                  }
+
+                  const headSha = runGit(['rev-parse', 'HEAD']);
+
+                  if (headSha !== process.env.RELEASE_COMMIT_SHA) {
+                      throw new Error(`HEAD ${headSha} does not match release commit ${process.env.RELEASE_COMMIT_SHA}`);
+                  }
+
+                  const subject = runGit(['log', '-1', '--format=%s']);
+
+                  if (subject !== 'Prepare release') {
+                      throw new Error(`Unexpected release commit subject: ${subject}`);
+                  }
+
+                  const commit = await githubApi(`/repos/${process.env.GITHUB_REPOSITORY}/commits/${headSha}`);
+
+                  if (commit.committer?.login !== 'github-actions[bot]') {
+                      throw new Error(`Unexpected release committer: ${commit.committer?.login ?? 'unknown'}`);
+                  }
+
+                  if (commit.commit.verification.verified !== true) {
+                      throw new Error(`Release commit is not verified: ${commit.commit.verification.reason}`);
+                  }
+
+                  const changedFiles = runGit(['diff-tree', '--no-commit-id', '--name-only', '-r', 'HEAD'])
+                      .split('\n')
+                      .filter((filePath) => {
+                          return filePath !== '';
+                      });
+                  const hasCoreRelease = changedFiles.includes(coreChangelog);
+                  const allowedFiles = new Set([cliChangelog]);
+
+                  if (hasCoreRelease) {
+                      allowedFiles.add(coreChangelog);
+                  }
+
+                  if (!changedFiles.includes(cliChangelog)) {
+                      throw new Error(`${cliChangelog} must be changed`);
+                  }
+
+                  for (const changedFile of changedFiles) {
+                      if (!allowedFiles.has(changedFile)) {
+                          throw new Error(`Unexpected release file change: ${changedFile}`);
+                      }
+                  }
+
+                  const cliChangelogContent = await fs.readFile(cliChangelog, { encoding: 'utf8' });
+                  const prLogVersion = readChangelogVersion(cliChangelogContent, cliChangelog);
+                  const prLogTag = `pr-log@${prLogVersion}`;
+                  let predictedCoreVersion = '';
+                  let predictedCoreTag = '';
+
+                  if (hasCoreRelease) {
+                      const coreChangelogContent = await fs.readFile(coreChangelog, { encoding: 'utf8' });
+                      predictedCoreVersion = readChangelogVersion(coreChangelogContent, coreChangelog);
+                      predictedCoreTag = `@pr-log/core@${predictedCoreVersion}`;
+                  }
+
+                  assertTagDoesNotExist(prLogTag);
+
+                  if (hasCoreRelease) {
+                      assertTagDoesNotExist(predictedCoreTag);
+                  }
+
+                  await writeOutput('pr_log_version', prLogVersion);
+                  await writeOutput('pr_log_tag', prLogTag);
+                  await writeOutput('core_release_needed', hasCoreRelease ? 'true' : 'false');
+                  await writeOutput('predicted_core_version', predictedCoreVersion);
+                  await writeOutput('predicted_core_tag', predictedCoreTag);
+                  NODE
+
+            - name: Check packages
+              env:
+                  PR_LOG_RELEASE_VERSION: ${{ steps.release-metadata.outputs.pr_log_version }}
+              run: npx just publish-dry-run
+
+            - name: Publish packages
+              env:
+                  PR_LOG_RELEASE_VERSION: ${{ steps.release-metadata.outputs.pr_log_version }}
+              run: |
+                  mkdir -p target/release
+                  set +e
+                  PR_LOG_RELEASE_VERSION="$PR_LOG_RELEASE_VERSION" npx just publish 2>&1 | tee target/release/publish.log
+                  status=${PIPESTATUS[0]}
+                  set -e
+
+                  if [ "$status" -eq 0 ]; then
+                      exit 0
+                  fi
+
+                  if grep -Eiq 'attestation|oidc|provenance|rekor|sigstore|tlog' target/release/publish.log; then
+                      sleep 30
+                      PR_LOG_RELEASE_VERSION="$PR_LOG_RELEASE_VERSION" npx just publish
+                      exit 0
+                  fi
+
+                  exit "$status"
+
+            - name: Validate core package version
+              if: steps.release-metadata.outputs.core_release_needed == 'true'
+              env:
+                  PREDICTED_CORE_VERSION: ${{ steps.release-metadata.outputs.predicted_core_version }}
+              run: |
+                  node --input-type=module <<'NODE'
+                  import { execFileSync } from 'node:child_process';
+
+                  function readPublishedCoreVersion() {
+                      try {
+                          const output = execFileSync('npm', ['view', '@pr-log/core', 'version', '--json'], {
+                              encoding: 'utf8'
+                          }).trim();
+
+                          return JSON.parse(output);
+                      } catch {
+                          return undefined;
+                      }
+                  }
+
+                  for (let attempt = 1; attempt <= 12; attempt += 1) {
+                      const publishedCoreVersion = readPublishedCoreVersion();
+
+                      if (publishedCoreVersion === process.env.PREDICTED_CORE_VERSION) {
+                          process.exit(0);
+                      }
+
+                      if (attempt === 12) {
+                          throw new Error(
+                              `Packtory published @pr-log/core ${publishedCoreVersion}, expected ${process.env.PREDICTED_CORE_VERSION}`
+                          );
+                      }
+
+                      await new Promise((resolve) => {
+                          setTimeout(resolve, 10_000);
+                      });
+                  }
+                  NODE
+
+            - name: Push release tags
+              env:
+                  PR_LOG_TAG: ${{ steps.release-metadata.outputs.pr_log_tag }}
+                  CORE_RELEASE_NEEDED: ${{ steps.release-metadata.outputs.core_release_needed }}
+                  PREDICTED_CORE_TAG: ${{ steps.release-metadata.outputs.predicted_core_tag }}
+              run: |
+                  git tag "$PR_LOG_TAG"
+
+                  if [ "$CORE_RELEASE_NEEDED" = "true" ]; then
+                      git tag "$PREDICTED_CORE_TAG"
+                  fi
+
+                  git push origin "$PR_LOG_TAG"
+
+                  if [ "$CORE_RELEASE_NEEDED" = "true" ]; then
+                      git push origin "$PREDICTED_CORE_TAG"
+                  fi
 
     coverage:
         needs: build

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,226 @@
+name: Prepare release
+
+on:
+    workflow_dispatch:
+
+permissions:
+    actions: write
+    contents: write
+    issues: read
+    pull-requests: read
+
+jobs:
+    prepare-release:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  ref: main
+                  fetch-depth: 0
+                  persist-credentials: false
+
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+
+            - name: Audit npm signatures and attestations
+              run: |
+                  mkdir -p target/release
+                  npm audit signatures --json --include-attestations > target/release/npm-audit-signatures.json
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+
+                  const report = JSON.parse(
+                      await fs.readFile('target/release/npm-audit-signatures.json', { encoding: 'utf8' })
+                  );
+                  const packtory = report.verified.find((entry) => {
+                      return entry.name === '@packtory/cli';
+                  });
+
+                  if (packtory?.attestations?.provenance?.predicateType !== 'https://slsa.dev/provenance/v1') {
+                      throw new Error('Missing npm provenance for @packtory/cli');
+                  }
+                  NODE
+
+            - name: Compile TypeScript
+              run: npx just compile
+
+            - name: Prepare release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: bash source/release/prepare-release.sh
+
+            - name: Read release metadata
+              id: release-metadata
+              run: |
+                  pr_log_version="$(cat target/release/pr-log-version.txt)"
+                  core_release_needed="$(node -e "const metadata = require('./target/release/core-release.json'); console.log(metadata.type === 'predicted-release' ? 'true' : 'false')")"
+                  predicted_core_version="$(node -e "const metadata = require('./target/release/core-release.json'); console.log(metadata.predictedVersion)")"
+                  predicted_core_tag="$(node -e "const metadata = require('./target/release/core-release.json'); console.log(metadata.predictedTagName)")"
+
+                  {
+                      echo "pr_log_version=${pr_log_version}"
+                      echo "core_release_needed=${core_release_needed}"
+                      echo "predicted_core_version=${predicted_core_version}"
+                      echo "predicted_core_tag=${predicted_core_tag}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Static code analysis
+              run: npx just lint
+
+            - name: Run tests
+              run: npx just test
+
+            - name: Check packages
+              env:
+                  PR_LOG_RELEASE_VERSION: ${{ steps.release-metadata.outputs.pr_log_version }}
+              run: npx just publish-dry-run
+
+            - name: Validate release diff
+              env:
+                  CORE_RELEASE_NEEDED: ${{ steps.release-metadata.outputs.core_release_needed }}
+              run: |
+                  node --input-type=module <<'NODE'
+                  import { execFileSync } from 'node:child_process';
+
+                  const cliChangelog = 'source/packages/command-line-interface/CHANGELOG.md';
+                  const coreChangelog = 'source/packages/core/CHANGELOG.md';
+                  const allowedFiles = new Set([cliChangelog]);
+
+                  if (process.env.CORE_RELEASE_NEEDED === 'true') {
+                      allowedFiles.add(coreChangelog);
+                  }
+
+                  const changedFiles = execFileSync('git', ['diff', '--name-only'], { encoding: 'utf8' })
+                      .trim()
+                      .split('\n')
+                      .filter((filePath) => {
+                          return filePath !== '';
+                      });
+
+                  if (!changedFiles.includes(cliChangelog)) {
+                      throw new Error(`${cliChangelog} must be changed`);
+                  }
+
+                  if (process.env.CORE_RELEASE_NEEDED === 'true' && !changedFiles.includes(coreChangelog)) {
+                      throw new Error(`${coreChangelog} must be changed for a core release`);
+                  }
+
+                  for (const changedFile of changedFiles) {
+                      if (!allowedFiles.has(changedFile)) {
+                          throw new Error(`Unexpected release file change: ${changedFile}`);
+                      }
+                  }
+                  NODE
+
+            - name: Create verified release commit
+              id: release-commit
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+                  import { execFileSync } from 'node:child_process';
+
+                  const repository = process.env.GITHUB_REPOSITORY;
+                  const branchName = 'main';
+                  const localHead = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+                  const changedFiles = execFileSync('git', ['diff', '--name-only'], { encoding: 'utf8' })
+                      .trim()
+                      .split('\n')
+                      .filter((filePath) => {
+                          return filePath !== '';
+                      });
+
+                  async function githubApi(path, options = {}) {
+                      const response = await fetch(`https://api.github.com${path}`, {
+                          ...options,
+                          headers: {
+                              Accept: 'application/vnd.github+json',
+                              Authorization: `Bearer ${process.env.GH_TOKEN}`,
+                              'X-GitHub-Api-Version': '2022-11-28',
+                              ...options.headers
+                          }
+                      });
+
+                      if (!response.ok) {
+                          const body = await response.text();
+                          throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}\n${body}`);
+                      }
+
+                      return response.json();
+                  }
+
+                  const ref = await githubApi(`/repos/${repository}/git/ref/heads/${branchName}`);
+                  const remoteHead = ref.object.sha;
+
+                  if (remoteHead !== localHead) {
+                      throw new Error(`main moved while preparing the release: expected ${localHead}, found ${remoteHead}`);
+                  }
+
+                  const parentCommit = await githubApi(`/repos/${repository}/git/commits/${remoteHead}`);
+                  const treeEntries = [];
+
+                  for (const changedFile of changedFiles) {
+                      const content = await fs.readFile(changedFile, { encoding: 'utf8' });
+                      const blob = await githubApi(`/repos/${repository}/git/blobs`, {
+                          method: 'POST',
+                          body: JSON.stringify({ content, encoding: 'utf-8' })
+                      });
+
+                      treeEntries.push({ path: changedFile, mode: '100644', type: 'blob', sha: blob.sha });
+                  }
+
+                  const tree = await githubApi(`/repos/${repository}/git/trees`, {
+                      method: 'POST',
+                      body: JSON.stringify({ base_tree: parentCommit.tree.sha, tree: treeEntries })
+                  });
+
+                  const commit = await githubApi(`/repos/${repository}/git/commits`, {
+                      method: 'POST',
+                      body: JSON.stringify({ message: 'Prepare release', tree: tree.sha, parents: [remoteHead] })
+                  });
+
+                  await githubApi(`/repos/${repository}/git/refs/heads/${branchName}`, {
+                      method: 'PATCH',
+                      body: JSON.stringify({ sha: commit.sha })
+                  });
+
+                  await fs.appendFile(process.env.GITHUB_OUTPUT, `release_commit_sha=${commit.sha}\n`, {
+                      encoding: 'utf8'
+                  });
+                  NODE
+
+            - name: Dispatch release CI
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_COMMIT_SHA: ${{ steps.release-commit.outputs.release_commit_sha }}
+              run: |
+                  node --input-type=module <<'NODE'
+                  const response = await fetch(
+                      `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/actions/workflows/continuous-integration.yml/dispatches`,
+                      {
+                          method: 'POST',
+                          headers: {
+                              Accept: 'application/vnd.github+json',
+                              Authorization: `Bearer ${process.env.GH_TOKEN}`,
+                              'X-GitHub-Api-Version': '2022-11-28'
+                          },
+                          body: JSON.stringify({
+                              ref: 'main',
+                              inputs: {
+                                  release_commit_sha: process.env.RELEASE_COMMIT_SHA
+                              }
+                          })
+                      }
+                  );
+
+                  if (!response.ok) {
+                      const body = await response.text();
+                      throw new Error(`Failed to dispatch release CI: ${response.status} ${response.statusText}\n${body}`);
+                  }
+                  NODE

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -36,10 +36,16 @@ function commonPackageSettings(packageInfo) {
     };
 }
 
+function registrySettings() {
+    return {
+        auth: { type: 'npm-oidc', provider: 'github-actions' }
+    };
+}
+
 function corePackage(sharedAttributes) {
     return {
         name: '@pr-log/core',
-        versioning: { automatic: false, version: '0.1.0' },
+        versioning: { automatic: true, minimumVersion: '0.1.0' },
         additionalFiles: [{ sourceFilePath: coreReadmePath, targetFilePath: 'README.md' }],
         roots: {
             main: {
@@ -56,9 +62,16 @@ function corePackage(sharedAttributes) {
 }
 
 function cliPackage(packageInfo, sharedAttributes) {
+    const environment = globalThis.process.env;
+    const version = environment.PR_LOG_RELEASE_VERSION;
+
+    if (version === undefined || version === '') {
+        throw new Error('PR_LOG_RELEASE_VERSION must be set to publish pr-log');
+    }
+
     return {
         name: 'pr-log',
-        versioning: { automatic: false, version: packageInfo.version },
+        versioning: { automatic: false, version },
         additionalFiles: [{ sourceFilePath: cliReadmePath, targetFilePath: 'README.md' }],
         roots: {
             cli: {
@@ -83,6 +96,7 @@ export async function buildConfig() {
     const sharedAttributes = sharedPackageAttributes(packageInfo);
 
     return {
+        registrySettings: registrySettings(),
         commonPackageSettings: commonPackageSettings(packageInfo),
         checks: {
             areTheTypesWrong: { enabled: true, profile: 'esm-only' },

--- a/source/packages/command-line-interface/composition.ts
+++ b/source/packages/command-line-interface/composition.ts
@@ -17,7 +17,7 @@ import {
 import { createJsonFileReader } from '../../lib/read-json-file.ts';
 import { createRemoteAliasReader } from '../../lib/remote-alias-reader.ts';
 import { createPrLogEngine, defaultValidLabels } from '../core/core.entry-point.ts';
-import { createPackageMetadata } from './package-metadata.ts';
+import { readPackageMetadata } from './package-metadata.ts';
 import { createErrorReporter } from './error-reporter.ts';
 import { createProgram } from './program.ts';
 
@@ -29,8 +29,14 @@ const readJsonFile = createJsonFileReader({
     }
 });
 
-const prLogPackageJsonURL = new URL('../../../../../package.json', import.meta.url);
-const packageMetadata = createPackageMetadata(await readJsonFile(prLogPackageJsonURL.pathname));
+const packageMetadata = await readPackageMetadata({
+    packageJsonUrls: [
+        new URL('../../package.json', import.meta.url),
+        new URL('../../../package.json', import.meta.url),
+        new URL('../../../../../package.json', import.meta.url)
+    ],
+    readJsonFile
+});
 
 const { GH_TOKEN } = process.env;
 const githubClient = new Octokit({ auth: GH_TOKEN });

--- a/source/packages/command-line-interface/package-metadata.test.ts
+++ b/source/packages/command-line-interface/package-metadata.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { createPackageMetadata } from './package-metadata.ts';
+import { createPackageMetadata, readPackageMetadata } from './package-metadata.ts';
 
 test('createPackageMetadata() reads string package fields', () => {
     const packageMetadata = createPackageMetadata({
@@ -27,4 +27,72 @@ test('createPackageMetadata() ignores non-string package fields', () => {
         description: '',
         version: ''
     });
+});
+
+test('readPackageMetadata() reads the first available package manifest', async () => {
+    const packageMetadata = await readPackageMetadata({
+        packageJsonUrls: [
+            new URL('file:///project/package/package.json'),
+            new URL('file:///project/source/package.json')
+        ],
+        async readJsonFile(filePath) {
+            if (filePath === '/project/package/package.json') {
+                return { name: 'pr-log', description: 'generated package', version: '9.9.9' };
+            }
+
+            throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+        }
+    });
+
+    assert.deepStrictEqual(packageMetadata, {
+        name: 'pr-log',
+        description: 'generated package',
+        version: '9.9.9'
+    });
+});
+
+test('readPackageMetadata() falls back when a package manifest is missing', async () => {
+    const packageMetadata = await readPackageMetadata({
+        packageJsonUrls: [
+            new URL('file:///project/package/package.json'),
+            new URL('file:///project/package/source/package.json')
+        ],
+        async readJsonFile(filePath) {
+            if (filePath === '/project/package/source/package.json') {
+                return { name: 'pr-log', description: 'source package', version: '1.2.3' };
+            }
+
+            throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+        }
+    });
+
+    assert.deepStrictEqual(packageMetadata, {
+        name: 'pr-log',
+        description: 'source package',
+        version: '1.2.3'
+    });
+});
+
+test('readPackageMetadata() rejects non-missing read errors', async () => {
+    await assert.rejects(
+        readPackageMetadata({
+            packageJsonUrls: [new URL('file:///project/package/package.json')],
+            async readJsonFile() {
+                throw new Error('failed');
+            }
+        }),
+        { message: 'failed' }
+    );
+});
+
+test('readPackageMetadata() rejects when all package manifests are missing', async () => {
+    await assert.rejects(
+        readPackageMetadata({
+            packageJsonUrls: [new URL('file:///project/package/package.json')],
+            async readJsonFile() {
+                throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+            }
+        }),
+        { message: 'Failed to read package metadata' }
+    );
 });

--- a/source/packages/command-line-interface/package-metadata.ts
+++ b/source/packages/command-line-interface/package-metadata.ts
@@ -6,6 +6,11 @@ export type PackageMetadata = {
     readonly version: string;
 };
 
+type PackageMetadataReader = {
+    readonly packageJsonUrls: readonly URL[];
+    readonly readJsonFile: (filePath: string) => Promise<Record<string, unknown>>;
+};
+
 function readStringValue(value: unknown): string {
     if (isString(value)) {
         return value;
@@ -20,4 +25,18 @@ export function createPackageMetadata(packageJson: Record<string, unknown>): Pac
         description: readStringValue(packageJson.description),
         version: readStringValue(packageJson.version)
     };
+}
+
+export async function readPackageMetadata(reader: PackageMetadataReader): Promise<PackageMetadata> {
+    for (const packageJsonUrl of reader.packageJsonUrls) {
+        try {
+            return createPackageMetadata(await reader.readJsonFile(packageJsonUrl.pathname));
+        } catch (error: unknown) {
+            if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) {
+                throw error;
+            }
+        }
+    }
+
+    throw new Error('Failed to read package metadata');
 }

--- a/source/release/prepare-release.sh
+++ b/source/release/prepare-release.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node --input-type=module <<'NODE'
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execaCommand } from 'execa';
+import { createPrLogEngine, defaultValidLabels } from './source/packages/core/core.entry-point.ts';
+import { getGithubRepoFromPackageInfo, getValidLabels } from './source/lib/package-info.ts';
+import { createJsonFileReader } from './source/lib/read-json-file.ts';
+import { splitByString } from './source/lib/split.ts';
+import { prepareRelease } from './source/release/prepare-release.ts';
+
+const releaseFolder = path.join(process.cwd(), 'target/release');
+const prLogVersionPath = path.join(releaseFolder, 'pr-log-version.txt');
+const coreReleaseMetadataPath = path.join(releaseFolder, 'core-release.json');
+const labelLookupIntervalMilliseconds = 250;
+const maximumRateLimitRetryCount = 3;
+
+function splitLines(value) {
+    return splitByString(value, '\n').filter((line) => {
+        return line !== '';
+    });
+}
+
+const readJsonFile = createJsonFileReader({
+    async readTextFile(filePath) {
+        return fs.readFile(filePath, { encoding: 'utf8' });
+    }
+});
+
+async function listTags() {
+    const { stdout } = await execaCommand('git tag --list');
+    return splitLines(stdout);
+}
+
+async function listTrackedFiles() {
+    const { stdout } = await execaCommand('git ls-files');
+    return splitLines(stdout);
+}
+
+async function prependChangelog(changelogPath, changelog) {
+    let existingChangelog = '';
+
+    try {
+        existingChangelog = await fs.readFile(changelogPath, { encoding: 'utf8' });
+    } catch (error) {
+        if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) {
+            throw error;
+        }
+    }
+
+    await fs.writeFile(changelogPath, `${changelog.trim()}\n\n${existingChangelog}`, { encoding: 'utf8' });
+}
+
+async function writeCoreReleaseMetadata(metadata) {
+    await fs.mkdir(releaseFolder, { recursive: true });
+    await fs.writeFile(coreReleaseMetadataPath, `${JSON.stringify(metadata, null, 4)}\n`, { encoding: 'utf8' });
+}
+
+async function writePrLogVersion(version) {
+    await fs.mkdir(releaseFolder, { recursive: true });
+    await fs.writeFile(prLogVersionPath, `${version}\n`, { encoding: 'utf8' });
+}
+
+const projectFolder = process.cwd();
+const packageInfo = await readJsonFile(path.join(projectFolder, 'package.json'));
+const githubRepo = getGithubRepoFromPackageInfo(packageInfo);
+const validLabels = getValidLabels(packageInfo, defaultValidLabels);
+const prLogEngine = createPrLogEngine({
+    githubToken: process.env.GH_TOKEN,
+    workingDirectory: projectFolder,
+    labelLookupIntervalMilliseconds,
+    maximumRateLimitRetryCount
+});
+
+await prepareRelease({
+    packageInfo,
+    githubRepo,
+    validLabels,
+    currentDate: new Date(),
+    tags: await listTags(),
+    trackedFiles: await listTrackedFiles(),
+    collectMergedPullRequests(input) {
+        return prLogEngine.collectMergedPullRequests(input);
+    },
+    resolvePullRequestLabels(input) {
+        return prLogEngine.resolvePullRequestLabels(input);
+    },
+    readPullRequestChangedFiles(input) {
+        return prLogEngine.readPullRequestChangedFiles(input);
+    },
+    renderChangelog(input) {
+        return prLogEngine.renderChangelog(input);
+    },
+    prependChangelog,
+    writePrLogVersion,
+    writeCoreReleaseMetadata
+});
+NODE

--- a/source/release/prepare-release.test.ts
+++ b/source/release/prepare-release.test.ts
@@ -1,0 +1,248 @@
+import assert from 'node:assert';
+import {
+    determineLatestPackageVersionTag,
+    filterTargetChangelogPullRequests,
+    formatPackageTag,
+    selectNextPatchVersion,
+    selectNextPrLogVersion,
+    selectReleaseTargetFiles,
+    type ReleaseTarget
+} from './release-plan.ts';
+import {
+    cliReleaseTarget,
+    coreReleaseTarget,
+    prepareRelease,
+    type CoreReleaseMetadata,
+    type ReleasePreparation
+} from './prepare-release.ts';
+
+const releaseTarget: ReleaseTarget = {
+    packageName: '@pr-log/core',
+    changelogPath: 'source/packages/core/CHANGELOG.md',
+    sourcePathPrefixes: ['source/core/', 'source/lib/'],
+    sourceFilePaths: ['package.json', 'packages/core/README.md'],
+    ignoredAttributionPaths: ['source/packages/core/CHANGELOG.md']
+};
+const cliPullRequestId = 1;
+const corePullRequestId = 2;
+const unrelatedPullRequestId = 3;
+
+function renderChangelogTitleList(input: Parameters<ReleasePreparation['renderChangelog']>[0]): string {
+    return `${input.versionNumber}:${input.mergedPullRequests
+        .map((pullRequest) => {
+            return pullRequest.title;
+        })
+        .join(',')}`;
+}
+
+function createChangedFilesByPullRequest(hasCoreChange: boolean): ReadonlyMap<number, readonly string[]> {
+    if (hasCoreChange) {
+        return new Map([
+            [corePullRequestId, ['source/core/pr-log-engine.ts']],
+            [unrelatedPullRequestId, ['packages/pr-log/README.md']]
+        ]);
+    }
+
+    return new Map([[corePullRequestId, ['packages/pr-log/README.md']]]);
+}
+
+function createReleasePreparation(options: {
+    readonly hasCoreChange: boolean;
+    readonly writes: string[];
+    readonly metadata: CoreReleaseMetadata[];
+    readonly resolvedTargets: (string | undefined)[];
+}): ReleasePreparation {
+    return {
+        packageInfo: {},
+        githubRepo: 'owner/repository',
+        validLabels: new Map([['bug', 'Bug Fixes']]),
+        currentDate: new Date('2026-06-15T00:00:00.000Z'),
+        tags: ['pr-log@1.0.0', '@pr-log/core@0.0.1'],
+        trackedFiles: ['source/core/pr-log-engine.ts'],
+        async collectMergedPullRequests(input) {
+            if (input.baseRef === 'pr-log@1.0.0') {
+                return [{ id: cliPullRequestId, title: 'Fix CLI' }];
+            }
+
+            if (options.hasCoreChange) {
+                return [
+                    { id: corePullRequestId, title: 'Fix core' },
+                    { id: unrelatedPullRequestId, title: 'Fix unrelated docs' }
+                ];
+            }
+
+            return [{ id: corePullRequestId, title: 'Fix docs' }];
+        },
+        async resolvePullRequestLabels(input) {
+            options.resolvedTargets.push(input.targetName);
+            return input.pullRequests.map((pullRequest) => {
+                return { ...pullRequest, label: 'bug' };
+            });
+        },
+        async readPullRequestChangedFiles() {
+            return createChangedFilesByPullRequest(options.hasCoreChange);
+        },
+        renderChangelog: renderChangelogTitleList,
+        async prependChangelog(changelogPath, changelog) {
+            options.writes.push(`${changelogPath}:${changelog}`);
+        },
+        async writePrLogVersion(version) {
+            options.writes.push(`version:${version}`);
+        },
+        async writeCoreReleaseMetadata(coreMetadata) {
+            options.metadata.push(coreMetadata);
+        }
+    };
+}
+
+test('determineLatestPackageVersionTag() reads the highest stable package tag', () => {
+    const latestTag = determineLatestPackageVersionTag(
+        ['pr-log@6.1.0', 'pr-log@6.2.0-alpha.1', '@pr-log/core@1.0.0', 'pr-log@6.2.0'],
+        'pr-log'
+    );
+
+    assert.deepStrictEqual(latestTag, { tagName: 'pr-log@6.2.0', version: '6.2.0' });
+});
+
+test('determineLatestPackageVersionTag() supports scoped package names', () => {
+    const latestTag = determineLatestPackageVersionTag(
+        ['@pr-log/core@0.0.2', '@pr-log/core@0.0.10', 'pr-log@6.2.0'],
+        '@pr-log/core'
+    );
+
+    assert.deepStrictEqual(latestTag, { tagName: '@pr-log/core@0.0.10', version: '0.0.10' });
+});
+
+test('determineLatestPackageVersionTag() rejects missing package tags', () => {
+    assert.throws(
+        () => {
+            determineLatestPackageVersionTag(['1.0.0', 'pr-log@invalid'], 'pr-log');
+        },
+        { message: 'Failed to determine latest "pr-log" git tag' }
+    );
+});
+
+test('selectNextPrLogVersion() uses configured bump labels', () => {
+    const version = selectNextPrLogVersion({
+        latestVersion: '6.2.0',
+        packageInfo: {
+            'pr-log': {
+                versionBumps: {
+                    major: ['breaking'],
+                    minor: ['feature'],
+                    patch: ['bug']
+                }
+            }
+        },
+        validLabels: new Map([
+            ['breaking', 'Breaking Changes'],
+            ['feature', 'Features'],
+            ['bug', 'Bug Fixes']
+        ]),
+        pullRequests: [
+            { id: 1, title: 'Fix bug', label: 'bug' },
+            { id: corePullRequestId, title: 'Add feature', label: 'feature' }
+        ]
+    });
+
+    assert.strictEqual(version, '6.3.0');
+});
+
+test('selectNextPatchVersion() increments a patch version', () => {
+    assert.strictEqual(selectNextPatchVersion('0.0.1'), '0.0.2');
+});
+
+test('selectNextPatchVersion() rejects invalid versions', () => {
+    assert.throws(
+        () => {
+            selectNextPatchVersion('invalid');
+        },
+        { message: 'Failed to increment version "invalid"' }
+    );
+});
+
+test('formatPackageTag() formats package-aware tags', () => {
+    assert.strictEqual(formatPackageTag('@pr-log/core', '0.0.2'), '@pr-log/core@0.0.2');
+});
+
+test('selectReleaseTargetFiles() keeps files owned by a release target', () => {
+    const files = selectReleaseTargetFiles(
+        [
+            'source/core/pr-log-engine.ts',
+            './source/lib/create-changelog.ts',
+            'packages/core/README.md',
+            'packages/pr-log/README.md'
+        ],
+        releaseTarget
+    );
+
+    assert.deepStrictEqual(files, [
+        'source/core/pr-log-engine.ts',
+        './source/lib/create-changelog.ts',
+        'packages/core/README.md'
+    ]);
+});
+
+test('filterTargetChangelogPullRequests() filters pull requests through target files', () => {
+    const pullRequests = [
+        { id: 1, title: 'Update core' },
+        { id: corePullRequestId, title: 'Update changelog' },
+        { id: unrelatedPullRequestId, title: 'Update CLI' }
+    ];
+    const targetSourceFiles = selectReleaseTargetFiles(
+        ['source/core/pr-log-engine.ts', 'source/packages/core/CHANGELOG.md', 'packages/core/README.md'],
+        releaseTarget
+    );
+    const filteredPullRequests = filterTargetChangelogPullRequests({
+        targetName: '@pr-log/core',
+        targetSourceFiles,
+        ignoredAttributionPaths: releaseTarget.ignoredAttributionPaths,
+        pullRequests,
+        changedFilesByPullRequest: new Map([
+            [1, ['source/core/pr-log-engine.ts']],
+            [corePullRequestId, ['source/packages/core/CHANGELOG.md']],
+            [unrelatedPullRequestId, ['source/packages/command-line-interface/program.ts']]
+        ])
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [{ id: 1, title: 'Update core' }]);
+});
+
+test('prepareRelease() writes pr-log metadata without a core release when core files did not change', async () => {
+    const writes: string[] = [];
+    const metadata: CoreReleaseMetadata[] = [];
+    const resolvedTargets: (string | undefined)[] = [];
+
+    await prepareRelease(createReleasePreparation({ hasCoreChange: false, writes, metadata, resolvedTargets }));
+
+    assert.deepStrictEqual(writes, [`${cliReleaseTarget.changelogPath}:1.0.1:Fix CLI`, 'version:1.0.1']);
+    assert.deepStrictEqual(metadata, [
+        {
+            type: 'no-release',
+            predictedVersion: '',
+            predictedTagName: ''
+        }
+    ]);
+});
+
+test('prepareRelease() writes core changelog and metadata when core files changed', async () => {
+    const writes: string[] = [];
+    const metadata: CoreReleaseMetadata[] = [];
+    const resolvedTargets: (string | undefined)[] = [];
+
+    await prepareRelease(createReleasePreparation({ hasCoreChange: true, writes, metadata, resolvedTargets }));
+
+    assert.deepStrictEqual(resolvedTargets, [undefined, coreReleaseTarget.packageName]);
+    assert.deepStrictEqual(writes, [
+        `${cliReleaseTarget.changelogPath}:1.0.1:Fix CLI`,
+        'version:1.0.1',
+        `${coreReleaseTarget.changelogPath}:0.0.2:Fix core`
+    ]);
+    assert.deepStrictEqual(metadata, [
+        {
+            type: 'predicted-release',
+            predictedVersion: '0.0.2',
+            predictedTagName: '@pr-log/core@0.0.2'
+        }
+    ]);
+});

--- a/source/release/prepare-release.ts
+++ b/source/release/prepare-release.ts
@@ -1,0 +1,199 @@
+import type { PullRequest, PullRequestWithLabel } from '../core/pr-log-engine.ts';
+import {
+    determineLatestPackageVersionTag,
+    filterTargetChangelogPullRequests,
+    formatPackageTag,
+    selectNextPatchVersion,
+    selectNextPrLogVersion,
+    selectReleaseTargetFiles,
+    type ReleaseTarget
+} from './release-plan.ts';
+
+type CoreNoReleaseMetadata = {
+    readonly type: 'no-release';
+    readonly predictedVersion: '';
+    readonly predictedTagName: '';
+};
+
+type CorePredictedReleaseMetadata = {
+    readonly type: 'predicted-release';
+    readonly predictedVersion: string;
+    readonly predictedTagName: string;
+};
+
+export type CoreReleaseMetadata = CoreNoReleaseMetadata | CorePredictedReleaseMetadata;
+
+export type ReleasePreparation = {
+    readonly packageInfo: Record<string, unknown>;
+    readonly githubRepo: string;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly currentDate: Readonly<Date>;
+    readonly tags: readonly string[];
+    readonly trackedFiles: readonly string[];
+    readonly collectMergedPullRequests: (input: {
+        readonly githubRepo: string;
+        readonly baseRef: string;
+    }) => Promise<readonly PullRequest[]>;
+    readonly resolvePullRequestLabels: (input: {
+        readonly githubRepo: string;
+        readonly validLabels: ReadonlyMap<string, string>;
+        readonly pullRequests: readonly PullRequest[];
+        readonly targetName: string | undefined;
+        readonly targetScopedLabelPattern: string | undefined;
+    }) => Promise<readonly PullRequestWithLabel[]>;
+    readonly readPullRequestChangedFiles: (input: {
+        readonly githubRepo: string;
+        readonly pullRequests: readonly PullRequest[];
+    }) => Promise<ReadonlyMap<number, readonly string[]>>;
+    readonly renderChangelog: (input: {
+        readonly packageInfo: Record<string, unknown>;
+        readonly currentDate: Readonly<Date>;
+        readonly validLabels: ReadonlyMap<string, string>;
+        readonly githubRepo: string;
+        readonly mergedPullRequests: readonly PullRequestWithLabel[];
+        readonly unreleased: false;
+        readonly versionNumber: string;
+    }) => string;
+    readonly prependChangelog: (changelogPath: string, changelog: string) => Promise<void>;
+    readonly writePrLogVersion: (version: string) => Promise<void>;
+    readonly writeCoreReleaseMetadata: (metadata: CoreReleaseMetadata) => Promise<void>;
+};
+
+export const cliReleaseTarget: ReleaseTarget = {
+    packageName: 'pr-log',
+    changelogPath: 'source/packages/command-line-interface/CHANGELOG.md',
+    sourcePathPrefixes: [
+        '.github/workflows/',
+        'source/core/',
+        'source/lib/',
+        'source/packages/command-line-interface/'
+    ],
+    sourceFilePaths: [
+        'README.md',
+        'justfile',
+        'package-lock.json',
+        'package.json',
+        'packages/pr-log/README.md',
+        'packtory.config.js'
+    ],
+    ignoredAttributionPaths: ['source/packages/command-line-interface/CHANGELOG.md']
+};
+
+export const coreReleaseTarget: ReleaseTarget = {
+    packageName: '@pr-log/core',
+    changelogPath: 'source/packages/core/CHANGELOG.md',
+    sourcePathPrefixes: ['.github/workflows/', 'source/core/', 'source/lib/', 'source/packages/core/'],
+    sourceFilePaths: [
+        'README.md',
+        'justfile',
+        'package-lock.json',
+        'package.json',
+        'packages/core/README.md',
+        'packtory.config.js'
+    ],
+    ignoredAttributionPaths: ['source/packages/core/CHANGELOG.md']
+};
+
+async function preparePrLogRelease(dependencies: ReleasePreparation): Promise<void> {
+    const latestCliTag = determineLatestPackageVersionTag(dependencies.tags, cliReleaseTarget.packageName);
+    const cliPullRequests = await dependencies.collectMergedPullRequests({
+        githubRepo: dependencies.githubRepo,
+        baseRef: latestCliTag.tagName
+    });
+    const labeledCliPullRequests = await dependencies.resolvePullRequestLabels({
+        githubRepo: dependencies.githubRepo,
+        validLabels: dependencies.validLabels,
+        pullRequests: cliPullRequests,
+        targetName: undefined,
+        targetScopedLabelPattern: undefined
+    });
+    const nextPrLogVersion = selectNextPrLogVersion({
+        latestVersion: latestCliTag.version,
+        packageInfo: dependencies.packageInfo,
+        validLabels: dependencies.validLabels,
+        pullRequests: labeledCliPullRequests
+    });
+
+    await dependencies.prependChangelog(
+        cliReleaseTarget.changelogPath,
+        dependencies.renderChangelog({
+            packageInfo: dependencies.packageInfo,
+            currentDate: dependencies.currentDate,
+            validLabels: dependencies.validLabels,
+            githubRepo: dependencies.githubRepo,
+            mergedPullRequests: labeledCliPullRequests,
+            unreleased: false,
+            versionNumber: nextPrLogVersion
+        })
+    );
+    await dependencies.writePrLogVersion(nextPrLogVersion);
+}
+
+async function readCoreTargetPullRequests(dependencies: ReleasePreparation): Promise<{
+    readonly latestCoreVersion: string;
+    readonly pullRequests: readonly PullRequest[];
+}> {
+    const latestCoreTag = determineLatestPackageVersionTag(dependencies.tags, coreReleaseTarget.packageName);
+    const corePullRequests = await dependencies.collectMergedPullRequests({
+        githubRepo: dependencies.githubRepo,
+        baseRef: latestCoreTag.tagName
+    });
+    const changedFilesByPullRequest = await dependencies.readPullRequestChangedFiles({
+        githubRepo: dependencies.githubRepo,
+        pullRequests: corePullRequests
+    });
+    const coreTargetPullRequests = filterTargetChangelogPullRequests({
+        targetName: coreReleaseTarget.packageName,
+        targetSourceFiles: selectReleaseTargetFiles(dependencies.trackedFiles, coreReleaseTarget),
+        ignoredAttributionPaths: coreReleaseTarget.ignoredAttributionPaths,
+        pullRequests: corePullRequests,
+        changedFilesByPullRequest
+    });
+
+    return { latestCoreVersion: latestCoreTag.version, pullRequests: coreTargetPullRequests };
+}
+
+async function prepareCoreRelease(dependencies: ReleasePreparation): Promise<void> {
+    const coreTargetPullRequests = await readCoreTargetPullRequests(dependencies);
+
+    if (coreTargetPullRequests.pullRequests.length === 0) {
+        await dependencies.writeCoreReleaseMetadata({
+            type: 'no-release',
+            predictedVersion: '',
+            predictedTagName: ''
+        });
+        return;
+    }
+
+    const labeledCorePullRequests = await dependencies.resolvePullRequestLabels({
+        githubRepo: dependencies.githubRepo,
+        validLabels: dependencies.validLabels,
+        pullRequests: coreTargetPullRequests.pullRequests,
+        targetName: coreReleaseTarget.packageName,
+        targetScopedLabelPattern: undefined
+    });
+    const predictedCoreVersion = selectNextPatchVersion(coreTargetPullRequests.latestCoreVersion);
+
+    await dependencies.prependChangelog(
+        coreReleaseTarget.changelogPath,
+        dependencies.renderChangelog({
+            packageInfo: dependencies.packageInfo,
+            currentDate: dependencies.currentDate,
+            validLabels: dependencies.validLabels,
+            githubRepo: dependencies.githubRepo,
+            mergedPullRequests: labeledCorePullRequests,
+            unreleased: false,
+            versionNumber: predictedCoreVersion
+        })
+    );
+    await dependencies.writeCoreReleaseMetadata({
+        type: 'predicted-release',
+        predictedVersion: predictedCoreVersion,
+        predictedTagName: formatPackageTag(coreReleaseTarget.packageName, predictedCoreVersion)
+    });
+}
+
+export async function prepareRelease(dependencies: ReleasePreparation): Promise<void> {
+    await preparePrLogRelease(dependencies);
+    await prepareCoreRelease(dependencies);
+}

--- a/source/release/release-plan.ts
+++ b/source/release/release-plan.ts
@@ -1,0 +1,125 @@
+import semver from 'semver';
+import { getVersionBumpConfig } from '../lib/version-bump-config.ts';
+import { proposeVersionNumber } from '../lib/propose-version-number.ts';
+import { filterPullRequestsByTargetFiles } from '../lib/filter-pull-requests-by-target-files.ts';
+import type { PullRequest, PullRequestWithLabel } from '../core/pr-log-engine.ts';
+
+export type PackageVersionTag = {
+    readonly tagName: string;
+    readonly version: string;
+};
+
+export type ReleaseTarget = {
+    readonly packageName: string;
+    readonly changelogPath: string;
+    readonly sourcePathPrefixes: readonly string[];
+    readonly sourceFilePaths: readonly string[];
+    readonly ignoredAttributionPaths: readonly string[];
+};
+
+type ReleaseTargetInput = {
+    readonly targetName: string;
+    readonly targetSourceFiles: readonly string[];
+    readonly ignoredAttributionPaths: readonly string[];
+    readonly pullRequests: readonly PullRequest[];
+    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly string[]>;
+};
+
+function normalizeRepositoryPath(filePath: string): string {
+    return filePath.replaceAll('\\', '/').replace(/^\.?\//u, '');
+}
+
+function isStableVersion(version: string): boolean {
+    return semver.valid(version) !== null && semver.prerelease(version) === null;
+}
+
+function toPackageVersionTag(packageName: string, tagName: string): PackageVersionTag | undefined {
+    const tagPrefix = `${packageName}@`;
+
+    if (!tagName.startsWith(tagPrefix)) {
+        return undefined;
+    }
+
+    const version = tagName.slice(tagPrefix.length);
+
+    if (!isStableVersion(version)) {
+        return undefined;
+    }
+
+    return { tagName, version };
+}
+
+function isPackageVersionTag(value: PackageVersionTag | undefined): value is PackageVersionTag {
+    return value !== undefined;
+}
+
+export function formatPackageTag(packageName: string, version: string): string {
+    return `${packageName}@${version}`;
+}
+
+export function determineLatestPackageVersionTag(tags: readonly string[], packageName: string): PackageVersionTag {
+    const packageTags = tags
+        .map((tagName) => {
+            return toPackageVersionTag(packageName, tagName);
+        })
+        .filter(isPackageVersionTag)
+        .toSorted((left, right) => {
+            return semver.rcompare(left.version, right.version);
+        });
+    const latestPackageTag = packageTags[0];
+
+    if (latestPackageTag === undefined) {
+        throw new TypeError(`Failed to determine latest "${packageName}" git tag`);
+    }
+
+    return latestPackageTag;
+}
+
+export function selectNextPrLogVersion(input: {
+    readonly latestVersion: string;
+    readonly packageInfo: Record<string, unknown>;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly pullRequests: readonly PullRequestWithLabel[];
+}): string {
+    return proposeVersionNumber(
+        input.latestVersion,
+        input.pullRequests,
+        getVersionBumpConfig(input.packageInfo, input.validLabels)
+    );
+}
+
+export function selectNextPatchVersion(version: string): string {
+    const nextVersion = semver.inc(version, 'patch');
+
+    if (nextVersion === null) {
+        throw new TypeError(`Failed to increment version "${version}"`);
+    }
+
+    return nextVersion;
+}
+
+export function selectReleaseTargetFiles(files: readonly string[], target: ReleaseTarget): readonly string[] {
+    const sourceFilePaths = new Set(target.sourceFilePaths.map(normalizeRepositoryPath));
+    const sourcePathPrefixes = target.sourcePathPrefixes.map(normalizeRepositoryPath);
+
+    return files.filter((filePath) => {
+        const normalizedFilePath = normalizeRepositoryPath(filePath);
+
+        return (
+            sourceFilePaths.has(normalizedFilePath) ||
+            sourcePathPrefixes.some((sourcePathPrefix) => {
+                return normalizedFilePath.startsWith(sourcePathPrefix);
+            })
+        );
+    });
+}
+
+export function filterTargetChangelogPullRequests(input: ReleaseTargetInput): readonly PullRequest[] {
+    return filterPullRequestsByTargetFiles({
+        targetName: input.targetName,
+        targetSourceFiles: input.targetSourceFiles,
+        pullRequests: input.pullRequests,
+        changedFilesByPullRequest: input.changedFilesByPullRequest,
+        ignoredAttributionPaths: input.ignoredAttributionPaths
+    });
+}


### PR DESCRIPTION
This adds a manual `Prepare release` workflow that derives release metadata from tags and labels, writes changelogs with a verified GitHub API commit, and dispatches CI to publish after checks pass. Publishing now uses `PR_LOG_RELEASE_VERSION`, npm OIDC, and Packtory provenance, while README publishing instructions are removed because the workflow is the release path.