### PR TITLE
Wait for `release/pr-log` workflow runs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -180,27 +180,38 @@ jobs:
                   }
 
                   async function approveReleasePullRequestWorkflowRuns(commitSha) {
-                      const response = await githubApi(
-                          `/repos/${repository}/actions/runs?branch=${encodeURIComponent(releaseBranch)}&event=pull_request&per_page=100`
-                      );
-                      const gatedRuns = response.workflow_runs.filter((run) => {
-                          return (
-                              run.head_branch === releaseBranch &&
-                              run.head_sha === commitSha &&
-                              run.event === 'pull_request' &&
-                              run.conclusion === 'action_required'
+                      for (let attempt = 1; attempt <= 12; attempt += 1) {
+                          const response = await githubApi(
+                              `/repos/${repository}/actions/runs?branch=${encodeURIComponent(releaseBranch)}&event=pull_request&per_page=100`
                           );
-                      });
+                          const gatedRuns = response.workflow_runs.filter((run) => {
+                              return (
+                                  run.head_branch === releaseBranch &&
+                                  run.head_sha === commitSha &&
+                                  run.event === 'pull_request' &&
+                                  run.conclusion === 'action_required'
+                              );
+                          });
 
-                      await Promise.all(
-                          gatedRuns.map((run) => {
-                              return githubApi(`/repos/${repository}/actions/runs/${run.id}/approve`, {
-                                  method: 'POST'
-                              });
-                          })
-                      );
+                          if (gatedRuns.length > 0) {
+                              await Promise.all(
+                                  gatedRuns.map((run) => {
+                                      return githubApi(`/repos/${repository}/actions/runs/${run.id}/approve`, {
+                                          method: 'POST'
+                                      });
+                                  })
+                              );
 
-                      console.log(`Approved ${gatedRuns.length} release pull request workflow run(s)`);
+                              console.log(`Approved ${gatedRuns.length} release pull request workflow run(s)`);
+                              return;
+                          }
+
+                          await new Promise((resolve) => {
+                              setTimeout(resolve, 5000);
+                          });
+                      }
+
+                      throw new Error(`No release pull request workflow runs required approval for ${commitSha}`);
                   }
 
                   async function closeReleasePullRequests() {


### PR DESCRIPTION
Waits briefly for GitHub to create `action_required` pull request workflow runs after updating `release/pr-log`, then approves those runs for the exact release commit SHA. This fixes the first attempt approving zero runs before GitHub had created them.