### PR TITLE
Add `pr-log.ignoredLabels` changelog filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
         "type": "git",
         "url": "https://github.com/lo1tuma/pr-log.git"
     },
+    "pr-log": {
+        "ignoredLabels": [
+            "release"
+        ]
+    },
     "keywords": [
         "pr-log",
         "changelog",

--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -190,6 +190,7 @@ test('resolves pull request labels', async () => {
         await engine.resolvePullRequestLabels({
             githubRepo,
             validLabels: defaultValidLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: pullRequestId, title: 'Fix bug' }],
             targetName: undefined,
             targetScopedLabelPattern: undefined
@@ -207,6 +208,7 @@ test('resolves target scoped pull request labels', async () => {
         await engine.resolvePullRequestLabels({
             githubRepo,
             validLabels: defaultValidLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: pullRequestId, title: 'Fix bug' }],
             targetName: 'pkg-a',
             targetScopedLabelPattern: undefined

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -56,6 +56,7 @@ export type ReadPullRequestLabelsOptions = {
 export type ResolvePullRequestLabelsOptions = {
     readonly githubRepo: string;
     readonly validLabels: ReadonlyMap<string, string>;
+    readonly ignoredLabels: readonly string[];
     readonly pullRequests: readonly PullRequestValue[];
     readonly targetName: string | undefined;
     readonly targetScopedLabelPattern: string | undefined;
@@ -198,6 +199,7 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
             return resolvePullRequestLabelsValue({
                 githubRepo: input.githubRepo,
                 validLabels: input.validLabels,
+                ignoredLabels: input.ignoredLabels,
                 pullRequests: input.pullRequests,
                 pullRequestLabelReader: createPullRequestLabelReader(dependencies),
                 waitForMilliseconds: dependencies.waitForMilliseconds,

--- a/source/lib/cli.test.ts
+++ b/source/lib/cli.test.ts
@@ -176,7 +176,7 @@ test('uses custom labels if they are provided in package.json', async () => {
     await cli.run(cliRunOptionsFactory.build());
 
     assert.strictEqual(getMergedPullRequests.callCount, 1);
-    assert.deepStrictEqual(getMergedPullRequests.firstCall.args, ['foo/bar', expectedLabels]);
+    assert.deepStrictEqual(getMergedPullRequests.firstCall.args, ['foo/bar', expectedLabels, []]);
 
     assert.strictEqual(renderChangelogMarkdown.callCount, 1);
     assert.deepStrictEqual(renderChangelogMarkdown.firstCall.args[0], {
@@ -188,6 +188,21 @@ test('uses custom labels if they are provided in package.json', async () => {
         unreleased: false,
         versionNumber: '1.2.3'
     });
+});
+
+test('passes configured ignored labels to merged pull request collection', async () => {
+    const packageInfo = {
+        repository: { url: 'https://github.com/foo/bar.git' },
+        'pr-log': {
+            ignoredLabels: ['release']
+        }
+    };
+    const getMergedPullRequests = stub().resolves([]);
+    const cli = createCli({ packageInfo, getMergedPullRequests });
+
+    await cli.run(cliRunOptionsFactory.build());
+
+    assert.deepStrictEqual(getMergedPullRequests.firstCall.args, ['foo/bar', defaultValidLabels, ['release']]);
 });
 
 test('calls ensureCleanLocalGitState with correct parameters', async () => {

--- a/source/lib/cli.ts
+++ b/source/lib/cli.ts
@@ -3,7 +3,7 @@ import type { Logger } from 'loglevel';
 import type { CliRunOptions } from './cli-run-options.ts';
 import type { GetMergedPullRequests } from './get-merged-pull-requests.ts';
 import type { EnsureCleanLocalGitState } from './ensure-clean-local-git-state.ts';
-import { getGithubRepoFromPackageInfo, getValidLabels } from './package-info.ts';
+import { getGithubRepoFromPackageInfo, getIgnoredLabels, getValidLabels } from './package-info.ts';
 import { type GetLatestVersionTag, resolveReleasedVersionNumber } from './resolve-version-number.ts';
 import { validateVersionNumber } from './version-number.ts';
 import type { renderChangelogMarkdown } from './render-changelog-markdown.ts';
@@ -50,6 +50,12 @@ type ChangelogData = {
 };
 
 type WriteChangelogContext = Pick<CliRunnerDependencies, 'logger' | 'prependFile'>;
+
+type ChangelogRequest = {
+    readonly githubRepo: string;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly ignoredLabels: readonly string[];
+};
 
 async function ensureCleanState(
     ensureCleanLocalGitState: EnsureCleanLocalGitState,
@@ -111,8 +117,7 @@ async function generateReleasedChangelog(
 async function generateChangelog(
     dependencies: GenerateChangelogContext,
     options: CliRunOptions,
-    githubRepo: string,
-    validLabels: ReadonlyMap<string, string>
+    request: ChangelogRequest
 ): Promise<string> {
     const {
         ensureCleanLocalGitState,
@@ -123,12 +128,12 @@ async function generateChangelog(
         renderChangelogMarkdown
     } = dependencies;
 
-    await ensureCleanState(ensureCleanLocalGitState, options, githubRepo);
+    await ensureCleanState(ensureCleanLocalGitState, options, request.githubRepo);
 
     const changelogData: ChangelogData = {
-        githubRepo,
-        validLabels,
-        mergedPullRequests: await getMergedPullRequests(githubRepo, validLabels)
+        githubRepo: request.githubRepo,
+        validLabels: request.validLabels,
+        mergedPullRequests: await getMergedPullRequests(request.githubRepo, request.validLabels, request.ignoredLabels)
     };
 
     if (options.unreleased) {
@@ -164,12 +169,17 @@ export function createCliRunner(dependencies: CliRunnerDependencies): CliRunner 
         async run(options: CliRunOptions) {
             const githubRepo = getGithubRepoFromPackageInfo(packageInfo);
             const validLabels = getValidLabels(packageInfo, defaultValidLabels);
+            const ignoredLabels = getIgnoredLabels(packageInfo);
 
             validateVersionNumber(options).unwrapOrElse((error) => {
                 throw error;
             });
 
-            const changelog = await generateChangelog(dependencies, options, githubRepo, validLabels);
+            const changelog = await generateChangelog(dependencies, options, {
+                githubRepo,
+                validLabels,
+                ignoredLabels
+            });
 
             await writeChangelog(dependencies, changelog, options);
         }

--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -94,7 +94,7 @@ test('throws when there is no tag at all', async () => {
     const listTags = fake.resolves([]);
     const getMergedPullRequests = factory({ listTags });
 
-    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
+    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels, []), {
         message: 'Failed to determine latest version number git tag'
     });
 });
@@ -103,7 +103,7 @@ test('throws when there are only non-semver tags', async () => {
     const listTags = fake.resolves(['foo', 'bar']);
     const getMergedPullRequests = factory({ listTags });
 
-    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
+    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels, []), {
         message: 'Failed to determine latest version number git tag'
     });
 });
@@ -113,7 +113,7 @@ test('ignores non-semver tag', async () => {
     const getFirstParentCommitLogs = fake.resolves([]);
     const getMergedPullRequests = factory({ listTags, getFirstParentCommitLogs });
 
-    await getMergedPullRequests(anyRepo, defaultValidLabels);
+    await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
     assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, ['0.0.2']);
@@ -124,7 +124,7 @@ test('always uses the highest version', async () => {
     const getFirstParentCommitLogs = fake.resolves([]);
     const getMergedPullRequests = factory({ listTags, getFirstParentCommitLogs });
 
-    await getMergedPullRequests(anyRepo, defaultValidLabels);
+    await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
     assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, ['2.0.0']);
@@ -135,7 +135,7 @@ test('ignores prerelease versions', async () => {
     const getFirstParentCommitLogs = fake.resolves([]);
     const getMergedPullRequests = factory({ listTags, getFirstParentCommitLogs });
 
-    await getMergedPullRequests(anyRepo, defaultValidLabels);
+    await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
     assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, ['2.0.0']);
@@ -151,7 +151,7 @@ test('throws when the pull request cannot be extracted from the commit message',
     ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs });
 
-    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
+    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels, []), {
         message: 'Failed to extract pull request id from merge commit log'
     });
 });
@@ -168,7 +168,7 @@ test('falls back to the GitHub API when the commit log does not have a body', as
     ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, githubClient });
 
-    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(get.callCount, 1);
     assert.deepStrictEqual(get.firstCall.args, [{ owner: 'any', repo: 'repo', pull_number: 1 }]);
@@ -190,7 +190,7 @@ test('throws when the title is missing in the commit log and the GitHub API requ
     ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, githubClient });
 
-    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels), {
+    await assert.rejects(getMergedPullRequests(anyRepo, defaultValidLabels, []), {
         message: 'GitHub API failed'
     });
 });
@@ -205,7 +205,7 @@ test('throws when the title is missing in the commit log and the repo is invalid
     ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs });
 
-    await assert.rejects(getMergedPullRequests('invalid-repo', defaultValidLabels), {
+    await assert.rejects(getMergedPullRequests('invalid-repo', defaultValidLabels, []), {
         message: 'Could not find a repository'
     });
 });
@@ -224,7 +224,7 @@ test('extracts id, title and label for merged pull requests', async () => {
     ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
 
-    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(getPullRequestLabels.callCount, expectedPullRequestLabelCallCount);
     assert.deepStrictEqual(getPullRequestLabels.firstCall.args.slice(0, comparedArgumentCount), [
@@ -249,7 +249,7 @@ test('looks up pull request labels sequentially', async () => {
     ]);
     const { getPullRequestLabels, firstLabelLookupStarted, resolveFirstLabelLookup } = createControlledLabelLookup();
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
-    const mergedPullRequests = getMergedPullRequests(anyRepo, defaultValidLabels);
+    const mergedPullRequests = getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     await firstLabelLookupStarted;
 
@@ -289,7 +289,7 @@ test('waits between pull request label lookups', async () => {
         labelLookupIntervalMilliseconds
     });
 
-    await getMergedPullRequests(anyRepo, defaultValidLabels);
+    await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(waitForMilliseconds.callCount, expectedWaitForMillisecondsCallCount);
     assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [labelLookupIntervalMilliseconds]);
@@ -304,7 +304,7 @@ test('ignores first-parent commits that are not merge commits', async () => {
     const getPullRequestLabels = fake.resolves(['bug']);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
 
-    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(getPullRequestLabels.callCount, 1);
     assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'pr-1 message', label: 'bug' }]);
@@ -328,7 +328,7 @@ test('ignores merge commits that were reverted later', async () => {
     const getPullRequestLabels = fake.resolves(['bug']);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
 
-    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(getPullRequestLabels.callCount, 1);
     assert.deepStrictEqual(getPullRequestLabels.firstCall.args.slice(0, comparedArgumentCount), [
@@ -357,7 +357,7 @@ test('includes a merge commit again when its revert was reverted later', async (
     const getPullRequestLabels = fake.resolves(['bug']);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
 
-    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.strictEqual(getPullRequestLabels.callCount, 1);
     assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'pr-1 message', label: 'bug' }]);
@@ -376,7 +376,7 @@ test('includes a revert commit when the reverted merge was already released', as
     const getPullRequestLabels = fake.resolves(['bug']);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels, githubClient });
 
-    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels);
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultValidLabels, []);
 
     assert.deepStrictEqual(get.firstCall.args, [{ owner: 'any', repo: 'repo', pull_number: 1 }]);
     assert.strictEqual(getPullRequestLabels.callCount, 1);

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -27,7 +27,8 @@ export type GetMergedPullRequestsDependencies = {
 
 export type GetMergedPullRequests = (
     repo: string,
-    validLabels: ReadonlyMap<string, string>
+    validLabels: ReadonlyMap<string, string>,
+    ignoredLabels: readonly string[]
 ) => Promise<readonly PullRequestWithLabel[]>;
 
 type PullRequestData = Readonly<Awaited<ReturnType<Octokit['pulls']['get']>>['data']>;
@@ -86,12 +87,17 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
         });
     }
 
-    return async function getMergedPullRequests(githubRepo: string, validLabels: ReadonlyMap<string, string>) {
+    return async function getMergedPullRequests(
+        githubRepo: string,
+        validLabels: ReadonlyMap<string, string>,
+        ignoredLabels: readonly string[]
+    ) {
         const latestVersionTag = await getLatestVersionTag();
         const pullRequests = await getPullRequests(latestVersionTag, githubRepo);
         const pullRequestsWithLabels = await resolvePullRequestLabels({
             githubRepo,
             validLabels,
+            ignoredLabels,
             pullRequests,
             waitForMilliseconds,
             labelLookupIntervalMilliseconds,

--- a/source/lib/package-info.test.ts
+++ b/source/lib/package-info.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert';
+import { getIgnoredLabels } from './package-info.ts';
+
+test('reads ignored labels from package info', () => {
+    assert.deepStrictEqual(
+        getIgnoredLabels({
+            'pr-log': {
+                ignoredLabels: ['release']
+            }
+        }),
+        ['release']
+    );
+});
+
+test('falls back to no ignored labels', () => {
+    assert.deepStrictEqual(getIgnoredLabels({}), []);
+});
+
+test('rejects ignored labels that are not an array', () => {
+    assert.throws(
+        () => {
+            getIgnoredLabels({
+                'pr-log': {
+                    ignoredLabels: 'release'
+                }
+            });
+        },
+        { message: 'pr-log.ignoredLabels must be an array of strings' }
+    );
+});
+
+test('rejects ignored label entries that are not strings', () => {
+    assert.throws(
+        () => {
+            getIgnoredLabels({
+                'pr-log': {
+                    ignoredLabels: ['release', 1]
+                }
+            });
+        },
+        { message: 'pr-log.ignoredLabels must be an array of strings' }
+    );
+});

--- a/source/lib/package-info.ts
+++ b/source/lib/package-info.ts
@@ -1,4 +1,4 @@
-import { isPlainObject, isString } from '@sindresorhus/is';
+import { isArray, isPlainObject, isString } from '@sindresorhus/is';
 import { getGithubRepo } from './get-github-repo.ts';
 
 type PackageInfo = Record<string, unknown>;
@@ -28,4 +28,30 @@ export function getValidLabels(
     }
 
     return defaultValidLabels;
+}
+
+function readStringArrayConfig(packageInfo: PackageInfo, fieldName: string): readonly string[] {
+    const prLogConfig = packageInfo['pr-log'];
+
+    if (!isPlainObject(prLogConfig) || prLogConfig[fieldName] === undefined) {
+        return [];
+    }
+
+    const value = prLogConfig[fieldName];
+
+    if (!isArray(value)) {
+        throw new TypeError(`pr-log.${fieldName} must be an array of strings`);
+    }
+
+    return value.map((entry) => {
+        if (!isString(entry)) {
+            throw new TypeError(`pr-log.${fieldName} must be an array of strings`);
+        }
+
+        return entry;
+    });
+}
+
+export function getIgnoredLabels(packageInfo: PackageInfo): readonly string[] {
+    return readStringArrayConfig(packageInfo, 'ignoredLabels');
 }

--- a/source/lib/pr-log-engine-cli-adapter.test.ts
+++ b/source/lib/pr-log-engine-cli-adapter.test.ts
@@ -54,7 +54,7 @@ test('createMergedPullRequestReader() collects pull requests from the latest bas
         targetScopedLabelPattern: undefined
     });
 
-    const result = await getMergedPullRequests('owner/repository', validLabels);
+    const result = await getMergedPullRequests('owner/repository', validLabels, []);
 
     assert.deepStrictEqual(result, [{ id: 1, title: 'Fix bug', label: 'bug' }]);
     assert.deepStrictEqual(collectMergedPullRequests.firstCall.args, [
@@ -64,6 +64,7 @@ test('createMergedPullRequestReader() collects pull requests from the latest bas
         {
             githubRepo: 'owner/repository',
             validLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: 1, title: 'Fix bug' }],
             targetName: undefined,
             targetScopedLabelPattern: undefined

--- a/source/lib/pr-log-engine-cli-adapter.ts
+++ b/source/lib/pr-log-engine-cli-adapter.ts
@@ -26,13 +26,14 @@ export function createMergedPullRequestReader(
     prLogEngine: MergedPullRequestReaderEngine,
     options: MergedPullRequestReaderOptions
 ): GetMergedPullRequests {
-    return async function getMergedPullRequests(githubRepo, validLabels) {
+    return async function getMergedPullRequests(githubRepo, validLabels, ignoredLabels) {
         const baseRef = await prLogEngine.resolveLatestSemverChangelogBaseRef();
         const pullRequests = await prLogEngine.collectMergedPullRequests({ githubRepo, baseRef: baseRef.ref });
 
         return prLogEngine.resolvePullRequestLabels({
             githubRepo,
             validLabels,
+            ignoredLabels,
             pullRequests,
             targetName: options.targetName,
             targetScopedLabelPattern: options.targetScopedLabelPattern

--- a/source/lib/resolve-pull-request-labels.test.ts
+++ b/source/lib/resolve-pull-request-labels.test.ts
@@ -15,6 +15,7 @@ test('resolves labels for pull requests sequentially', async () => {
     const pullRequests = await resolvePullRequestLabels({
         githubRepo: 'owner/repo',
         validLabels: defaultValidLabels,
+        ignoredLabels: [],
         pullRequests: [
             { id: 1, title: 'Fix bug' },
             { id: secondPullRequestId, title: 'Update docs' }
@@ -38,6 +39,7 @@ test('applies target scoped labels over pull request level labels', async () => 
     const pullRequests = await resolvePullRequestLabels({
         githubRepo: 'owner/repo',
         validLabels: defaultValidLabels,
+        ignoredLabels: [],
         pullRequests: [{ id: 1, title: 'Fix bug' }],
         pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking']) },
         waitForMilliseconds: fake.resolves(undefined),
@@ -53,6 +55,7 @@ test('ignores raw labels that are not valid labels', async () => {
     const pullRequests = await resolvePullRequestLabels({
         githubRepo: 'owner/repo',
         validLabels: defaultValidLabels,
+        ignoredLabels: [],
         pullRequests: [{ id: 1, title: 'Fix bug' }],
         pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'not-for-changelog']) },
         waitForMilliseconds: fake.resolves(undefined),
@@ -69,6 +72,7 @@ test('rejects missing pull request level labels', async () => {
         resolvePullRequestLabels({
             githubRepo: 'owner/repo',
             validLabels: defaultValidLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: 1, title: 'Fix bug' }],
             pullRequestLabelReader: { getLabels: fake.resolves(['not-for-changelog']) },
             waitForMilliseconds: fake.resolves(undefined),
@@ -88,6 +92,7 @@ test('rejects multiple pull request level labels', async () => {
         resolvePullRequestLabels({
             githubRepo: 'owner/repo',
             validLabels: defaultValidLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: 1, title: 'Fix bug' }],
             pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'documentation']) },
             waitForMilliseconds: fake.resolves(undefined),
@@ -106,6 +111,7 @@ test('ignores scoped labels for other targets', async () => {
     const pullRequests = await resolvePullRequestLabels({
         githubRepo: 'owner/repo',
         validLabels: defaultValidLabels,
+        ignoredLabels: [],
         pullRequests: [{ id: 1, title: 'Fix bug' }],
         pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking']) },
         waitForMilliseconds: fake.resolves(undefined),
@@ -122,6 +128,7 @@ test('rejects conflicting target scoped labels', async () => {
         resolvePullRequestLabels({
             githubRepo: 'owner/repo',
             validLabels: defaultValidLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: 1, title: 'Fix bug' }],
             pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:breaking', 'pkg-a:feature']) },
             waitForMilliseconds: fake.resolves(undefined),
@@ -138,6 +145,7 @@ test('rejects unknown target scoped labels', async () => {
         resolvePullRequestLabels({
             githubRepo: 'owner/repo',
             validLabels: defaultValidLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: 1, title: 'Fix bug' }],
             pullRequestLabelReader: { getLabels: fake.resolves(['bug', 'pkg-a:not-real']) },
             waitForMilliseconds: fake.resolves(undefined),
@@ -153,6 +161,7 @@ test('supports scoped package names in target labels', async () => {
     const pullRequests = await resolvePullRequestLabels({
         githubRepo: 'owner/repo',
         validLabels: defaultValidLabels,
+        ignoredLabels: [],
         pullRequests: [{ id: 1, title: 'Fix bug' }],
         pullRequestLabelReader: { getLabels: fake.resolves(['bug', '@scope/pkg:documentation']) },
         waitForMilliseconds: fake.resolves(undefined),
@@ -162,4 +171,20 @@ test('supports scoped package names in target labels', async () => {
     });
 
     assert.deepStrictEqual(pullRequests, [{ id: 1, title: 'Fix bug', label: 'documentation' }]);
+});
+
+test('skips ignored pull requests before changelog label validation', async () => {
+    const pullRequests = await resolvePullRequestLabels({
+        githubRepo: 'owner/repo',
+        validLabels: defaultValidLabels,
+        ignoredLabels: ['release'],
+        pullRequests: [{ id: 1, title: 'Prepare release' }],
+        pullRequestLabelReader: { getLabels: fake.resolves(['release']) },
+        waitForMilliseconds: fake.resolves(undefined),
+        labelLookupIntervalMilliseconds: 0,
+        targetName: undefined,
+        targetScopedLabelPattern: undefined
+    });
+
+    assert.deepStrictEqual(pullRequests, []);
 });

--- a/source/lib/resolve-pull-request-labels.ts
+++ b/source/lib/resolve-pull-request-labels.ts
@@ -11,6 +11,7 @@ export type PullRequestLabelReader = {
 export type ResolvePullRequestLabelsInput = {
     readonly githubRepo: string;
     readonly validLabels: ReadonlyMap<string, string>;
+    readonly ignoredLabels: readonly string[];
     readonly pullRequests: readonly PullRequest[];
     readonly pullRequestLabelReader: PullRequestLabelReader;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
@@ -115,24 +116,46 @@ function resolveLabel(
     );
 }
 
+function hasIgnoredLabel(labels: readonly string[], ignoredLabels: ReadonlySet<string>): boolean {
+    return labels.some((label) => {
+        return ignoredLabels.has(label);
+    });
+}
+
+async function resolvePullRequestLabel(
+    input: ResolvePullRequestLabelsInput,
+    ignoredLabels: ReadonlySet<string>,
+    pullRequest: PullRequest
+): Promise<PullRequestWithLabel | undefined> {
+    const labels = await input.pullRequestLabelReader.getLabels(input.githubRepo, pullRequest.id);
+
+    if (hasIgnoredLabel(labels, ignoredLabels)) {
+        return undefined;
+    }
+
+    return {
+        id: pullRequest.id,
+        title: pullRequest.title,
+        label: resolveLabel(input, pullRequest, labels)
+    };
+}
+
 export async function resolvePullRequestLabels(
     input: ResolvePullRequestLabelsInput
 ): Promise<readonly PullRequestWithLabel[]> {
     const pullRequestsWithLabels: PullRequestWithLabel[] = [];
+    const ignoredLabels = new Set(input.ignoredLabels);
 
     for (const [pullRequestIndex, pullRequest] of input.pullRequests.entries()) {
         if (pullRequestIndex > 0 && input.labelLookupIntervalMilliseconds > 0) {
             await input.waitForMilliseconds(input.labelLookupIntervalMilliseconds);
         }
 
-        const labels = await input.pullRequestLabelReader.getLabels(input.githubRepo, pullRequest.id);
-        const label = resolveLabel(input, pullRequest, labels);
+        const pullRequestWithLabel = await resolvePullRequestLabel(input, ignoredLabels, pullRequest);
 
-        pullRequestsWithLabels.push({
-            id: pullRequest.id,
-            title: pullRequest.title,
-            label
-        });
+        if (pullRequestWithLabel !== undefined) {
+            pullRequestsWithLabels.push(pullRequestWithLabel);
+        }
     }
 
     return pullRequestsWithLabels;

--- a/source/release/prepare-release.sh
+++ b/source/release/prepare-release.sh
@@ -6,7 +6,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execaCommand } from 'execa';
 import { createPrLogEngine, defaultValidLabels } from './source/packages/core/core.entry-point.ts';
-import { getGithubRepoFromPackageInfo, getValidLabels } from './source/lib/package-info.ts';
+import { getGithubRepoFromPackageInfo, getIgnoredLabels, getValidLabels } from './source/lib/package-info.ts';
 import { createJsonFileReader } from './source/lib/read-json-file.ts';
 import { splitByString } from './source/lib/split.ts';
 import { prepareRelease } from './source/release/prepare-release.ts';
@@ -67,6 +67,7 @@ const projectFolder = process.cwd();
 const packageInfo = await readJsonFile(path.join(projectFolder, 'package.json'));
 const githubRepo = getGithubRepoFromPackageInfo(packageInfo);
 const validLabels = getValidLabels(packageInfo, defaultValidLabels);
+const ignoredLabels = getIgnoredLabels(packageInfo);
 const prLogEngine = createPrLogEngine({
     githubToken: process.env.GH_TOKEN,
     workingDirectory: projectFolder,
@@ -78,6 +79,7 @@ await prepareRelease({
     packageInfo,
     githubRepo,
     validLabels,
+    ignoredLabels,
     currentDate: new Date(),
     tags: await listTags(),
     trackedFiles: await listTrackedFiles(),

--- a/source/release/prepare-release.test.ts
+++ b/source/release/prepare-release.test.ts
@@ -46,8 +46,52 @@ function createChangedFilesByPullRequest(hasCoreChange: boolean): ReadonlyMap<nu
     return new Map([[corePullRequestId, ['packages/pr-log/README.md']]]);
 }
 
+function createMergedPullRequestCollector(options: {
+    readonly hasCoreChange: boolean;
+    readonly ignoredPrLogRelease: boolean;
+}) {
+    return async function collectMergedPullRequests(input: { readonly baseRef: string }) {
+        if (input.baseRef === 'pr-log@1.0.0') {
+            if (options.ignoredPrLogRelease) {
+                return [{ id: cliPullRequestId, title: 'Prepare release' }];
+            }
+
+            return [{ id: cliPullRequestId, title: 'Fix CLI' }];
+        }
+
+        if (options.hasCoreChange) {
+            return [
+                { id: corePullRequestId, title: 'Fix core' },
+                { id: unrelatedPullRequestId, title: 'Fix unrelated docs' }
+            ];
+        }
+
+        return [{ id: corePullRequestId, title: 'Fix docs' }];
+    };
+}
+
+function createPullRequestLabelResolver(options: {
+    readonly ignoredPrLogRelease: boolean;
+    readonly resolvedTargets: (string | undefined)[];
+}) {
+    return async function resolvePullRequestLabels(
+        input: Parameters<ReleasePreparation['resolvePullRequestLabels']>[0]
+    ) {
+        options.resolvedTargets.push(input.targetName);
+
+        if (options.ignoredPrLogRelease) {
+            return [];
+        }
+
+        return input.pullRequests.map((pullRequest) => {
+            return { ...pullRequest, label: 'bug' };
+        });
+    };
+}
+
 function createReleasePreparation(options: {
     readonly hasCoreChange: boolean;
+    readonly ignoredPrLogRelease: boolean;
     readonly writes: string[];
     readonly metadata: CoreReleaseMetadata[];
     readonly resolvedTargets: (string | undefined)[];
@@ -56,29 +100,12 @@ function createReleasePreparation(options: {
         packageInfo: {},
         githubRepo: 'owner/repository',
         validLabels: new Map([['bug', 'Bug Fixes']]),
+        ignoredLabels: ['release'],
         currentDate: new Date('2026-06-15T00:00:00.000Z'),
         tags: ['pr-log@1.0.0', '@pr-log/core@0.0.1'],
         trackedFiles: ['source/core/pr-log-engine.ts'],
-        async collectMergedPullRequests(input) {
-            if (input.baseRef === 'pr-log@1.0.0') {
-                return [{ id: cliPullRequestId, title: 'Fix CLI' }];
-            }
-
-            if (options.hasCoreChange) {
-                return [
-                    { id: corePullRequestId, title: 'Fix core' },
-                    { id: unrelatedPullRequestId, title: 'Fix unrelated docs' }
-                ];
-            }
-
-            return [{ id: corePullRequestId, title: 'Fix docs' }];
-        },
-        async resolvePullRequestLabels(input) {
-            options.resolvedTargets.push(input.targetName);
-            return input.pullRequests.map((pullRequest) => {
-                return { ...pullRequest, label: 'bug' };
-            });
-        },
+        collectMergedPullRequests: createMergedPullRequestCollector(options),
+        resolvePullRequestLabels: createPullRequestLabelResolver(options),
         async readPullRequestChangedFiles() {
             return createChangedFilesByPullRequest(options.hasCoreChange);
         },
@@ -213,7 +240,15 @@ test('prepareRelease() writes pr-log metadata without a core release when core f
     const metadata: CoreReleaseMetadata[] = [];
     const resolvedTargets: (string | undefined)[] = [];
 
-    await prepareRelease(createReleasePreparation({ hasCoreChange: false, writes, metadata, resolvedTargets }));
+    await prepareRelease(
+        createReleasePreparation({
+            hasCoreChange: false,
+            ignoredPrLogRelease: false,
+            writes,
+            metadata,
+            resolvedTargets
+        })
+    );
 
     assert.deepStrictEqual(writes, [`${cliReleaseTarget.changelogPath}:1.0.1:Fix CLI`, 'version:1.0.1']);
     assert.deepStrictEqual(metadata, [
@@ -230,7 +265,9 @@ test('prepareRelease() writes core changelog and metadata when core files change
     const metadata: CoreReleaseMetadata[] = [];
     const resolvedTargets: (string | undefined)[] = [];
 
-    await prepareRelease(createReleasePreparation({ hasCoreChange: true, writes, metadata, resolvedTargets }));
+    await prepareRelease(
+        createReleasePreparation({ hasCoreChange: true, ignoredPrLogRelease: false, writes, metadata, resolvedTargets })
+    );
 
     assert.deepStrictEqual(resolvedTargets, [undefined, coreReleaseTarget.packageName]);
     assert.deepStrictEqual(writes, [
@@ -243,6 +280,26 @@ test('prepareRelease() writes core changelog and metadata when core files change
             type: 'predicted-release',
             predictedVersion: '0.0.2',
             predictedTagName: '@pr-log/core@0.0.2'
+        }
+    ]);
+});
+
+test('prepareRelease() produces no new release content when only ignored release pull requests changed', async () => {
+    const writes: string[] = [];
+    const metadata: CoreReleaseMetadata[] = [];
+    const resolvedTargets: (string | undefined)[] = [];
+
+    await prepareRelease(
+        createReleasePreparation({ hasCoreChange: true, ignoredPrLogRelease: true, writes, metadata, resolvedTargets })
+    );
+
+    assert.deepStrictEqual(resolvedTargets, [undefined]);
+    assert.deepStrictEqual(writes, []);
+    assert.deepStrictEqual(metadata, [
+        {
+            type: 'no-release',
+            predictedVersion: '',
+            predictedTagName: ''
         }
     ]);
 });

--- a/source/release/prepare-release.ts
+++ b/source/release/prepare-release.ts
@@ -27,6 +27,7 @@ export type ReleasePreparation = {
     readonly packageInfo: Record<string, unknown>;
     readonly githubRepo: string;
     readonly validLabels: ReadonlyMap<string, string>;
+    readonly ignoredLabels: readonly string[];
     readonly currentDate: Readonly<Date>;
     readonly tags: readonly string[];
     readonly trackedFiles: readonly string[];
@@ -37,6 +38,7 @@ export type ReleasePreparation = {
     readonly resolvePullRequestLabels: (input: {
         readonly githubRepo: string;
         readonly validLabels: ReadonlyMap<string, string>;
+        readonly ignoredLabels: readonly string[];
         readonly pullRequests: readonly PullRequest[];
         readonly targetName: string | undefined;
         readonly targetScopedLabelPattern: string | undefined;
@@ -94,7 +96,7 @@ export const coreReleaseTarget: ReleaseTarget = {
     ignoredAttributionPaths: ['source/packages/core/CHANGELOG.md']
 };
 
-async function preparePrLogRelease(dependencies: ReleasePreparation): Promise<void> {
+async function preparePrLogRelease(dependencies: ReleasePreparation): Promise<boolean> {
     const latestCliTag = determineLatestPackageVersionTag(dependencies.tags, cliReleaseTarget.packageName);
     const cliPullRequests = await dependencies.collectMergedPullRequests({
         githubRepo: dependencies.githubRepo,
@@ -103,10 +105,16 @@ async function preparePrLogRelease(dependencies: ReleasePreparation): Promise<vo
     const labeledCliPullRequests = await dependencies.resolvePullRequestLabels({
         githubRepo: dependencies.githubRepo,
         validLabels: dependencies.validLabels,
+        ignoredLabels: dependencies.ignoredLabels,
         pullRequests: cliPullRequests,
         targetName: undefined,
         targetScopedLabelPattern: undefined
     });
+
+    if (labeledCliPullRequests.length === 0) {
+        return false;
+    }
+
     const nextPrLogVersion = selectNextPrLogVersion({
         latestVersion: latestCliTag.version,
         packageInfo: dependencies.packageInfo,
@@ -127,6 +135,8 @@ async function preparePrLogRelease(dependencies: ReleasePreparation): Promise<vo
         })
     );
     await dependencies.writePrLogVersion(nextPrLogVersion);
+
+    return true;
 }
 
 async function readCoreTargetPullRequests(dependencies: ReleasePreparation): Promise<{
@@ -168,6 +178,7 @@ async function prepareCoreRelease(dependencies: ReleasePreparation): Promise<voi
     const labeledCorePullRequests = await dependencies.resolvePullRequestLabels({
         githubRepo: dependencies.githubRepo,
         validLabels: dependencies.validLabels,
+        ignoredLabels: dependencies.ignoredLabels,
         pullRequests: coreTargetPullRequests.pullRequests,
         targetName: coreReleaseTarget.packageName,
         targetScopedLabelPattern: undefined
@@ -194,6 +205,14 @@ async function prepareCoreRelease(dependencies: ReleasePreparation): Promise<voi
 }
 
 export async function prepareRelease(dependencies: ReleasePreparation): Promise<void> {
-    await preparePrLogRelease(dependencies);
+    if (!(await preparePrLogRelease(dependencies))) {
+        await dependencies.writeCoreReleaseMetadata({
+            type: 'no-release',
+            predictedVersion: '',
+            predictedTagName: ''
+        });
+        return;
+    }
+
     await prepareCoreRelease(dependencies);
 }


### PR DESCRIPTION
Adds `pr-log.ignoredLabels` so configured labels are excluded before changelog label resolution. Configures this repository to ignore `release`, including release preparation no-op behavior when only ignored release PRs remain.