### PR TITLE
Pin Renovate `npm` artifact updates to `10.9.8`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
     "automerge": true,
     "automergeType": "branch",
     "dependencyDashboard": false,
+    "constraints": {
+        "npm": "10.9.8"
+    },
     "lockFileMaintenance": {
         "enabled": true
     },


### PR DESCRIPTION
Configure Renovate to generate npm artifacts with `npm` `10.9.8`, matching the installer used by the Node 22 CI job. This prevents lockfile updates that pass newer npm versions but fail `npm clean-install` in the matrix.