### PR TITLE
Fix package repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/lo1tuma/pr-log.git"
+        "url": "https://github.com/enormora/pr-log.git"
     },
     "pr-log": {
         "ignoredLabels": [


### PR DESCRIPTION
Updates the package repository metadata to match the CI repository used for npm provenance. Packtory rejects provenance when the package repository points at the old `lo1tuma/pr-log` repository.