### PR TITLE
Update `@packtory/cli` to `0.0.57`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@enormora/eslint-config-mocha": "0.0.44",
                 "@enormora/eslint-config-node": "0.0.36",
                 "@enormora/eslint-config-typescript": "0.0.54",
-                "@packtory/cli": "0.0.56",
+                "@packtory/cli": "0.0.57",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.2",
@@ -833,15 +833,6 @@
             "integrity": "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@dprint/json": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.21.3.tgz",
-            "integrity": "sha512-fOmRKstf4kVZunnJcrGg1SNzoU6Y11mnLR1SbHQ7PwVvOUQTTUeCtxm3oLy/56nf69kaZmrdeegWXyxnTM5WDQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/@dprint/markdown": {
             "version": "0.22.1",
@@ -1741,9 +1732,9 @@
             }
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.56",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.56.tgz",
-            "integrity": "sha512-y545VTgykAS11B9bj8zpM0nUH3WoeqbLpi8wG5CB8maIGddOz5FTYgLaUUWdCy/g2ai5qDFsWBxt1XRirb6TKg==",
+            "version": "0.0.57",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.57.tgz",
+            "integrity": "sha512-w/+TbnmjsZg/O7d70PJOwJ3OSG1pFq9AnqUASYj/jJH5xQOZd9XtrCvdtr6i+8yl/CoTFd3xwuMzDsXkwLIUVA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@enormora/eslint-config-mocha": "0.0.44",
         "@enormora/eslint-config-node": "0.0.36",
         "@enormora/eslint-config-typescript": "0.0.54",
-        "@packtory/cli": "0.0.56",
+        "@packtory/cli": "0.0.57",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.2",


### PR DESCRIPTION
Updates `@packtory/cli` to `0.0.57`, which includes the release PR staging branch fix needed for repositories using slash-delimited release branch names.