### PR TITLE
Update `@packtory/cli` to `0.0.42`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@enormora/eslint-config-mocha": "0.0.26",
                 "@enormora/eslint-config-node": "0.0.26",
                 "@enormora/eslint-config-typescript": "0.0.36",
-                "@packtory/cli": "0.0.41",
+                "@packtory/cli": "0.0.42",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.1",
@@ -1920,9 +1920,9 @@
             "license": "MIT"
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.41",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.41.tgz",
-            "integrity": "sha512-a4O11VhmvQELCeXyqlUEvKQ+bYE8+EkOqXiFF/RZMN9xBSdhA+sHWGiDTqVbP9+aLJQtKysl6MXL2ac5Ch7hXA==",
+            "version": "0.0.42",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.42.tgz",
+            "integrity": "sha512-wM3b3TtcQE3YFoxYLEEkxEGRA4qfA2EWaUUBALpRpHzStXu6QFEKC+N7jC+WXvHrhgkcj5N7HhndkXbuxGNzaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1932,7 +1932,7 @@
                 "cmd-ts": "0.15.0",
                 "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.41",
+                "packtory": "0.0.42",
                 "remeda": "2.39.0",
                 "ts-pattern": "5.9.0",
                 "yoctocolors": "2.1.2"
@@ -7945,9 +7945,9 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/packtory": {
-            "version": "0.0.41",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.41.tgz",
-            "integrity": "sha512-pc2Mi3dpCccC8YQ/nzdkhRMj2QE3KJhs5Tld65WI1er30Z9gkki0hX2C8joknfr6nbfdJ2jzXtCV0rNv8B4eow==",
+            "version": "0.0.42",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.42.tgz",
+            "integrity": "sha512-Kszb7yNNYNDGSW1YCD4LzYOueiJRLlFXhAWQcWdmxjeXsGcCajwUBMhNwClIids09SAsLeaH+Lt2yRgbCXqZpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@enormora/eslint-config-mocha": "0.0.26",
         "@enormora/eslint-config-node": "0.0.26",
         "@enormora/eslint-config-typescript": "0.0.36",
-        "@packtory/cli": "0.0.41",
+        "@packtory/cli": "0.0.42",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.1",


### PR DESCRIPTION
Updates Packtory to `0.0.42` so generated SBOM tool metadata no longer makes `@pr-log/core` look changed. Local `publish-dry-run` now reports `@pr-log/core` as unchanged, but `prepare-release` still fails because `pr-log` is planned as a version-only release with no attributed changelog entries.