### PR TITLE
Update `@packtory/cli` to `0.0.58`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@enormora/eslint-config-mocha": "0.0.44",
                 "@enormora/eslint-config-node": "0.0.36",
                 "@enormora/eslint-config-typescript": "0.0.54",
-                "@packtory/cli": "0.0.57",
+                "@packtory/cli": "0.0.58",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.2",
@@ -1732,9 +1732,9 @@
             }
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.57",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.57.tgz",
-            "integrity": "sha512-w/+TbnmjsZg/O7d70PJOwJ3OSG1pFq9AnqUASYj/jJH5xQOZd9XtrCvdtr6i+8yl/CoTFd3xwuMzDsXkwLIUVA==",
+            "version": "0.0.58",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.58.tgz",
+            "integrity": "sha512-VmQB0vCUSXVVPf2CAs2MVZeQGv3NZX6RoddyCyFZYctidFS+9507Gu7H/qNcK6nj44OIrrsqps2q+fN1PxZAcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1745,7 +1745,7 @@
                 "cmd-ts": "0.15.0",
                 "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.53",
+                "packtory": "0.0.54",
                 "remeda": "2.39.0",
                 "semver": "7.8.5",
                 "ts-pattern": "5.9.0",
@@ -3261,9 +3261,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.3.tgz",
-            "integrity": "sha512-xRgplks8SvcKkdlv2M6Z2LZmRsmqd+x0nXXGXeMEjwdibj1HSDrlnqBRLeYdMvsgCox7Bq0e+DHwfczOfsn6IA==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+            "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3285,25 +3285,12 @@
                 }
             }
         },
-        "node_modules/bare-os": {
-            "version": "3.9.3",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
-            "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "bare": ">=1.14.0"
-            }
-        },
         "node_modules/bare-path": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-            "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.0.tgz",
+            "integrity": "sha512-322oSBHOhMhOm2CVwn7b3+gWQqwzSgIY4gNpKKb+Ha5jx2dEl9ClOgz/SK57DwuDql8YQg8JRpb9U0o8K3pW9g==",
             "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-os": "^3.0.1"
-            }
+            "license": "Apache-2.0"
         },
         "node_modules/bare-stream": {
             "version": "2.13.3",
@@ -9078,9 +9065,9 @@
             }
         },
         "node_modules/packtory": {
-            "version": "0.0.53",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.53.tgz",
-            "integrity": "sha512-gNXmRXnMlJDDtqPotPe1WD/Z8b2SjbuF7YqynFWdRuEsMO9w4s7C7WiqBqc3oqBQLbbTN5fIbcd+04/JkH4J7Q==",
+            "version": "0.0.54",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.54.tgz",
+            "integrity": "sha512-+G+EakxpVT3PtsAh/pIrXO46iqNH0o1V5QYEhzV+Dg6+Gixwy040EC2FDlYrEYPuW72nYHhJ784bHyyCbCbnlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@enormora/eslint-config-mocha": "0.0.44",
         "@enormora/eslint-config-node": "0.0.36",
         "@enormora/eslint-config-typescript": "0.0.54",
-        "@packtory/cli": "0.0.57",
+        "@packtory/cli": "0.0.58",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.2",


### PR DESCRIPTION
Updates `@packtory/cli` to `0.0.58`, which includes the authenticated release PR GraphQL commit path needed by `release-pr maintain`.