### PR TITLE
Add reusable `release-publish` workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -115,116 +115,17 @@ jobs:
 
     publish-release:
         needs: build
-        runs-on: ubuntu-latest
         name: Publish release
         if: >
             github.event_name == 'push' ||
             (github.event_name == 'workflow_dispatch' && inputs.release_pull_request_number != '')
+        uses: ./.github/workflows/release-publish.yml
         permissions:
             contents: write # required to push release tags and create GitHub releases
             id-token: write # required by npm trusted publishing to mint the OIDC token
             pull-requests: read # required to validate release PR identity before publishing
-        steps:
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-              with:
-                  fetch-depth: 0
-                  persist-credentials: false
-
-            - name: Use Node.js
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-              with:
-                  node-version: 24
-
-            - name: Install dependencies
-              run: npm clean-install --ignore-scripts
-
-            - name: Authorize release publish
-              id: publish-target
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  RELEASE_PULL_REQUEST_NUMBER: ${{ inputs.release_pull_request_number }}
-              run: |
-                  set -euo pipefail
-
-                  if [ -n "$RELEASE_PULL_REQUEST_NUMBER" ]; then
-                      npx just authorize-release-publish --release-pull-request "$RELEASE_PULL_REQUEST_NUMBER"
-                  else
-                      npx just authorize-release-publish
-                  fi
-
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-              if: steps.publish-target.outputs.should_publish == 'true'
-              with:
-                  ref: ${{ steps.publish-target.outputs.publish_commit_sha }}
-                  fetch-depth: 0
-                  persist-credentials: true
-
-            - name: Use Node.js
-              if: steps.publish-target.outputs.should_publish == 'true'
-              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-              with:
-                  node-version: 24
-
-            - name: Install dependencies
-              if: steps.publish-target.outputs.should_publish == 'true'
-              run: npm clean-install --ignore-scripts
-
-            - name: Check packages
-              if: steps.publish-target.outputs.should_publish == 'true'
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: npx just publish-dry-run
-
-            - name: Audit npm signatures and attestations
-              if: steps.publish-target.outputs.should_publish == 'true'
-              run: |
-                  mkdir -p target/release
-                  npm audit signatures --json --include-attestations > target/release/npm-audit-signatures.json
-                  node --input-type=module <<'NODE'
-                  import fs from 'node:fs/promises';
-
-                  const report = JSON.parse(
-                      await fs.readFile('target/release/npm-audit-signatures.json', { encoding: 'utf8' })
-                  );
-                  const packtory = report.verified.find((entry) => {
-                      return entry.name === '@packtory/cli';
-                  });
-
-                  if (packtory?.attestations?.provenance?.predicateType !== 'https://slsa.dev/provenance/v1') {
-                      throw new Error('Missing npm provenance for @packtory/cli');
-                  }
-                  NODE
-
-            - name: Configure release author
-              if: steps.publish-target.outputs.should_publish == 'true'
-              run: |
-                  git config user.name 'github-actions[bot]'
-                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-            - name: Publish packages
-              if: steps.publish-target.outputs.should_publish == 'true'
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  mkdir -p target/release
-                  git config remote.origin.push 'refs/tags/*:refs/tags/*'
-
-                  set +e
-                  npx just publish-release 2>&1 | tee target/release/publish.log
-                  status=${PIPESTATUS[0]}
-                  set -e
-
-                  if [ "$status" -eq 0 ]; then
-                      exit 0
-                  fi
-
-                  if grep -Eiq 'attestation|oidc|provenance|rekor|sigstore|tlog' target/release/publish.log; then
-                      sleep 30
-                      npx just publish-release
-                      exit 0
-                  fi
-
-                  exit "$status"
+        with:
+            release_pull_request_number: ${{ inputs.release_pull_request_number || '' }}
 
     maintain-release-pr:
         needs: publish-release

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,142 @@
+---
+name: Release publish
+
+on:
+    workflow_call:
+        inputs:
+            release_pull_request_number:
+                default: ""
+                required: false
+                type: string
+    workflow_dispatch:
+        inputs:
+            release_pull_request_number:
+                required: true
+                type: string
+
+permissions: {}
+
+concurrency:
+    group: release-publish
+    cancel-in-progress: false
+
+jobs:
+    publish-release:
+        runs-on: ubuntu-latest
+        name: Publish release
+        permissions:
+            contents: write # required to push release tags and create GitHub releases
+            id-token: write # required by npm trusted publishing to mint the OIDC token
+            pull-requests: read # required to validate release PR identity before publishing
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+
+            - name: Use Node.js
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 24
+
+            - name: Install workflow dependencies
+              run: npm clean-install --ignore-scripts
+
+            - name: Authorize release publish
+              id: publish-target
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_PULL_REQUEST_NUMBER: ${{ inputs.release_pull_request_number }}
+              run: |
+                  set -euo pipefail
+
+                  if [ -n "$RELEASE_PULL_REQUEST_NUMBER" ]; then
+                      npx just authorize-release-publish --release-pull-request "$RELEASE_PULL_REQUEST_NUMBER"
+                  else
+                      npx just authorize-release-publish
+                  fi
+
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              if: steps.publish-target.outputs.should_publish == 'true'
+              with:
+                  ref: ${{ steps.publish-target.outputs.publish_commit_sha }}
+                  fetch-depth: 0
+                  path: target/release-source
+                  persist-credentials: true
+
+            - name: Use Node.js
+              if: steps.publish-target.outputs.should_publish == 'true'
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 24
+
+            - name: Install release dependencies
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              run: npm clean-install --ignore-scripts
+
+            - name: Prepare release source
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              run: npx just prepare-packtory-source
+
+            - name: Check packages
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  "$GITHUB_WORKSPACE/node_modules/.bin/packtory" publish
+
+            - name: Audit release tooling
+              if: steps.publish-target.outputs.should_publish == 'true'
+              run: |
+                  mkdir -p target/release
+                  npm audit signatures --json --include-attestations > target/release/npm-audit-signatures.json
+                  node --input-type=module <<'NODE'
+                  import fs from 'node:fs/promises';
+
+                  const report = JSON.parse(
+                      await fs.readFile('target/release/npm-audit-signatures.json', { encoding: 'utf8' })
+                  );
+                  const packtory = report.verified.find((entry) => {
+                      return entry.name === '@packtory/cli';
+                  });
+
+                  if (packtory?.attestations?.provenance?.predicateType !== 'https://slsa.dev/provenance/v1') {
+                      throw new Error('Missing npm provenance for @packtory/cli');
+                  }
+                  NODE
+
+            - name: Configure release author
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+            - name: Publish packages
+              if: steps.publish-target.outputs.should_publish == 'true'
+              working-directory: target/release-source
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  mkdir -p target/release
+                  git config remote.origin.push 'refs/tags/*:refs/tags/*'
+
+                  set +e
+                  "$GITHUB_WORKSPACE/node_modules/.bin/packtory" release --publish --tag --push --github-release --no-dry-run 2>&1 | tee target/release/publish.log
+                  status=${PIPESTATUS[0]}
+                  set -e
+
+                  if [ "$status" -eq 0 ]; then
+                      exit 0
+                  fi
+
+                  if grep -Eiq 'attestation|oidc|provenance|rekor|sigstore|tlog' target/release/publish.log; then
+                      sleep 30
+                      "$GITHUB_WORKSPACE/node_modules/.bin/packtory" release --publish --tag --push --github-release --no-dry-run
+                      exit 0
+                  fi
+
+                  exit "$status"


### PR DESCRIPTION
Moves release publishing into a reusable workflow that CI calls after the build job. The workflow can also be manually dispatched with a merged release PR number, and it checks out the original publish commit while using the current pinned `@packtory/cli` version for retry recovery.