### PR TITLE
Remove `release/pr-log` workflow approval attempt

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -179,41 +179,6 @@ jobs:
                       );
                   }
 
-                  async function approveReleasePullRequestWorkflowRuns(commitSha) {
-                      for (let attempt = 1; attempt <= 12; attempt += 1) {
-                          const response = await githubApi(
-                              `/repos/${repository}/actions/runs?branch=${encodeURIComponent(releaseBranch)}&event=pull_request&per_page=100`
-                          );
-                          const gatedRuns = response.workflow_runs.filter((run) => {
-                              return (
-                                  run.head_branch === releaseBranch &&
-                                  run.head_sha === commitSha &&
-                                  run.event === 'pull_request' &&
-                                  run.conclusion === 'action_required'
-                              );
-                          });
-
-                          if (gatedRuns.length > 0) {
-                              await Promise.all(
-                                  gatedRuns.map((run) => {
-                                      return githubApi(`/repos/${repository}/actions/runs/${run.id}/approve`, {
-                                          method: 'POST'
-                                      });
-                                  })
-                              );
-
-                              console.log(`Approved ${gatedRuns.length} release pull request workflow run(s)`);
-                              return;
-                          }
-
-                          await new Promise((resolve) => {
-                              setTimeout(resolve, 5000);
-                          });
-                      }
-
-                      throw new Error(`No release pull request workflow runs required approval for ${commitSha}`);
-                  }
-
                   async function closeReleasePullRequests() {
                       const pullRequests = await listOpenReleasePullRequests();
 
@@ -312,7 +277,6 @@ jobs:
                           method: 'POST',
                           body: JSON.stringify({ ref: releaseBranch })
                       });
-                      await approveReleasePullRequestWorkflowRuns(commitSha);
 
                       console.log(`Release PR #${pullRequest.number} points at ${commitSha}`);
                   }


### PR DESCRIPTION
Removes the failed `GITHUB_TOKEN` workflow approval attempt. GitHub rejects the approval endpoint for these generated same-repository release PR runs with `This run is not from a fork pull request`, so keeping the call makes `main` fail during release PR maintenance.