### PR TITLE
Update `@packtory/cli` to `0.0.53`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@enormora/eslint-config-mocha": "0.0.42",
                 "@enormora/eslint-config-node": "0.0.35",
                 "@enormora/eslint-config-typescript": "0.0.52",
-                "@packtory/cli": "0.0.52",
+                "@packtory/cli": "0.0.53",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.2",
@@ -1732,9 +1732,9 @@
             }
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.52",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.52.tgz",
-            "integrity": "sha512-74vbANG1zaQV8ZlBLd4YtUsvCc0Zp+o80A2x6EFYFHz06fs2IjmVxwZTSVYlEmQfo/Ztg2nh4VNq8sH1IyAK5A==",
+            "version": "0.0.53",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.53.tgz",
+            "integrity": "sha512-lcF+O6lTxzomqw5ZfrMZ4HKqzYd0JwXbM3cSX2Ak4mLPFuPxDv32EkUuTDebUMEV4VGCLu9+iCzNa01rfvWv0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@enormora/eslint-config-mocha": "0.0.42",
         "@enormora/eslint-config-node": "0.0.35",
         "@enormora/eslint-config-typescript": "0.0.52",
-        "@packtory/cli": "0.0.52",
+        "@packtory/cli": "0.0.53",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.2",


### PR DESCRIPTION
Updates the pinned `@packtory/cli` dev dependency to the latest published version and refreshes the lockfile.