### PR TITLE
Fix `@pr-log/core` minimum version

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -45,7 +45,7 @@ function registrySettings() {
 function corePackage(sharedAttributes) {
     return {
         name: '@pr-log/core',
-        versioning: { automatic: true, minimumVersion: '0.1.0' },
+        versioning: { automatic: true, minimumVersion: '0.0.1' },
         additionalFiles: [{ sourceFilePath: coreReadmePath, targetFilePath: 'README.md' }],
         roots: {
             main: {


### PR DESCRIPTION
This restores the Packtory automatic version floor for `@pr-log/core` to `0.0.1`, matching the currently published npm version so the next changed package dry run resolves to `0.0.2`.