### PR TITLE
Update `@packtory/cli` to `0.0.59`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@enormora/eslint-config-mocha": "0.0.45",
                 "@enormora/eslint-config-node": "0.0.36",
                 "@enormora/eslint-config-typescript": "0.0.56",
-                "@packtory/cli": "0.0.58",
+                "@packtory/cli": "0.0.59",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.3",
@@ -833,15 +833,6 @@
             "integrity": "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@dprint/json": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.21.3.tgz",
-            "integrity": "sha512-fOmRKstf4kVZunnJcrGg1SNzoU6Y11mnLR1SbHQ7PwVvOUQTTUeCtxm3oLy/56nf69kaZmrdeegWXyxnTM5WDQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/@dprint/markdown": {
             "version": "0.22.1",
@@ -1741,9 +1732,9 @@
             }
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.58",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.58.tgz",
-            "integrity": "sha512-VmQB0vCUSXVVPf2CAs2MVZeQGv3NZX6RoddyCyFZYctidFS+9507Gu7H/qNcK6nj44OIrrsqps2q+fN1PxZAcQ==",
+            "version": "0.0.59",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.59.tgz",
+            "integrity": "sha512-0onisrQOdJy7Y1ORQNcq3kREaN2xh3psrJEah33zGPY23EClUX35lQdbNOdf+DsfEpRZAUygw1l2u03UUrtaPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1754,7 +1745,7 @@
                 "cmd-ts": "0.15.0",
                 "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.54",
+                "packtory": "0.0.55",
                 "remeda": "2.39.0",
                 "semver": "7.8.5",
                 "ts-pattern": "5.9.0",
@@ -3295,9 +3286,9 @@
             }
         },
         "node_modules/bare-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.0.tgz",
-            "integrity": "sha512-322oSBHOhMhOm2CVwn7b3+gWQqwzSgIY4gNpKKb+Ha5jx2dEl9ClOgz/SK57DwuDql8YQg8JRpb9U0o8K3pW9g==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+            "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -9194,9 +9185,9 @@
             }
         },
         "node_modules/packtory": {
-            "version": "0.0.54",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.54.tgz",
-            "integrity": "sha512-+G+EakxpVT3PtsAh/pIrXO46iqNH0o1V5QYEhzV+Dg6+Gixwy040EC2FDlYrEYPuW72nYHhJ784bHyyCbCbnlA==",
+            "version": "0.0.55",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.55.tgz",
+            "integrity": "sha512-uaBc3mjWuVLLmiN07rKu9Hh5EIE5oRV4S3EAhAF88lOxLwHeawkYvjrMBvIEgdOcgeJW3U6GTNl5lzNyYQPLYg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9221,7 +9212,7 @@
                 "true-myth": "9.4.0",
                 "ts-morph": "27.0.2",
                 "ts-pattern": "5.9.0",
-                "type-fest": "5.7.0",
+                "type-fest": "5.8.0",
                 "unix-permissions": "6.0.1",
                 "zod": "4.4.3"
             },
@@ -11187,9 +11178,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-            "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+            "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@enormora/eslint-config-mocha": "0.0.45",
         "@enormora/eslint-config-node": "0.0.36",
         "@enormora/eslint-config-typescript": "0.0.56",
-        "@packtory/cli": "0.0.58",
+        "@packtory/cli": "0.0.59",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.3",


### PR DESCRIPTION
Updates `@packtory/cli` to `0.0.59`, including the release retry behavior for already-published packages at the current Git head.