### PR TITLE
Use `validate-pull-request-labels` in CI

### DIFF
--- a/.github/workflows/pull-request-label-policy.yml
+++ b/.github/workflows/pull-request-label-policy.yml
@@ -5,7 +5,9 @@ on:
     pull_request:
         types: [opened, reopened, synchronize, labeled, unlabeled]
 
-permissions: {}
+permissions:
+    contents: read # required for actions/checkout to read the workflow source
+    issues: read # required to read labels assigned to the pull request
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,17 +18,23 @@ jobs:
         runs-on: ubuntu-latest
         name: Pull request label policy
         steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+
+            - name: Use Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 24
+
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+
+            - name: Compile
+              run: npx just compile
+
             - name: Validate pull request label
-              if: >
-                  contains(github.event.pull_request.labels.*.name, 'breaking') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'bug') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'feature') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'enhancement') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'documentation') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'upgrade') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'refactor') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'build') == false &&
-                  contains(github.event.pull_request.labels.*.name, 'release') == false
-              run: |
-                  echo "Set one pr-log pull request label: breaking, bug, feature, enhancement, documentation, upgrade, refactor, build, release"
-                  exit 1
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+              run: node target/build/source/packages/command-line-interface/bin.entry-point.js validate-pull-request-labels "$PULL_REQUEST_NUMBER"


### PR DESCRIPTION
Updates the pull request label policy workflow to call `pr-log validate-pull-request-labels` instead of duplicating the accepted labels in YAML. The workflow now relies on the repository `pr-log` configuration from the base feature branch.

Stacked on #599.

Validated with `npx just compile`, `npx just lint`, and a local `npx pr-log validate-pull-request-labels not-a-number` bin check.