### PR TITLE
Add `release/pr-log` check-run proof

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,6 +79,7 @@ jobs:
             cancel-in-progress: false
         permissions:
             actions: write
+            checks: write
             contents: write
             issues: write
             pull-requests: write
@@ -179,6 +180,22 @@ jobs:
                       );
                   }
 
+                  async function createReleasePullRequestProofCheck(commitSha) {
+                      await githubApi(`/repos/${repository}/check-runs`, {
+                          method: 'POST',
+                          body: JSON.stringify({
+                              name: 'Release PR workflow proof',
+                              head_sha: commitSha,
+                              status: 'completed',
+                              conclusion: 'success',
+                              output: {
+                                  title: 'Release PR workflow proof',
+                                  summary: 'Created by release PR maintenance to verify whether explicit check runs attach to the release PR.'
+                              }
+                          })
+                      });
+                  }
+
                   async function closeReleasePullRequests() {
                       const pullRequests = await listOpenReleasePullRequests();
 
@@ -277,6 +294,7 @@ jobs:
                           method: 'POST',
                           body: JSON.stringify({ ref: releaseBranch })
                       });
+                      await createReleasePullRequestProofCheck(commitSha);
 
                       console.log(`Release PR #${pullRequest.number} points at ${commitSha}`);
                   }


### PR DESCRIPTION
Adds one non-required `Release PR workflow proof` check-run on the generated release commit after `release/pr-log` is updated. This verifies whether explicit Checks API runs created with `GITHUB_TOKEN` attach to the generated release PR check rollup.