### PR TITLE
Add `validate-pull-request-labels` command

### DIFF
--- a/packages/pr-log/README.md
+++ b/packages/pr-log/README.md
@@ -154,6 +154,14 @@ Example:
 - Fix some spelling mistakes in documentation. (#22)
 ```
 
+To validate labels on a single pull request, run:
+
+```sh
+pr-log validate-pull-request-labels 123
+```
+
+This command uses the same `pr-log` label configuration as changelog generation, including custom `validLabels` and `ignoredLabels`.
+
 ## Options
 
 ### `--sloppy`

--- a/source/lib/validate-pull-request-labels.test.ts
+++ b/source/lib/validate-pull-request-labels.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert';
+import { fake } from 'sinon';
+import { createPullRequestLabelValidator } from './validate-pull-request-labels.ts';
+import { defaultValidLabels } from './valid-labels.ts';
+
+const pullRequestId = 123;
+
+test('validates pull request labels with package configuration', async () => {
+    const validLabels = new Map([['custom', 'Custom Changes']]);
+    const configuredValidLabels = [['custom', 'Custom Changes']];
+    const resolvePullRequestLabels = fake.resolves([]);
+    const validator = createPullRequestLabelValidator({
+        defaultValidLabels,
+        packageInfo: {
+            repository: { url: 'https://github.com/owner/repo.git' },
+            'pr-log': {
+                validLabels: configuredValidLabels,
+                ignoredLabels: ['release']
+            }
+        },
+        resolvePullRequestLabels
+    });
+
+    await validator.validate(pullRequestId);
+
+    assert.deepStrictEqual(resolvePullRequestLabels.firstCall.args, [
+        {
+            githubRepo: 'owner/repo',
+            validLabels,
+            ignoredLabels: ['release'],
+            pullRequests: [{ id: pullRequestId, title: '' }],
+            targetName: undefined,
+            targetScopedLabelPattern: undefined
+        }
+    ]);
+});
+
+test('reports pull request label validation failures', async () => {
+    const error = new Error('Pull Request #123 has no label of bug');
+    const validator = createPullRequestLabelValidator({
+        defaultValidLabels,
+        packageInfo: {
+            repository: { url: 'https://github.com/owner/repo.git' }
+        },
+        resolvePullRequestLabels: fake.rejects(error)
+    });
+
+    await assert.rejects(validator.validate(pullRequestId), error);
+});

--- a/source/lib/validate-pull-request-labels.ts
+++ b/source/lib/validate-pull-request-labels.ts
@@ -1,0 +1,45 @@
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+import { getGithubRepoFromPackageInfo, getIgnoredLabels, getValidLabels } from './package-info.ts';
+import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
+
+type ResolvePullRequestLabels = (input: {
+    readonly githubRepo: string;
+    readonly validLabels: ReadonlyMap<string, string>;
+    readonly ignoredLabels: readonly string[];
+    readonly pullRequests: readonly PullRequest[];
+    readonly targetName: string | undefined;
+    readonly targetScopedLabelPattern: string | undefined;
+}) => Promise<readonly PullRequestWithLabel[]>;
+
+export type PullRequestLabelValidatorDependencies = {
+    readonly defaultValidLabels: ReadonlyMap<string, string>;
+    readonly packageInfo: Record<string, unknown>;
+    readonly resolvePullRequestLabels: ResolvePullRequestLabels;
+};
+
+export type PullRequestLabelValidator = {
+    validate(pullRequestId: number): Promise<void>;
+};
+
+export function createPullRequestLabelValidator(
+    dependencies: PullRequestLabelValidatorDependencies
+): PullRequestLabelValidator {
+    const { defaultValidLabels, packageInfo, resolvePullRequestLabels } = dependencies;
+
+    return {
+        async validate(pullRequestId) {
+            const githubRepo = getGithubRepoFromPackageInfo(packageInfo);
+            const validLabels = getValidLabels(packageInfo, defaultValidLabels);
+            const ignoredLabels = getIgnoredLabels(packageInfo);
+
+            await resolvePullRequestLabels({
+                githubRepo,
+                validLabels,
+                ignoredLabels,
+                pullRequests: [{ id: pullRequestId, title: '' }],
+                targetName: undefined,
+                targetScopedLabelPattern: undefined
+            });
+        }
+    };
+}

--- a/source/packages/command-line-interface/composition.ts
+++ b/source/packages/command-line-interface/composition.ts
@@ -16,6 +16,7 @@ import {
 } from '../../lib/pr-log-engine-cli-adapter.ts';
 import { createJsonFileReader } from '../../lib/read-json-file.ts';
 import { createRemoteAliasReader } from '../../lib/remote-alias-reader.ts';
+import { createPullRequestLabelValidator } from '../../lib/validate-pull-request-labels.ts';
 import { createPrLogEngine, defaultValidLabels } from '../core/core.entry-point.ts';
 import { readPackageMetadata } from './package-metadata.ts';
 import { createErrorReporter } from './error-reporter.ts';
@@ -96,6 +97,15 @@ const commandLineInterfaceProgram = createProgram({
         };
 
         return createCliRunner(dependencies);
+    },
+    createPullRequestLabelValidator({ packageInfo }) {
+        return createPullRequestLabelValidator({
+            defaultValidLabels,
+            packageInfo,
+            async resolvePullRequestLabels(input) {
+                return prLogEngine.resolvePullRequestLabels(input);
+            }
+        });
     },
     reportError
 });

--- a/source/packages/command-line-interface/program.test.ts
+++ b/source/packages/command-line-interface/program.test.ts
@@ -2,48 +2,79 @@ import assert from 'node:assert';
 import { stub, type SinonStub } from 'sinon';
 import type { CliRunner } from '../../lib/cli.ts';
 import type { CliRunOptions } from '../../lib/cli-run-options.ts';
+import type { PullRequestLabelValidator } from '../../lib/validate-pull-request-labels.ts';
 import { createProgramError, createProgram, type ProgramDependencies } from './program.ts';
 
 type FactoryResult = {
     readonly dependencies: ProgramDependencies;
     readonly auth: SinonStub;
     readonly createCliRunner: SinonStub;
+    readonly createPullRequestLabelValidator: SinonStub;
     readonly readPackageInfo: SinonStub;
     readonly reportError: SinonStub;
     readonly run: SinonStub;
+    readonly validate: SinonStub;
 };
 
-function createDependencies(githubToken: string | undefined): FactoryResult {
+type ProgramStubs = {
+    readonly auth: SinonStub;
+    readonly createCliRunner: SinonStub;
+    readonly createPullRequestLabelValidator: SinonStub;
+    readonly readPackageInfo: SinonStub;
+    readonly reportError: SinonStub;
+    readonly run: SinonStub;
+    readonly validate: SinonStub;
+};
+
+const pullRequestId = 123;
+const pullRequestIdText = '123';
+
+function createProgramStubs(): ProgramStubs {
     const auth = stub().resolves(undefined);
     const readPackageInfo = stub().resolves({ name: 'consumer-package' });
     const run = stub().resolves(undefined);
+    const validate = stub().resolves(undefined);
     const cliRunner: CliRunner = { run };
+    const pullRequestLabelValidator: PullRequestLabelValidator = { validate };
     const createCliRunner = stub().returns(cliRunner);
+    const createPullRequestLabelValidator = stub().returns(pullRequestLabelValidator);
     const reportError = stub();
-    const reportProgramError: ProgramDependencies['reportError'] = (error, options) => {
-        reportError(error, options);
-    };
 
     return {
-        dependencies: {
-            packageMetadata: {
-                name: 'pr-log',
-                description: 'Changelog generator',
-                version: '1.2.3'
-            },
-            githubToken,
-            githubClient: { auth },
-            changelogPath: '/project/CHANGELOG.md',
-            readPackageInfo,
-            createCliRunner,
-            reportError: reportProgramError
-        },
         auth,
         createCliRunner,
+        createPullRequestLabelValidator,
         readPackageInfo,
         reportError,
-        run
+        run,
+        validate
     };
+}
+
+function createProgramDependencies(githubToken: string | undefined, programStubs: ProgramStubs): ProgramDependencies {
+    return {
+        packageMetadata: {
+            name: 'pr-log',
+            description: 'Changelog generator',
+            version: '1.2.3'
+        },
+        githubToken,
+        githubClient: { auth: programStubs.auth },
+        changelogPath: '/project/CHANGELOG.md',
+        readPackageInfo: programStubs.readPackageInfo,
+        createCliRunner: programStubs.createCliRunner,
+        createPullRequestLabelValidator: programStubs.createPullRequestLabelValidator,
+        reportError(error, options) {
+            programStubs.reportError(error, options);
+        }
+    };
+}
+
+function createDependencies(githubToken: string | undefined): FactoryResult {
+    const programStubs = createProgramStubs();
+    const dependencies = createProgramDependencies(githubToken, programStubs);
+
+    return { dependencies, ...programStubs };
 }
 
 test('createProgram() runs the CLI with parsed release options', async () => {
@@ -81,6 +112,36 @@ test('createProgram() skips authentication without a GitHub token', async () => 
 
     assert.strictEqual(auth.callCount, 0);
     assert.strictEqual((run.firstCall.args[0] as CliRunOptions).unreleased, true);
+});
+
+test('createProgram() validates pull request labels', async () => {
+    const { dependencies, auth, createPullRequestLabelValidator, readPackageInfo, validate } =
+        createDependencies('github-token');
+    const program = createProgram(dependencies);
+
+    await program.run(['node', 'pr-log', 'validate-pull-request-labels', pullRequestIdText]);
+
+    assert.strictEqual(auth.callCount, 1);
+    assert.strictEqual(readPackageInfo.callCount, 1);
+    assert.deepStrictEqual(createPullRequestLabelValidator.firstCall.args, [
+        {
+            packageInfo: { name: 'consumer-package' }
+        }
+    ]);
+    assert.deepStrictEqual(validate.firstCall.args, [pullRequestId]);
+});
+
+test('createProgram() reports invalid pull request numbers', async () => {
+    const { dependencies, reportError, validate } = createDependencies(undefined);
+    const program = createProgram(dependencies);
+
+    await program.run(['node', 'pr-log', 'validate-pull-request-labels', 'not-a-number']);
+
+    assert.strictEqual(validate.callCount, 0);
+    assert.strictEqual(
+        (reportError.firstCall.args[0] as Error).message,
+        'Pull request number must be a positive integer'
+    );
 });
 
 test('createProgram() reports run option errors', async () => {

--- a/source/packages/command-line-interface/program.ts
+++ b/source/packages/command-line-interface/program.ts
@@ -2,11 +2,16 @@ import { createCommand } from 'commander';
 import { isString } from '@sindresorhus/is';
 import { createCliRunOptions } from '../../lib/cli-run-options.ts';
 import type { CliRunner } from '../../lib/cli.ts';
+import type { PullRequestLabelValidator } from '../../lib/validate-pull-request-labels.ts';
 import type { ErrorReporter } from './error-reporter.ts';
 import type { PackageMetadata } from './package-metadata.ts';
 
 type ProgramRunnerOptions = {
     readonly defaultBranch: string;
+    readonly packageInfo: Record<string, unknown>;
+};
+
+type PullRequestLabelValidatorOptions = {
     readonly packageInfo: Record<string, unknown>;
 };
 
@@ -21,6 +26,7 @@ export type ProgramDependencies = {
     readonly changelogPath: string;
     readonly readPackageInfo: () => Promise<Record<string, unknown>>;
     readonly createCliRunner: (options: ProgramRunnerOptions) => CliRunner;
+    readonly createPullRequestLabelValidator: (options: PullRequestLabelValidatorOptions) => PullRequestLabelValidator;
     readonly reportError: ErrorReporter;
 };
 
@@ -36,9 +42,67 @@ export function createProgramError(value: unknown): Readonly<Error> {
     return new Error(String(value));
 }
 
+async function authenticateIfTokenExists(
+    dependencies: Pick<ProgramDependencies, 'githubClient' | 'githubToken'>
+): Promise<void> {
+    if (isString(dependencies.githubToken)) {
+        await dependencies.githubClient.auth();
+    }
+}
+
+function parsePullRequestId(value: string): number {
+    const pullRequestId = Number(value);
+
+    if (!Number.isSafeInteger(pullRequestId) || pullRequestId < 1) {
+        throw new Error('Pull request number must be a positive integer');
+    }
+
+    return pullRequestId;
+}
+
+async function runChangelogCommand(
+    dependencies: ProgramDependencies,
+    versionNumber: string | undefined,
+    commandOptions: Record<string, unknown>
+): Promise<void> {
+    const runOptionsResult = createCliRunOptions({
+        versionNumber,
+        changelogPath: dependencies.changelogPath,
+        commandOptions
+    });
+
+    await runOptionsResult.match({
+        async Ok(runOptions) {
+            await authenticateIfTokenExists(dependencies);
+
+            const cliRunner = dependencies.createCliRunner({
+                defaultBranch: commandOptions.defaultBranch as string,
+                packageInfo: await dependencies.readPackageInfo()
+            });
+
+            await cliRunner.run(runOptions);
+        },
+        Err(error) {
+            throw error;
+        }
+    });
+}
+
+async function runPullRequestLabelValidationCommand(
+    dependencies: ProgramDependencies,
+    pullRequestId: number
+): Promise<void> {
+    await authenticateIfTokenExists(dependencies);
+
+    const pullRequestLabelValidator = dependencies.createPullRequestLabelValidator({
+        packageInfo: await dependencies.readPackageInfo()
+    });
+
+    await pullRequestLabelValidator.validate(pullRequestId);
+}
+
 export function createProgram(dependencies: ProgramDependencies): Program {
-    const { packageMetadata, githubToken, githubClient, changelogPath, readPackageInfo, createCliRunner, reportError } =
-        dependencies;
+    const { packageMetadata } = dependencies;
     let isTracingEnabled = false;
     const program = createCommand(packageMetadata.name);
 
@@ -55,32 +119,22 @@ export function createProgram(dependencies: ProgramDependencies): Program {
         .option('--unreleased', 'include section for unreleased changes', false)
         .action(async (versionNumber: string | undefined, commandOptions: Record<string, unknown>) => {
             isTracingEnabled = commandOptions.trace === true;
+            await runChangelogCommand(dependencies, versionNumber, commandOptions);
+        });
 
-            const runOptionsResult = createCliRunOptions({ versionNumber, changelogPath, commandOptions });
-
-            await runOptionsResult.match({
-                async Ok(runOptions) {
-                    if (isString(githubToken)) {
-                        await githubClient.auth();
-                    }
-
-                    const cliRunner = createCliRunner({
-                        defaultBranch: commandOptions.defaultBranch as string,
-                        packageInfo: await readPackageInfo()
-                    });
-
-                    await cliRunner.run(runOptions);
-                },
-                Err(error) {
-                    throw error;
-                }
-            });
+    program
+        .command('validate-pull-request-labels')
+        .description('validate labels assigned to a GitHub pull request')
+        .argument('<pull-request-number>', 'GitHub pull request number', parsePullRequestId)
+        .action(async (pullRequestId: number) => {
+            isTracingEnabled = program.opts().trace === true;
+            await runPullRequestLabelValidationCommand(dependencies, pullRequestId);
         });
 
     return {
         async run(commandLineArguments) {
             await program.parseAsync(Array.from(commandLineArguments)).catch((error: unknown) => {
-                reportError(createProgramError(error), { isTracingEnabled });
+                dependencies.reportError(createProgramError(error), { isTracingEnabled });
             });
         }
     };


### PR DESCRIPTION
Adds `pr-log validate-pull-request-labels <number>` so CI can validate one pull request with the same label configuration used by changelog generation. The command reuses configured `validLabels` and `ignoredLabels` instead of duplicating label policy in workflow YAML.

Validated with `npx just test-unit`, `npx just compile`, and `npx just lint`.