### PR TITLE
Run release PR maintenance in a latest-wins workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -84,45 +84,6 @@ jobs:
                   echo "zizmor findings: $count"
                   test "$count" -eq 0
 
-    maintain-release-pr:
-        needs: build
-        runs-on: ubuntu-latest
-        name: Maintain release PR
-        if: github.event_name == 'push'
-        concurrency:
-            group: release-pr-maintenance
-            cancel-in-progress: false
-        permissions:
-            actions: write # required to dispatch release PR CI and delete gated PR runs
-            contents: write # required to push and delete the release branch
-            issues: write # required to replace release PR labels
-            pull-requests: write # required to create, update, and close release PRs
-            statuses: write # required to mirror dispatched release PR CI results
-        steps:
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-              with:
-                  ref: main
-                  fetch-depth: 0
-                  persist-credentials: true
-
-            - name: Use Node.js
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-              with:
-                  node-version: 24
-
-            - name: Install dependencies
-              run: npm clean-install --ignore-scripts
-
-            - name: Configure release author
-              run: |
-                  git config user.name 'github-actions[bot]'
-                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-            - name: Maintain release pull request
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: npx just prepare-release
-
     publish-release:
         needs: build
         runs-on: ubuntu-latest

--- a/.github/workflows/release-pr-maintenance.yml
+++ b/.github/workflows/release-pr-maintenance.yml
@@ -1,0 +1,48 @@
+---
+name: Release PR maintenance
+
+on:
+    push:
+        branches: [main]
+    workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+    group: release-pr-maintenance
+    cancel-in-progress: true
+
+jobs:
+    maintain-release-pr:
+        runs-on: ubuntu-latest
+        name: Maintain release PR
+        permissions:
+            actions: write # required to dispatch release PR CI and delete gated PR runs
+            contents: write # required to push and delete the release branch
+            issues: write # required to replace release PR labels
+            pull-requests: write # required to create, update, and close release PRs
+            statuses: write # required to mirror dispatched release PR CI results
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  ref: main
+                  fetch-depth: 0
+                  persist-credentials: true
+
+            - name: Use Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 24
+
+            - name: Install dependencies
+              run: npm clean-install --ignore-scripts
+
+            - name: Configure release author
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+            - name: Maintain release pull request
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: npx just prepare-release


### PR DESCRIPTION
Release PR maintenance is split out of continuous integration so merge queue pushes do not leave it waiting behind stale main runs. The dedicated workflow cancels older maintenance runs and keeps the newest main push responsible for updating the release PR.