### PR TITLE
Use `@enormora/eslint-config-mocha-node-assert`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 import { baseConfig } from '@enormora/eslint-config-base';
-import { mochaConfig } from '@enormora/eslint-config-mocha';
+import { mochaNodeAssertConfig } from '@enormora/eslint-config-mocha-node-assert';
 import { nodeConfig, nodeConfigFileConfig, nodeEntryPointFileConfig } from '@enormora/eslint-config-node';
 import { typescriptConfig } from '@enormora/eslint-config-typescript';
 
@@ -27,7 +27,7 @@ export default [
         files: [ 'eslint.config.js', 'mocha.config.json', 'packtory.config.js' ]
     },
     {
-        ...mochaConfig,
+        ...mochaNodeAssertConfig,
         files: [ '**/*.test.ts' ],
         languageOptions: {
             globals: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
             },
             "devDependencies": {
                 "@enormora/eslint-config-base": "0.0.49",
-                "@enormora/eslint-config-mocha": "0.0.45",
+                "@enormora/eslint-config-mocha-node-assert": "0.0.3",
                 "@enormora/eslint-config-node": "0.0.36",
                 "@enormora/eslint-config-typescript": "0.0.56",
                 "@packtory/cli": "0.0.59",
@@ -945,6 +945,17 @@
                 "eslint-plugin-mocha": "11.3.0"
             }
         },
+        "node_modules/@enormora/eslint-config-mocha-node-assert": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-mocha-node-assert/-/eslint-config-mocha-node-assert-0.0.3.tgz",
+            "integrity": "sha512-4nxNGVHgF135yiQ9XJJnEUyB6JSdvlWLOWjJs0jwss4TMwLGZ/PINaMhKDS0vfpaivD5uWEOcCKQ9tu1b6/Zgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@enormora/eslint-config-mocha": "0.0.45",
+                "@enormora/eslint-config-node-assert": "0.0.3"
+            }
+        },
         "node_modules/@enormora/eslint-config-node": {
             "version": "0.0.36",
             "resolved": "https://registry.npmjs.org/@enormora/eslint-config-node/-/eslint-config-node-0.0.36.tgz",
@@ -954,6 +965,16 @@
             "dependencies": {
                 "eslint-plugin-n": "18.2.1",
                 "globals": "17.7.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-node-assert": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-node-assert/-/eslint-config-node-assert-0.0.3.tgz",
+            "integrity": "sha512-m2q5EJLIq5QQWHnC5/7In1QgTBWQnlijAFXNn6kBPgf2FekDH9SlTC8Ejj1vTemyHDPB30drcA+1LxZ24AKp2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@enormora/eslint-plugin-node-assert": "0.0.1"
             }
         },
         "node_modules/@enormora/eslint-config-test-base": {
@@ -1020,6 +1041,173 @@
                 "eslint-plugin-import-x": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-plugin-node-assert/-/eslint-plugin-node-assert-0.0.1.tgz",
+            "integrity": "sha512-dWNe4o03/xYM/C6BCN97a05jmusBx2XfxKBR+zIZ0H2i7La6D3soQGKvzAwwGz3g0Y8sENvRX0O+QwFV02mhOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "8.62.1"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/project-service": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+            "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.62.1",
+                "@typescript-eslint/types": "^8.62.1",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+            "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.62.1",
+                "@typescript-eslint/visitor-keys": "8.62.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+            "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/types": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+            "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+            "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.62.1",
+                "@typescript-eslint/tsconfig-utils": "8.62.1",
+                "@typescript-eslint/types": "8.62.1",
+                "@typescript-eslint/visitor-keys": "8.62.1",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/utils": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+            "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.62.1",
+                "@typescript-eslint/types": "8.62.1",
+                "@typescript-eslint/typescript-estree": "8.62.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.62.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+            "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.62.1",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
@@ -9268,25 +9456,6 @@
                 }
             }
         },
-        "node_modules/packtory/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
         "node_modules/packtory/node_modules/diff": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
@@ -9309,15 +9478,6 @@
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
-        },
-        "node_modules/packtory/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/packtory/node_modules/npm-package-arg": {
             "version": "14.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9456,6 +9456,25 @@
                 }
             }
         },
+        "node_modules/packtory/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/packtory/node_modules/diff": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
@@ -9478,6 +9497,15 @@
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
             }
+        },
+        "node_modules/packtory/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/packtory/node_modules/npm-package-arg": {
             "version": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "devDependencies": {
         "@enormora/eslint-config-base": "0.0.49",
-        "@enormora/eslint-config-mocha": "0.0.45",
+        "@enormora/eslint-config-mocha-node-assert": "0.0.3",
         "@enormora/eslint-config-node": "0.0.36",
         "@enormora/eslint-config-typescript": "0.0.56",
         "@packtory/cli": "0.0.59",

--- a/source/lib/changelog-base-ref.test.ts
+++ b/source/lib/changelog-base-ref.test.ts
@@ -80,7 +80,12 @@ test('throws when the selected base ref is missing', async function () {
     await assert.rejects(resolveChangelogBaseRef(packageInput, gitRefReaderFactory([])), function (error: unknown) {
         const missingBaseRefError = error as MissingChangelogBaseRefError;
 
-        assert.partialDeepStrictEqual(missingBaseRefError, {
+        assert.deepStrictEqual({
+            name: missingBaseRefError.name,
+            packageName: missingBaseRefError.packageName,
+            ref: missingBaseRefError.ref,
+            reason: missingBaseRefError.reason
+        }, {
             name: 'MissingChangelogBaseRefError',
             packageName: '@scope/package',
             ref: 'explicit-ref',

--- a/source/lib/changelog-base-ref.test.ts
+++ b/source/lib/changelog-base-ref.test.ts
@@ -80,10 +80,12 @@ test('throws when the selected base ref is missing', async function () {
     await assert.rejects(resolveChangelogBaseRef(packageInput, gitRefReaderFactory([])), function (error: unknown) {
         const missingBaseRefError = error as MissingChangelogBaseRefError;
 
-        assert.strictEqual(missingBaseRefError.name, 'MissingChangelogBaseRefError');
-        assert.strictEqual(missingBaseRefError.packageName, '@scope/package');
-        assert.strictEqual(missingBaseRefError.ref, 'explicit-ref');
-        assert.strictEqual(missingBaseRefError.reason, 'explicit-base-ref');
+        assert.partialDeepStrictEqual(missingBaseRefError, {
+            name: 'MissingChangelogBaseRefError',
+            packageName: '@scope/package',
+            ref: 'explicit-ref',
+            reason: 'explicit-base-ref'
+        });
         return true;
     });
 });

--- a/source/lib/cli.test.ts
+++ b/source/lib/cli.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { stub } from 'sinon';
+import { stub, type SinonSpy } from 'sinon';
 import type _prependFile from 'prepend-file';
 import type { Logger } from 'loglevel';
 import { Factory, type DeepPartial } from 'fishery';
@@ -38,6 +38,18 @@ function createCli(dependencies: Partial<CliRunnerDependencies> = {}): CliRunner
     return createCliRunner({
         ...createDefaultCliDependencies(),
         ...dependencies
+    });
+}
+
+function assertSpyCalls(sinonSpy: SinonSpy, calls: readonly (readonly unknown[])[]): void {
+    assert.deepStrictEqual({
+        callCount: sinonSpy.callCount,
+        calls: sinonSpy.getCalls().map(function (call): readonly unknown[] {
+            return call.args as readonly unknown[];
+        })
+    }, {
+        callCount: calls.length,
+        calls
     });
 }
 
@@ -147,10 +159,7 @@ test('does not throw if the repository is dirty', async function () {
 
     await cli.run(options);
 
-    assert.partialDeepStrictEqual(prependFile, {
-        callCount: 1,
-        firstCall: { args: [ '/foo/CHANGELOG.md', 'sloppy changelog\n\n' ] }
-    });
+    assertSpyCalls(prependFile, [ [ '/foo/CHANGELOG.md', 'sloppy changelog\n\n' ] ]);
 });
 
 test('uses custom labels if they are provided in package.json', async function () {
@@ -181,10 +190,7 @@ test('uses custom labels if they are provided in package.json', async function (
 
     await cli.run(cliRunOptionsFactory.build());
 
-    assert.partialDeepStrictEqual(getMergedPullRequests, {
-        callCount: 1,
-        firstCall: { args: [ 'foo/bar', expectedConfig ] }
-    });
+    assertSpyCalls(getMergedPullRequests, [ [ 'foo/bar', expectedConfig ] ]);
 
     assert.strictEqual(renderChangelogMarkdown.callCount, 1);
     assert.deepStrictEqual(renderChangelogMarkdown.firstCall.args[0], {
@@ -225,10 +231,7 @@ test('calls ensureCleanLocalGitState with correct parameters', async function ()
 
     await cli.run(options);
 
-    assert.partialDeepStrictEqual(ensureCleanLocalGitState, {
-        callCount: 1,
-        firstCall: { args: [ expectedGithubRepo ] }
-    });
+    assertSpyCalls(ensureCleanLocalGitState, [ [ expectedGithubRepo ] ]);
 });
 
 test('calls getMergedPullRequests with the correct repo', async function () {
@@ -274,10 +277,7 @@ test('reports the generated changelog to stdout and not to a file when stdout is
 
     assert.strictEqual(prependFile.callCount, 0);
 
-    assert.partialDeepStrictEqual(log, {
-        callCount: 1,
-        firstCall: { args: [ 'generated changelog' ] }
-    });
+    assertSpyCalls(log, [ [ 'generated changelog' ] ]);
 });
 
 test('reports the generated changelog to a file when stdout is set to false', async function () {
@@ -304,10 +304,7 @@ test('reports the generated changelog to a file when stdout is set to false', as
         versionNumber: '1.2.3'
     });
 
-    assert.partialDeepStrictEqual(prependFile, {
-        callCount: 1,
-        firstCall: { args: [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] }
-    });
+    assertSpyCalls(prependFile, [ [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] ]);
 });
 
 test('reports the generated unreleased changelog to a file when stdout is set to false', async function () {
@@ -339,10 +336,7 @@ test('reports the generated unreleased changelog to a file when stdout is set to
         versionNumber: undefined
     });
 
-    assert.partialDeepStrictEqual(prependFile, {
-        callCount: 1,
-        firstCall: { args: [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] }
-    });
+    assertSpyCalls(prependFile, [ [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] ]);
 });
 
 test('derives the version number automatically from merged pull request labels', async function () {

--- a/source/lib/cli.test.ts
+++ b/source/lib/cli.test.ts
@@ -147,8 +147,10 @@ test('does not throw if the repository is dirty', async function () {
 
     await cli.run(options);
 
-    assert.strictEqual(prependFile.callCount, 1);
-    assert.deepStrictEqual(prependFile.firstCall.args, [ '/foo/CHANGELOG.md', 'sloppy changelog\n\n' ]);
+    assert.partialDeepStrictEqual(prependFile, {
+        callCount: 1,
+        firstCall: { args: [ '/foo/CHANGELOG.md', 'sloppy changelog\n\n' ] }
+    });
 });
 
 test('uses custom labels if they are provided in package.json', async function () {
@@ -179,8 +181,10 @@ test('uses custom labels if they are provided in package.json', async function (
 
     await cli.run(cliRunOptionsFactory.build());
 
-    assert.strictEqual(getMergedPullRequests.callCount, 1);
-    assert.deepStrictEqual(getMergedPullRequests.firstCall.args, [ 'foo/bar', expectedConfig ]);
+    assert.partialDeepStrictEqual(getMergedPullRequests, {
+        callCount: 1,
+        firstCall: { args: [ 'foo/bar', expectedConfig ] }
+    });
 
     assert.strictEqual(renderChangelogMarkdown.callCount, 1);
     assert.deepStrictEqual(renderChangelogMarkdown.firstCall.args[0], {
@@ -221,8 +225,10 @@ test('calls ensureCleanLocalGitState with correct parameters', async function ()
 
     await cli.run(options);
 
-    assert.strictEqual(ensureCleanLocalGitState.callCount, 1);
-    assert.deepStrictEqual(ensureCleanLocalGitState.firstCall.args, [ expectedGithubRepo ]);
+    assert.partialDeepStrictEqual(ensureCleanLocalGitState, {
+        callCount: 1,
+        firstCall: { args: [ expectedGithubRepo ] }
+    });
 });
 
 test('calls getMergedPullRequests with the correct repo', async function () {
@@ -268,8 +274,10 @@ test('reports the generated changelog to stdout and not to a file when stdout is
 
     assert.strictEqual(prependFile.callCount, 0);
 
-    assert.strictEqual(log.callCount, 1);
-    assert.deepStrictEqual(log.firstCall.args, [ 'generated changelog' ]);
+    assert.partialDeepStrictEqual(log, {
+        callCount: 1,
+        firstCall: { args: [ 'generated changelog' ] }
+    });
 });
 
 test('reports the generated changelog to a file when stdout is set to false', async function () {
@@ -296,8 +304,10 @@ test('reports the generated changelog to a file when stdout is set to false', as
         versionNumber: '1.2.3'
     });
 
-    assert.strictEqual(prependFile.callCount, 1);
-    assert.deepStrictEqual(prependFile.firstCall.args, [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ]);
+    assert.partialDeepStrictEqual(prependFile, {
+        callCount: 1,
+        firstCall: { args: [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] }
+    });
 });
 
 test('reports the generated unreleased changelog to a file when stdout is set to false', async function () {
@@ -329,8 +339,10 @@ test('reports the generated unreleased changelog to a file when stdout is set to
         versionNumber: undefined
     });
 
-    assert.strictEqual(prependFile.callCount, 1);
-    assert.deepStrictEqual(prependFile.firstCall.args, [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ]);
+    assert.partialDeepStrictEqual(prependFile, {
+        callCount: 1,
+        firstCall: { args: [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] }
+    });
 });
 
 test('derives the version number automatically from merged pull request labels', async function () {

--- a/source/lib/ensure-clean-local-git-state.test.ts
+++ b/source/lib/ensure-clean-local-git-state.test.ts
@@ -88,8 +88,10 @@ test('fetches the remote repository', async function () {
 
     await ensureCleanLocalGitState(githubRepo);
 
-    assert.strictEqual(fetchRemote.callCount, 1);
-    assert.deepStrictEqual(fetchRemote.firstCall.args, [ 'origin' ]);
+    assert.partialDeepStrictEqual(fetchRemote, {
+        callCount: 1,
+        firstCall: { args: [ 'origin' ] }
+    });
 });
 
 test('fulfills if the local git state is clean', async function () {
@@ -98,6 +100,8 @@ test('fulfills if the local git state is clean', async function () {
 
     await ensureCleanLocalGitState(githubRepo);
 
-    assert.strictEqual(getSymmetricDifferencesBetweenBranches.callCount, 1);
-    assert.deepStrictEqual(getSymmetricDifferencesBetweenBranches.firstCall.args, [ 'master', 'origin/master' ]);
+    assert.partialDeepStrictEqual(getSymmetricDifferencesBetweenBranches, {
+        callCount: 1,
+        firstCall: { args: [ 'master', 'origin/master' ] }
+    });
 });

--- a/source/lib/ensure-clean-local-git-state.test.ts
+++ b/source/lib/ensure-clean-local-git-state.test.ts
@@ -88,9 +88,14 @@ test('fetches the remote repository', async function () {
 
     await ensureCleanLocalGitState(githubRepo);
 
-    assert.partialDeepStrictEqual(fetchRemote, {
+    assert.deepStrictEqual({
+        callCount: fetchRemote.callCount,
+        calls: fetchRemote.getCalls().map(function (call): readonly unknown[] {
+            return call.args as readonly unknown[];
+        })
+    }, {
         callCount: 1,
-        firstCall: { args: [ 'origin' ] }
+        calls: [ [ 'origin' ] ]
     });
 });
 
@@ -100,8 +105,13 @@ test('fulfills if the local git state is clean', async function () {
 
     await ensureCleanLocalGitState(githubRepo);
 
-    assert.partialDeepStrictEqual(getSymmetricDifferencesBetweenBranches, {
+    assert.deepStrictEqual({
+        callCount: getSymmetricDifferencesBetweenBranches.callCount,
+        calls: getSymmetricDifferencesBetweenBranches.getCalls().map(function (call): readonly unknown[] {
+            return call.args as readonly unknown[];
+        })
+    }, {
         callCount: 1,
-        firstCall: { args: [ 'master', 'origin/master' ] }
+        calls: [ [ 'master', 'origin/master' ] ]
     });
 });

--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -130,8 +130,10 @@ test('ignores non-semver tag', async function () {
 
     await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
-    assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, [ '0.0.2' ]);
+    assert.partialDeepStrictEqual(getFirstParentCommitLogs, {
+        callCount: 1,
+        firstCall: { args: [ '0.0.2' ] }
+    });
 });
 
 test('always uses the highest version', async function () {
@@ -141,8 +143,10 @@ test('always uses the highest version', async function () {
 
     await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
-    assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, [ '2.0.0' ]);
+    assert.partialDeepStrictEqual(getFirstParentCommitLogs, {
+        callCount: 1,
+        firstCall: { args: [ '2.0.0' ] }
+    });
 });
 
 test('ignores prerelease versions', async function () {
@@ -152,8 +156,10 @@ test('ignores prerelease versions', async function () {
 
     await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.strictEqual(getFirstParentCommitLogs.callCount, 1);
-    assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, [ '2.0.0' ]);
+    assert.partialDeepStrictEqual(getFirstParentCommitLogs, {
+        callCount: 1,
+        firstCall: { args: [ '2.0.0' ] }
+    });
 });
 
 test('throws when the pull request cannot be extracted from the commit message', async function () {
@@ -185,8 +191,10 @@ test('falls back to the GitHub API when the commit log does not have a body', as
 
     const pullRequests = await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.strictEqual(get.callCount, 1);
-    assert.deepStrictEqual(get.firstCall.args, [ { owner: 'any', repo: 'repo', pull_number: 1 } ]);
+    assert.partialDeepStrictEqual(get, {
+        callCount: 1,
+        firstCall: { args: [ { owner: 'any', repo: 'repo', pull_number: 1 } ] }
+    });
     assert.deepStrictEqual(pullRequests, [ { id: 1, title: 'pull request title from github', label: 'bug' } ]);
 });
 
@@ -305,9 +313,11 @@ test('waits between pull request label lookups', async function () {
 
     await getMergedPullRequests(anyRepo, { ...defaultPrLogConfig, labelLookupIntervalMilliseconds });
 
-    assert.strictEqual(waitForMilliseconds.callCount, expectedWaitForMillisecondsCallCount);
-    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [ labelLookupIntervalMilliseconds ]);
-    assert.deepStrictEqual(waitForMilliseconds.secondCall.args, [ labelLookupIntervalMilliseconds ]);
+    assert.partialDeepStrictEqual(waitForMilliseconds, {
+        callCount: expectedWaitForMillisecondsCallCount,
+        firstCall: { args: [ labelLookupIntervalMilliseconds ] },
+        secondCall: { args: [ labelLookupIntervalMilliseconds ] }
+    });
 });
 
 test('ignores first-parent commits that are not merge commits', async function () {

--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -11,9 +11,20 @@ import {
 const anyRepo = 'any/repo';
 const latestVersion = '1.2.3';
 const expectedPullRequestLabelCallCount = 2;
-const expectedWaitForMillisecondsCallCount = 2;
 const comparedArgumentCount = 2;
 const secondPullRequestIdentifier = 2;
+
+function assertSpyCalls(sinonSpy: SinonSpy, calls: readonly (readonly unknown[])[]): void {
+    assert.deepStrictEqual({
+        callCount: sinonSpy.callCount,
+        calls: sinonSpy.getCalls().map(function (call): readonly unknown[] {
+            return call.args as readonly unknown[];
+        })
+    }, {
+        callCount: calls.length,
+        calls
+    });
+}
 
 type Overrides = {
     readonly listTags?: SinonSpy;
@@ -130,10 +141,7 @@ test('ignores non-semver tag', async function () {
 
     await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.partialDeepStrictEqual(getFirstParentCommitLogs, {
-        callCount: 1,
-        firstCall: { args: [ '0.0.2' ] }
-    });
+    assertSpyCalls(getFirstParentCommitLogs, [ [ '0.0.2' ] ]);
 });
 
 test('always uses the highest version', async function () {
@@ -143,10 +151,7 @@ test('always uses the highest version', async function () {
 
     await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.partialDeepStrictEqual(getFirstParentCommitLogs, {
-        callCount: 1,
-        firstCall: { args: [ '2.0.0' ] }
-    });
+    assertSpyCalls(getFirstParentCommitLogs, [ [ '2.0.0' ] ]);
 });
 
 test('ignores prerelease versions', async function () {
@@ -156,10 +161,7 @@ test('ignores prerelease versions', async function () {
 
     await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.partialDeepStrictEqual(getFirstParentCommitLogs, {
-        callCount: 1,
-        firstCall: { args: [ '2.0.0' ] }
-    });
+    assertSpyCalls(getFirstParentCommitLogs, [ [ '2.0.0' ] ]);
 });
 
 test('throws when the pull request cannot be extracted from the commit message', async function () {
@@ -191,10 +193,7 @@ test('falls back to the GitHub API when the commit log does not have a body', as
 
     const pullRequests = await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
-    assert.partialDeepStrictEqual(get, {
-        callCount: 1,
-        firstCall: { args: [ { owner: 'any', repo: 'repo', pull_number: 1 } ] }
-    });
+    assertSpyCalls(get, [ [ { owner: 'any', repo: 'repo', pull_number: 1 } ] ]);
     assert.deepStrictEqual(pullRequests, [ { id: 1, title: 'pull request title from github', label: 'bug' } ]);
 });
 
@@ -313,11 +312,10 @@ test('waits between pull request label lookups', async function () {
 
     await getMergedPullRequests(anyRepo, { ...defaultPrLogConfig, labelLookupIntervalMilliseconds });
 
-    assert.partialDeepStrictEqual(waitForMilliseconds, {
-        callCount: expectedWaitForMillisecondsCallCount,
-        firstCall: { args: [ labelLookupIntervalMilliseconds ] },
-        secondCall: { args: [ labelLookupIntervalMilliseconds ] }
-    });
+    assertSpyCalls(waitForMilliseconds, [
+        [ labelLookupIntervalMilliseconds ],
+        [ labelLookupIntervalMilliseconds ]
+    ]);
 });
 
 test('ignores first-parent commits that are not merge commits', async function () {

--- a/source/lib/get-pull-request-label.test.ts
+++ b/source/lib/get-pull-request-label.test.ts
@@ -52,6 +52,18 @@ const expectedRateLimitResetDelayMilliseconds = 4000;
 const rateLimitResetSeconds = (currentTimeMilliseconds + expectedRateLimitResetDelayMilliseconds) /
     millisecondsPerSecond;
 
+function assertSpyCalls(sinonSpy: SinonSpy, calls: readonly (readonly unknown[])[]): void {
+    assert.deepStrictEqual({
+        callCount: sinonSpy.callCount,
+        calls: sinonSpy.getCalls().map(function (call): readonly unknown[] {
+            return call.args as readonly unknown[];
+        })
+    }, {
+        callCount: calls.length,
+        calls
+    });
+}
+
 function createGitHubRateLimitError(
     message: string,
     headers: Readonly<Record<string, number | string>>
@@ -117,10 +129,7 @@ test('requests the labels for the correct repo and pull request', async function
         maximumRateLimitRetryCount
     });
 
-    assert.partialDeepStrictEqual(listLabelsOnIssue, {
-        callCount: 1,
-        firstCall: { args: [ { owner: 'any', repo: 'repo', issue_number: 123 } ] }
-    });
+    assertSpyCalls(listLabelsOnIssue, [ [ { owner: 'any', repo: 'repo', issue_number: 123 } ] ]);
 });
 
 test('fulfills with the correct label name', async function () {
@@ -249,10 +258,7 @@ test('retries using the retry-after header', async function () {
 
     assert.strictEqual(labelName, 'bug');
     assert.strictEqual(listLabelsOnIssue.callCount, expectedRequestAttemptCount);
-    assert.partialDeepStrictEqual(waitForMilliseconds, {
-        callCount: 1,
-        firstCall: { args: [ expectedRetryAfterDelayMilliseconds ] }
-    });
+    assertSpyCalls(waitForMilliseconds, [ [ expectedRetryAfterDelayMilliseconds ] ]);
 });
 
 test('retries using the rate limit reset header when retry-after is missing', async function () {
@@ -277,10 +283,7 @@ test('retries using the rate limit reset header when retry-after is missing', as
 
     assert.strictEqual(labelName, 'bug');
     assert.strictEqual(listLabelsOnIssue.callCount, expectedRequestAttemptCount);
-    assert.partialDeepStrictEqual(waitForMilliseconds, {
-        callCount: 1,
-        firstCall: { args: [ expectedRateLimitResetDelayMilliseconds ] }
-    });
+    assertSpyCalls(waitForMilliseconds, [ [ expectedRateLimitResetDelayMilliseconds ] ]);
 });
 
 test('rejects immediately when a non-error value was thrown', async function () {

--- a/source/lib/get-pull-request-label.test.ts
+++ b/source/lib/get-pull-request-label.test.ts
@@ -117,8 +117,10 @@ test('requests the labels for the correct repo and pull request', async function
         maximumRateLimitRetryCount
     });
 
-    assert.strictEqual(listLabelsOnIssue.callCount, 1);
-    assert.deepStrictEqual(listLabelsOnIssue.firstCall.args, [ { owner: 'any', repo: 'repo', issue_number: 123 } ]);
+    assert.partialDeepStrictEqual(listLabelsOnIssue, {
+        callCount: 1,
+        firstCall: { args: [ { owner: 'any', repo: 'repo', issue_number: 123 } ] }
+    });
 });
 
 test('fulfills with the correct label name', async function () {
@@ -247,8 +249,10 @@ test('retries using the retry-after header', async function () {
 
     assert.strictEqual(labelName, 'bug');
     assert.strictEqual(listLabelsOnIssue.callCount, expectedRequestAttemptCount);
-    assert.strictEqual(waitForMilliseconds.callCount, 1);
-    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [ expectedRetryAfterDelayMilliseconds ]);
+    assert.partialDeepStrictEqual(waitForMilliseconds, {
+        callCount: 1,
+        firstCall: { args: [ expectedRetryAfterDelayMilliseconds ] }
+    });
 });
 
 test('retries using the rate limit reset header when retry-after is missing', async function () {
@@ -273,8 +277,10 @@ test('retries using the rate limit reset header when retry-after is missing', as
 
     assert.strictEqual(labelName, 'bug');
     assert.strictEqual(listLabelsOnIssue.callCount, expectedRequestAttemptCount);
-    assert.strictEqual(waitForMilliseconds.callCount, 1);
-    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [ expectedRateLimitResetDelayMilliseconds ]);
+    assert.partialDeepStrictEqual(waitForMilliseconds, {
+        callCount: 1,
+        firstCall: { args: [ expectedRateLimitResetDelayMilliseconds ] }
+    });
 });
 
 test('rejects immediately when a non-error value was thrown', async function () {

--- a/source/lib/git-command-runner.test.ts
+++ b/source/lib/git-command-runner.test.ts
@@ -17,14 +17,20 @@ function gitCommandRunnerFactory(overrides: Overrides = {}): GitCommandRunner {
     return createGitCommandRunner(fakeDependencies);
 }
 
+function assertExecutedCommand(execute: SinonSpy, command: string): void {
+    assert.partialDeepStrictEqual(execute, {
+        callCount: 1,
+        firstCall: { args: [ command ] }
+    });
+}
+
 test('getShortStatus() executes "git status" with correct options', async function () {
     const execute = fake.resolves({ stdout: '' });
     const runner = gitCommandRunnerFactory({ execute });
 
     await runner.getShortStatus();
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [ 'git status --short' ]);
+    assertExecutedCommand(execute, 'git status --short');
 });
 
 test('getShortStatus() returns the command output without leading or trailing whitespace', async function () {
@@ -42,8 +48,7 @@ test('getCurrentBranchName() executes "git rev-parse" with correct options', asy
 
     await runner.getCurrentBranchName();
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [ 'git rev-parse --abbrev-ref HEAD' ]);
+    assertExecutedCommand(execute, 'git rev-parse --abbrev-ref HEAD');
 });
 
 test('getCurrentBranchName() returns the command output without leading or trailing whitespace', async function () {
@@ -61,8 +66,7 @@ test('fetchRemote() executes "git fetch" with the given remote', async function 
 
     await runner.fetchRemote('foo');
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [ 'git fetch foo' ]);
+    assertExecutedCommand(execute, 'git fetch foo');
 });
 
 test('getSymmetricDifferencesBetweenBranches() executes "git rev-list" with correct options', async function () {
@@ -71,8 +75,7 @@ test('getSymmetricDifferencesBetweenBranches() executes "git rev-list" with corr
 
     await runner.getSymmetricDifferencesBetweenBranches('a', 'b');
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [ 'git rev-list --left-right a...b' ]);
+    assertExecutedCommand(execute, 'git rev-list --left-right a...b');
 });
 
 test('getSymmetricDifferencesBetweenBranches() returns the command output splitted as individual lines', async function () {
@@ -90,8 +93,7 @@ test('getRemoteAliases() executes "git remote -v"', async function () {
 
     await runner.getRemoteAliases();
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [ 'git remote -v' ]);
+    assertExecutedCommand(execute, 'git remote -v');
 });
 
 test('getRemoteAliases() returns the parsed command output', async function () {
@@ -121,8 +123,7 @@ test('listTags() executes "git tag" with correct options', async function () {
 
     await runner.listTags();
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [ 'git tag --list' ]);
+    assertExecutedCommand(execute, 'git tag --list');
 });
 
 test('listTags() returns the command output splitted as individual lines', async function () {
@@ -140,8 +141,7 @@ test('hasRef() executes "git rev-parse" with the given ref', async function () {
 
     await runner.hasRef('foo');
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [ 'git rev-parse --verify --quiet foo^{commit}' ]);
+    assertExecutedCommand(execute, 'git rev-parse --verify --quiet foo^{commit}');
 });
 
 test('hasRef() returns true when git finds the ref', async function () {
@@ -168,10 +168,10 @@ test('getMergeCommitLogs() executes "git log" with the correct options', async f
 
     await runner.getMergeCommitLogs('foo');
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [
+    assertExecutedCommand(
+        execute,
         'git log --first-parent --no-color --pretty=format:%s__||__%b##$$@@$$## --merges foo..HEAD'
-    ]);
+    );
 });
 
 test('getMergeCommitLogs() returns the parsed command output', async function () {
@@ -234,10 +234,10 @@ test('getFirstParentCommitLogs() executes "git log" with the correct options', a
 
     await runner.getFirstParentCommitLogs('foo');
 
-    assert.strictEqual(execute.callCount, 1);
-    assert.deepStrictEqual(execute.firstCall.args, [
+    assertExecutedCommand(
+        execute,
         'git log --first-parent --no-color --pretty=format:%H__||__%s__||__%b##$$@@$$## foo..HEAD'
-    ]);
+    );
 });
 
 test('getFirstParentCommitLogs() returns the parsed command output', async function () {

--- a/source/lib/git-command-runner.test.ts
+++ b/source/lib/git-command-runner.test.ts
@@ -18,9 +18,14 @@ function gitCommandRunnerFactory(overrides: Overrides = {}): GitCommandRunner {
 }
 
 function assertExecutedCommand(execute: SinonSpy, command: string): void {
-    assert.partialDeepStrictEqual(execute, {
+    assert.deepStrictEqual({
+        callCount: execute.callCount,
+        calls: execute.getCalls().map(function (call): readonly unknown[] {
+            return call.args as readonly unknown[];
+        })
+    }, {
         callCount: 1,
-        firstCall: { args: [ command ] }
+        calls: [ [ command ] ]
     });
 }
 

--- a/source/lib/pr-log-config.test.ts
+++ b/source/lib/pr-log-config.test.ts
@@ -20,22 +20,24 @@ test('reads changelog config from package info', function () {
         }
     });
 
-    assert.deepStrictEqual(config.validLabels, new Map([ [ 'custom', 'Custom Changes' ] ]));
-    assert.deepStrictEqual(config.ignoredLabels, [ 'release' ]);
-    assert.deepStrictEqual(config.versionBumps, { major: [], minor: [ 'custom' ], patch: [] });
-    assert.strictEqual(config.dateFormat, 'dd.MM.yyyy');
-    assert.deepStrictEqual(config.collapseRules, [
-        {
-            label: 'custom',
-            pattern: /^Custom (?<dependency>.+) from (?<from>.+) to (?<to>.+)$/u,
-            replace: 'Custom $<dependency> from $<from> to $<to>',
-            keyGroup: 'dependency',
-            fromGroup: 'from',
-            toGroup: 'to'
-        }
-    ]);
-    assert.strictEqual(config.labelLookupIntervalMilliseconds, defaultPrLogConfig.labelLookupIntervalMilliseconds);
-    assert.strictEqual(config.maximumRateLimitRetryCount, defaultPrLogConfig.maximumRateLimitRetryCount);
+    assert.partialDeepStrictEqual(config, {
+        validLabels: new Map([ [ 'custom', 'Custom Changes' ] ]),
+        ignoredLabels: [ 'release' ],
+        versionBumps: { major: [], minor: [ 'custom' ], patch: [] },
+        dateFormat: 'dd.MM.yyyy',
+        collapseRules: [
+            {
+                label: 'custom',
+                pattern: /^Custom (?<dependency>.+) from (?<from>.+) to (?<to>.+)$/u,
+                replace: 'Custom $<dependency> from $<from> to $<to>',
+                keyGroup: 'dependency',
+                fromGroup: 'from',
+                toGroup: 'to'
+            }
+        ],
+        labelLookupIntervalMilliseconds: defaultPrLogConfig.labelLookupIntervalMilliseconds,
+        maximumRateLimitRetryCount: defaultPrLogConfig.maximumRateLimitRetryCount
+    });
 });
 
 test('uses fallback config values when package info has no changelog config', function () {

--- a/source/lib/resolve-pull-request-labels.test.ts
+++ b/source/lib/resolve-pull-request-labels.test.ts
@@ -27,9 +27,14 @@ test('resolves labels for pull requests sequentially', async function () {
         targetScopedLabelPattern: undefined
     });
 
-    assert.partialDeepStrictEqual(waitForMilliseconds, {
+    assert.deepStrictEqual({
+        callCount: waitForMilliseconds.callCount,
+        calls: waitForMilliseconds.getCalls().map(function (call): readonly unknown[] {
+            return call.args as readonly unknown[];
+        })
+    }, {
         callCount: 1,
-        firstCall: { args: [ labelLookupIntervalMilliseconds ] }
+        calls: [ [ labelLookupIntervalMilliseconds ] ]
     });
     assert.deepStrictEqual(pullRequests, [
         { id: 1, title: 'Fix bug', label: 'bug' },

--- a/source/lib/resolve-pull-request-labels.test.ts
+++ b/source/lib/resolve-pull-request-labels.test.ts
@@ -27,8 +27,10 @@ test('resolves labels for pull requests sequentially', async function () {
         targetScopedLabelPattern: undefined
     });
 
-    assert.strictEqual(waitForMilliseconds.callCount, 1);
-    assert.deepStrictEqual(waitForMilliseconds.firstCall.args, [ labelLookupIntervalMilliseconds ]);
+    assert.partialDeepStrictEqual(waitForMilliseconds, {
+        callCount: 1,
+        firstCall: { args: [ labelLookupIntervalMilliseconds ] }
+    });
     assert.deepStrictEqual(pullRequests, [
         { id: 1, title: 'Fix bug', label: 'bug' },
         { id: secondPullRequestId, title: 'Update docs', label: 'documentation' }


### PR DESCRIPTION
`Mocha` tests in this repository already use `node:assert`, so this switches ESLint test linting to `@enormora/eslint-config-mocha-node-assert`. Assertions were updated for the additional `node-assert` rules reported by that preset.