### PR TITLE
Filter `pr-log` release version by package sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@enormora/eslint-config-mocha": "0.0.26",
                 "@enormora/eslint-config-node": "0.0.26",
                 "@enormora/eslint-config-typescript": "0.0.36",
-                "@packtory/cli": "0.0.42",
+                "@packtory/cli": "0.0.43",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.1",
@@ -1920,9 +1920,9 @@
             "license": "MIT"
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.42",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.42.tgz",
-            "integrity": "sha512-wM3b3TtcQE3YFoxYLEEkxEGRA4qfA2EWaUUBALpRpHzStXu6QFEKC+N7jC+WXvHrhgkcj5N7HhndkXbuxGNzaw==",
+            "version": "0.0.43",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.43.tgz",
+            "integrity": "sha512-4a7VoappF9oMaK9AYn9UMWPNpsy7RQh5ASbAgqyIp21Do8xvbcaNCNSFn8QPawY7GbHCf4FjDFjoK1TrwFpGxQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1932,7 +1932,7 @@
                 "cmd-ts": "0.15.0",
                 "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.42",
+                "packtory": "0.0.43",
                 "remeda": "2.39.0",
                 "ts-pattern": "5.9.0",
                 "yoctocolors": "2.1.2"
@@ -7945,9 +7945,9 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/packtory": {
-            "version": "0.0.42",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.42.tgz",
-            "integrity": "sha512-Kszb7yNNYNDGSW1YCD4LzYOueiJRLlFXhAWQcWdmxjeXsGcCajwUBMhNwClIids09SAsLeaH+Lt2yRgbCXqZpQ==",
+            "version": "0.0.43",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.43.tgz",
+            "integrity": "sha512-XnJwIOkzarO0rz53SM7D3/jtiQGeZiwODKRCz/ptzDTFRKfMpO47tkPS2wYXMMTcoSEAS89Eb7YaAT4IOg6O9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@enormora/eslint-config-mocha": "0.0.26",
         "@enormora/eslint-config-node": "0.0.26",
         "@enormora/eslint-config-typescript": "0.0.36",
-        "@packtory/cli": "0.0.42",
+        "@packtory/cli": "0.0.43",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.1",

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -60,7 +60,7 @@ async function listTags() {
     return splitLines(stdout);
 }
 
-async function readPrLogVersion(packageInfo) {
+async function readPrLogVersion(packageInfo, versionInput) {
     const environment = globalThis.process.env;
     const githubRepo = getGithubRepoFromPackageInfo(packageInfo);
     const validLabels = getValidLabels(packageInfo, defaultValidLabels);
@@ -74,12 +74,21 @@ async function readPrLogVersion(packageInfo) {
 
     return resolvePrLogReleaseVersion({
         tags: await listTags(),
+        currentVersion: versionInput.currentVersion,
         packageInfo,
         githubRepo,
         validLabels,
         ignoredLabels,
+        targetSourceFiles: versionInput.targetSourceFiles,
+        ignoredAttributionPaths: versionInput.ignoredAttributionPaths,
         collectMergedPullRequests(input) {
             return prLogEngine.collectMergedPullRequests(input);
+        },
+        readPullRequestChangedFiles(input) {
+            return prLogEngine.readPullRequestChangedFiles(input);
+        },
+        filterPullRequestsByTargetFiles(input) {
+            return prLogEngine.filterPullRequestsByTargetFiles(input);
         },
         resolvePullRequestLabels(input) {
             return prLogEngine.resolvePullRequestLabels(input);
@@ -106,10 +115,15 @@ function corePackage(sharedAttributes) {
     };
 }
 
-function cliPackage(packageInfo, sharedAttributes, version) {
+function cliPackage(packageInfo, sharedAttributes) {
     return {
         name: 'pr-log',
-        versioning: { automatic: false, version },
+        versioning: {
+            automatic: false,
+            provideVersion(input) {
+                return readPrLogVersion(packageInfo, input);
+            }
+        },
         additionalFiles: [{ sourceFilePath: cliReadmePath, targetFilePath: 'README.md' }],
         roots: {
             cli: {
@@ -132,7 +146,6 @@ function cliPackage(packageInfo, sharedAttributes, version) {
 export async function buildConfig() {
     const packageInfo = await readPackageInfo();
     const sharedAttributes = sharedPackageAttributes(packageInfo);
-    const prLogVersion = await readPrLogVersion(packageInfo);
 
     return {
         registrySettings: registrySettings(),
@@ -160,6 +173,6 @@ export async function buildConfig() {
             uniqueTargetPaths: { enabled: true },
             noSideEffects: { enabled: false }
         },
-        packages: [corePackage(sharedAttributes), cliPackage(packageInfo, sharedAttributes, prLogVersion)]
+        packages: [corePackage(sharedAttributes), cliPackage(packageInfo, sharedAttributes)]
     };
 }

--- a/source/release/pr-log-release-version.test.ts
+++ b/source/release/pr-log-release-version.test.ts
@@ -1,12 +1,20 @@
 import assert from 'node:assert';
+import { filterPullRequestsByTargetFiles } from '../lib/filter-pull-requests-by-target-files.ts';
 import { resolvePrLogReleaseVersion, type PrLogReleaseVersionInput } from './pr-log-release-version.ts';
 
+const bugPullRequestId = 1;
+const featurePullRequestId = 2;
+const targetSourceFiles = ['source/packages/command-line-interface/program.ts', 'source/lib/create-changelog.ts'];
+
 function createInput(options: {
+    readonly currentVersion: string | undefined;
     readonly resolvedLabels: readonly string[];
     readonly collectedBaseRefs: string[];
+    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly string[]>;
 }): PrLogReleaseVersionInput {
     return {
         tags: ['pr-log@1.0.0'],
+        currentVersion: options.currentVersion,
         packageInfo: {
             'pr-log': {
                 versionBumps: {
@@ -23,13 +31,19 @@ function createInput(options: {
             ['bug', 'Bug Fixes']
         ]),
         ignoredLabels: ['release'],
+        targetSourceFiles,
+        ignoredAttributionPaths: [],
         async collectMergedPullRequests(input) {
             options.collectedBaseRefs.push(input.baseRef);
             return [
-                { id: 1, title: 'Fix bug' },
-                { id: 2, title: 'Add feature' }
+                { id: bugPullRequestId, title: 'Fix bug' },
+                { id: featurePullRequestId, title: 'Add feature' }
             ];
         },
+        async readPullRequestChangedFiles() {
+            return options.changedFilesByPullRequest;
+        },
+        filterPullRequestsByTargetFiles,
         async resolvePullRequestLabels(input) {
             return options.resolvedLabels.map((label, index) => {
                 const pullRequest = input.pullRequests[index];
@@ -44,7 +58,15 @@ function createInput(options: {
 test('resolvePrLogReleaseVersion() selects the next label-based version', async () => {
     const collectedBaseRefs: string[] = [];
     const version = await resolvePrLogReleaseVersion(
-        createInput({ resolvedLabels: ['bug', 'feature'], collectedBaseRefs })
+        createInput({
+            currentVersion: '1.0.0',
+            resolvedLabels: ['bug', 'feature'],
+            collectedBaseRefs,
+            changedFilesByPullRequest: new Map([
+                [bugPullRequestId, ['source/packages/command-line-interface/program.ts']],
+                [featurePullRequestId, ['source/lib/create-changelog.ts']]
+            ])
+        })
     );
 
     assert.strictEqual(version, '1.1.0');
@@ -52,7 +74,46 @@ test('resolvePrLogReleaseVersion() selects the next label-based version', async 
 });
 
 test('resolvePrLogReleaseVersion() keeps the latest version when all pull requests are ignored', async () => {
-    const version = await resolvePrLogReleaseVersion(createInput({ resolvedLabels: [], collectedBaseRefs: [] }));
+    const version = await resolvePrLogReleaseVersion(
+        createInput({
+            currentVersion: undefined,
+            resolvedLabels: [],
+            collectedBaseRefs: [],
+            changedFilesByPullRequest: new Map([
+                [bugPullRequestId, ['source/packages/command-line-interface/program.ts']],
+                [featurePullRequestId, ['source/lib/create-changelog.ts']]
+            ])
+        })
+    );
+
+    assert.strictEqual(version, '1.0.0');
+});
+
+test('resolvePrLogReleaseVersion() keeps the latest version when pull requests miss package sources', async () => {
+    const version = await resolvePrLogReleaseVersion(
+        createInput({
+            currentVersion: '1.0.0',
+            resolvedLabels: [],
+            collectedBaseRefs: [],
+            changedFilesByPullRequest: new Map([
+                [bugPullRequestId, ['.github/workflows/continuous-integration.yml']],
+                [featurePullRequestId, ['packtory.config.js', 'package-lock.json']]
+            ])
+        })
+    );
+
+    assert.strictEqual(version, '1.0.0');
+});
+
+test('resolvePrLogReleaseVersion() keeps the latest version when pull request files are missing', async () => {
+    const version = await resolvePrLogReleaseVersion(
+        createInput({
+            currentVersion: '1.0.0',
+            resolvedLabels: [],
+            collectedBaseRefs: [],
+            changedFilesByPullRequest: new Map([[bugPullRequestId, ['.github/workflows/continuous-integration.yml']]])
+        })
+    );
 
     assert.strictEqual(version, '1.0.0');
 });

--- a/source/release/pr-log-release-version.ts
+++ b/source/release/pr-log-release-version.ts
@@ -1,16 +1,30 @@
 import type { PullRequest, PullRequestWithLabel } from '../core/pr-log-engine.ts';
-import { determineLatestPackageVersionTag, selectNextPrLogVersion } from './release-plan.ts';
+import type { FilterPullRequestsByTargetFilesInput } from '../lib/filter-pull-requests-by-target-files.ts';
+import {
+    determineLatestPackageVersionTag,
+    formatPackageTag,
+    type PackageVersionTag,
+    selectNextPrLogVersion
+} from './release-plan.ts';
 
 export type PrLogReleaseVersionInput = {
     readonly tags: readonly string[];
+    readonly currentVersion: string | undefined;
     readonly packageInfo: Record<string, unknown>;
     readonly githubRepo: string;
     readonly validLabels: ReadonlyMap<string, string>;
     readonly ignoredLabels: readonly string[];
+    readonly targetSourceFiles: readonly string[];
+    readonly ignoredAttributionPaths: readonly string[];
     readonly collectMergedPullRequests: (input: {
         readonly githubRepo: string;
         readonly baseRef: string;
     }) => Promise<readonly PullRequest[]>;
+    readonly readPullRequestChangedFiles: (input: {
+        readonly githubRepo: string;
+        readonly pullRequests: readonly PullRequest[];
+    }) => Promise<ReadonlyMap<number, readonly string[]>>;
+    readonly filterPullRequestsByTargetFiles: (input: FilterPullRequestsByTargetFilesInput) => readonly PullRequest[];
     readonly resolvePullRequestLabels: (input: {
         readonly githubRepo: string;
         readonly validLabels: ReadonlyMap<string, string>;
@@ -21,17 +35,39 @@ export type PrLogReleaseVersionInput = {
     }) => Promise<readonly PullRequestWithLabel[]>;
 };
 
+function determineReleaseBase(input: Pick<PrLogReleaseVersionInput, 'currentVersion' | 'tags'>): PackageVersionTag {
+    if (input.currentVersion !== undefined) {
+        return {
+            tagName: formatPackageTag('pr-log', input.currentVersion),
+            version: input.currentVersion
+        };
+    }
+
+    return determineLatestPackageVersionTag(input.tags, 'pr-log');
+}
+
 export async function resolvePrLogReleaseVersion(input: PrLogReleaseVersionInput): Promise<string> {
-    const latestTag = determineLatestPackageVersionTag(input.tags, 'pr-log');
+    const latestTag = determineReleaseBase(input);
     const pullRequests = await input.collectMergedPullRequests({
         githubRepo: input.githubRepo,
         baseRef: latestTag.tagName
+    });
+    const changedFilesByPullRequest = await input.readPullRequestChangedFiles({
+        githubRepo: input.githubRepo,
+        pullRequests
+    });
+    const targetPullRequests = input.filterPullRequestsByTargetFiles({
+        targetName: 'pr-log',
+        targetSourceFiles: input.targetSourceFiles,
+        pullRequests,
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: input.ignoredAttributionPaths
     });
     const labeledPullRequests = await input.resolvePullRequestLabels({
         githubRepo: input.githubRepo,
         validLabels: input.validLabels,
         ignoredLabels: input.ignoredLabels,
-        pullRequests,
+        pullRequests: targetPullRequests,
         targetName: undefined,
         targetScopedLabelPattern: undefined
     });


### PR DESCRIPTION
Use Packtory `0.0.43` and its `provideVersion` callback for the manual `pr-log` package version. The callback reuses Packtory-provided attribution files with pr-log label-based versioning, so release-tooling and lockfile-only changes no longer force a version-only CLI release.