### PR TITLE
Automerge all Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,21 +3,16 @@
     "commitMessagePrefix": "⬆️ ",
     "labels": ["renovate", "upgrade"],
     "rebaseStalePrs": true,
+    "automerge": true,
+    "automergeType": "branch",
     "dependencyDashboard": false,
     "lockFileMaintenance": {
-        "enabled": true,
-        "automerge": true
+        "enabled": true
     },
     "packageRules": [
         {
             "matchPackagePatterns": ["^@enormora/eslint-config", "^eslint$"],
             "groupName": "eslint"
-        },
-        {
-            "depTypeList": ["dependencies", "devDependencies"],
-            "updateTypes": ["minor", "patch"],
-            "automerge": true,
-            "automergeType": "branch"
         }
     ]
 }


### PR DESCRIPTION
Moves `automerge` and `automergeType` to the top-level Renovate config so major dependency updates use the same branch automerge behavior as minor and patch updates.

Keeps the existing `eslint` grouping and lockfile maintenance enabled.