### PR TITLE
Configure `Renovate` to automerge through PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,10 @@
     "labels": ["renovate", "upgrade"],
     "rebaseStalePrs": true,
     "automerge": true,
-    "automergeType": "branch",
+    "automergeType": "pr",
     "dependencyDashboard": false,
     "constraints": {
-        "npm": "11.17.0"
+        "npm": "10.9.8"
     },
     "lockFileMaintenance": {
         "enabled": true


### PR DESCRIPTION
This makes `Renovate` open PRs for automergeable updates so `pull_request` checks run before GitHub merges them. It also pins Renovate npm constraint to Node 22 bundled npm so generated lockfiles match CI.