### PR TITLE
Add `extractChangelogReleaseSection` to `@pr-log/core`

### DIFF
--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { fake } from 'sinon';
+import { ok } from 'true-myth/result';
 import { defaultPrLogConfig, type PrLogConfig } from '../lib/pr-log-config.ts';
 import type { GitCommandRunner } from '../lib/git-command-runner.ts';
 import type { GetPullRequestLabels } from '../lib/get-pull-request-label.ts';
@@ -469,4 +470,17 @@ test('updates changelog markdown', function () {
     });
 
     assert.strictEqual(changelog, '## 1.0.0\n\n* New change\n\n## 0.9.0\n\n* Older change\n');
+});
+
+test('extracts changelog release sections', function () {
+    const engine = createEngine();
+
+    const releaseSection = engine.extractChangelogReleaseSection({
+        changelogMarkdown:
+            '## 1.0.0 (January 1, 1970)\n\n* New change\n\n## 0.9.0 (December 31, 1969)\n\n* Older change\n',
+        targetName: undefined,
+        versionNumber: '1.0.0'
+    });
+
+    assert.deepStrictEqual(releaseSection, ok('## 1.0.0 (January 1, 1970)\n\n* New change'));
 });

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -30,9 +30,13 @@ import {
     renderGroupedTargetChangelogMarkdown,
     renderChangelogMarkdown,
     renderTargetChangelogMarkdown,
+    extractChangelogReleaseSection as extractChangelogReleaseSectionValue,
+    type ExtractChangelogReleaseSectionInput as ExtractChangelogReleaseSectionInputValue,
+    type ExtractChangelogReleaseSectionResult as ExtractChangelogReleaseSectionResultValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
     type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
     type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
+    type ReleaseSectionNotFound as ReleaseSectionNotFoundValue,
     updateChangelogMarkdown,
     type TargetChangelogSection as TargetChangelogSectionValue,
     type UpdateChangelogMarkdownInput as UpdateChangelogMarkdownInputValue
@@ -78,6 +82,9 @@ export type PrLogEngine = {
     filterPullRequestsByTargetFiles: (input: FilterPullRequestsByTargetFilesInputValue) => readonly PullRequestValue[];
     resolvePullRequestLabels: (input: ResolvePullRequestLabelsOptions) => Promise<readonly PullRequestWithLabelValue[]>;
     resolveVersionNumber: (input: ResolveVersionNumberInput) => string;
+    extractChangelogReleaseSection: (
+        input: ExtractChangelogReleaseSectionInputValue
+    ) => ExtractChangelogReleaseSectionResultValue;
     renderChangelog: (input: RenderChangelogMarkdownInputValue) => string;
     renderTargetChangelog: (input: RenderTargetChangelogMarkdownInputValue) => string;
     renderGroupedTargetChangelog: (input: RenderGroupedTargetChangelogMarkdownInputValue) => string;
@@ -248,6 +255,7 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
             );
         },
 
+        extractChangelogReleaseSection: extractChangelogReleaseSectionValue,
         renderChangelog: renderChangelogMarkdown,
         renderTargetChangelog: renderTargetChangelogMarkdown,
         renderGroupedTargetChangelog: renderGroupedTargetChangelogMarkdown,
@@ -256,6 +264,8 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
 }
 
 export type ChangelogBaseRef = ChangelogBaseRefValue;
+export type ExtractChangelogReleaseSectionInput = ExtractChangelogReleaseSectionInputValue;
+export type ExtractChangelogReleaseSectionResult = ExtractChangelogReleaseSectionResultValue;
 export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PullRequest = PullRequestValue;
@@ -264,5 +274,6 @@ export type PrLogConfig = PrLogConfigValue;
 export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
 export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
+export type ReleaseSectionNotFound = ReleaseSectionNotFoundValue;
 export type TargetChangelogSection = TargetChangelogSectionValue;
 export type UpdateChangelogInput = UpdateChangelogMarkdownInputValue;

--- a/source/lib/extract-changelog-release-section.test.ts
+++ b/source/lib/extract-changelog-release-section.test.ts
@@ -1,0 +1,201 @@
+import assert from 'node:assert';
+import { err, ok } from 'true-myth/result';
+import {
+    extractChangelogReleaseSection,
+    type ReleaseSectionNotFound
+} from './render-changelog-markdown.ts';
+
+test('extracts a package release section', function () {
+    const changelogMarkdown = [
+        '## package-name 1.2.3 (January 1, 1970)',
+        '',
+        '### Bug Fixes',
+        '',
+        '* Fix package bug',
+        '',
+        '## package-name 1.2.2 (December 31, 1969)',
+        '',
+        '* Older change',
+        ''
+    ]
+        .join('\n');
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: 'package-name',
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(
+        releaseSection,
+        ok('## package-name 1.2.3 (January 1, 1970)\n\n### Bug Fixes\n\n* Fix package bug')
+    );
+});
+
+test('extracts a scoped package release section', function () {
+    const changelogMarkdown = [
+        '## @scope/name 1.2.3 (January 1, 1970)',
+        '',
+        '### Features',
+        '',
+        '* Add scoped feature',
+        '',
+        '## @scope/name 1.2.2 (December 31, 1969)',
+        '',
+        '* Older change',
+        ''
+    ]
+        .join('\n');
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: '@scope/name',
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(
+        releaseSection,
+        ok('## @scope/name 1.2.3 (January 1, 1970)\n\n### Features\n\n* Add scoped feature')
+    );
+});
+
+test('extracts a release section without a target', function () {
+    const changelogMarkdown = [
+        '## 1.2.3 (January 1, 1970)',
+        '',
+        '### Documentation',
+        '',
+        '* Update docs',
+        '',
+        '## 1.2.2 (December 31, 1969)',
+        '',
+        '* Older change',
+        ''
+    ]
+        .join('\n');
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(releaseSection, ok('## 1.2.3 (January 1, 1970)\n\n### Documentation\n\n* Update docs'));
+});
+
+test('returns a typed not found result for missing versions', function () {
+    const changelogMarkdown = '## 1.2.2 (December 31, 1969)\n\n* Older change\n';
+    const expectedError: ReleaseSectionNotFound = {
+        reason: 'release-section-not-found',
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    };
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(releaseSection, err(expectedError));
+});
+
+test('does not return empty release sections', function () {
+    const changelogMarkdown = [
+        '## 1.2.3 (January 1, 1970)',
+        '',
+        ' '.repeat(3),
+        '',
+        '## 1.2.2 (December 31, 1969)',
+        '',
+        '* Older change',
+        ''
+    ]
+        .join('\n');
+    const expectedError: ReleaseSectionNotFound = {
+        reason: 'release-section-not-found',
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    };
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(releaseSection, err(expectedError));
+});
+
+test('stops extraction at the next release section boundary', function () {
+    const changelogMarkdown = [
+        '## 1.2.3 (January 1, 1970)',
+        '',
+        '### Bug Fixes',
+        '',
+        '* Fix current bug',
+        '',
+        '## package-name 1.2.2 (December 31, 1969)',
+        '',
+        '* Older package change',
+        ''
+    ]
+        .join('\n');
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(releaseSection, ok('## 1.2.3 (January 1, 1970)\n\n### Bug Fixes\n\n* Fix current bug'));
+});
+
+test('extracts a final release section without a following boundary', function () {
+    const changelogMarkdown = [
+        '## 1.2.4 (January 2, 1970)',
+        '',
+        '* Newer change',
+        '',
+        '## 1.2.3 (January 1, 1970)',
+        '',
+        '* Final matching change',
+        ''
+    ]
+        .join('\n');
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(releaseSection, ok('## 1.2.3 (January 1, 1970)\n\n* Final matching change'));
+});
+
+test('does not match unrelated headings or partial versions', function () {
+    const changelogMarkdown = [
+        '## Release 1.2.3 (January 1, 1970)',
+        '',
+        '* Not a pr-log release heading',
+        '',
+        '## 1.2.30 (January 1, 1970)',
+        '',
+        '* Wrong version',
+        ''
+    ]
+        .join('\n');
+    const expectedError: ReleaseSectionNotFound = {
+        reason: 'release-section-not-found',
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    };
+
+    const releaseSection = extractChangelogReleaseSection({
+        changelogMarkdown,
+        targetName: undefined,
+        versionNumber: '1.2.3'
+    });
+
+    assert.deepStrictEqual(releaseSection, err(expectedError));
+});

--- a/source/lib/render-changelog-markdown.ts
+++ b/source/lib/render-changelog-markdown.ts
@@ -1,4 +1,5 @@
 import { nothing } from 'true-myth/maybe';
+import { err, ok, type Result } from 'true-myth/result';
 import { createChangelogFactory, formatChangelogDate } from './create-changelog.ts';
 import type { PrLogConfig } from './pr-log-config.ts';
 import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
@@ -55,6 +56,106 @@ export type UpdateChangelogMarkdownInput = {
     readonly existingChangelogMarkdown: string;
     readonly generatedChangelogMarkdown: string;
 };
+
+export type ExtractChangelogReleaseSectionInput = {
+    readonly changelogMarkdown: string;
+    readonly targetName: string | undefined;
+    readonly versionNumber: string;
+};
+
+export type ReleaseSectionNotFound = {
+    readonly reason: 'release-section-not-found';
+    readonly targetName: string | undefined;
+    readonly versionNumber: string;
+};
+
+export type ExtractChangelogReleaseSectionResult = Result<string, ReleaseSectionNotFound>;
+
+type ChangelogReleaseHeading = {
+    readonly startIndex: number;
+    readonly endIndex: number;
+    readonly markdown: string;
+};
+
+const releaseVersionPattern = String.raw`\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?`;
+const releasePackagePattern = String.raw`(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*`;
+const releaseHeadingPattern = new RegExp(
+    String.raw`^## (?:${releaseVersionPattern}|${releasePackagePattern} ${releaseVersionPattern}) \(.+\)\s*$`,
+    'gimu'
+);
+
+function createReleaseSectionNotFound(input: ExtractChangelogReleaseSectionInput): ReleaseSectionNotFound {
+    return {
+        reason: 'release-section-not-found',
+        targetName: input.targetName,
+        versionNumber: input.versionNumber
+    };
+}
+
+function readReleaseHeadings(changelogMarkdown: string): readonly ChangelogReleaseHeading[] {
+    return Array.from(changelogMarkdown.matchAll(releaseHeadingPattern), function (match) {
+        return {
+            startIndex: match.index,
+            endIndex: match.index + match[0].length,
+            markdown: match[0]
+        };
+    });
+}
+
+function isRequestedReleaseHeading(
+    input: ExtractChangelogReleaseSectionInput,
+    heading: ChangelogReleaseHeading
+): boolean {
+    const requestedHeadingStart = input.targetName === undefined
+        ? `## ${input.versionNumber} (`
+        : `## ${input.targetName} ${input.versionNumber} (`;
+
+    return heading.markdown.trimEnd().startsWith(requestedHeadingStart);
+}
+
+function sectionEndIndex(
+    changelogMarkdown: string,
+    headings: readonly ChangelogReleaseHeading[],
+    headingIndex: number
+): number {
+    return headings[headingIndex + 1]?.startIndex ?? changelogMarkdown.length;
+}
+
+function extractMatchingReleaseSection(
+    input: ExtractChangelogReleaseSectionInput,
+    releaseHeadings: readonly ChangelogReleaseHeading[],
+    headingIndex: number,
+    heading: ChangelogReleaseHeading
+): string | undefined {
+    if (!isRequestedReleaseHeading(input, heading)) {
+        return undefined;
+    }
+
+    const endIndex = sectionEndIndex(input.changelogMarkdown, releaseHeadings, headingIndex);
+    const sectionBody = input.changelogMarkdown.slice(heading.endIndex, endIndex);
+
+    if (sectionBody.trim().length === 0) {
+        return undefined;
+    }
+
+    return input.changelogMarkdown.slice(heading.startIndex, endIndex).trimEnd();
+}
+
+export function extractChangelogReleaseSection(
+    input: ExtractChangelogReleaseSectionInput
+): ExtractChangelogReleaseSectionResult {
+    const releaseHeadings = readReleaseHeadings(input.changelogMarkdown);
+
+    for (const [ headingIndex, heading ] of releaseHeadings.entries()) {
+        const releaseSection = extractMatchingReleaseSection(input, releaseHeadings, headingIndex, heading);
+
+        if (releaseSection !== undefined) {
+            return ok(releaseSection);
+        }
+    }
+
+    return err(createReleaseSectionNotFound(input));
+}
 
 export function renderChangelogMarkdown(input: RenderChangelogMarkdownInput): string {
     const createChangelog = createChangelogFactory({

--- a/source/packages/core/README.md
+++ b/source/packages/core/README.md
@@ -20,7 +20,7 @@ const prLogEngine = createPrLogEngine({
 });
 ```
 
-`@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, changelog rendering, and changelog Markdown merging.
+`@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, changelog rendering, release-section extraction, and changelog Markdown merging.
 Target impact and release planning stay outside pr-log. Consumers pass target source files into pr-log when they need target-specific changelogs.
 
 A target-aware integration usually follows this flow:
@@ -33,8 +33,9 @@ A target-aware integration usually follows this flow:
 6. Resolve labels for each target.
 7. Render one Markdown string per target, or one grouped Markdown string for all targets.
 8. Read the existing changelog outside pr-log.
-9. Pass the existing and generated Markdown to `prLogEngine.updateChangelog()`.
-10. Write the returned Markdown outside pr-log.
+9. Extract an existing release section with `prLogEngine.extractChangelogReleaseSection()` when release tooling needs already-committed notes.
+10. Pass the existing and generated Markdown to `prLogEngine.updateChangelog()`.
+11. Write the returned Markdown outside pr-log.
 
 Target-scoped labels can override the pull request level label for one target. The default pattern is `{targetName}:{label}`.
 For example, `pkg-a:breaking` overrides a `bug` pull request label when rendering `pkg-a`, while other targets still use `bug`.
@@ -75,3 +76,6 @@ Consumers can pass a package tag format with `{packageName}` and `{version}` pla
 Missing package base refs reject with `MissingChangelogBaseRefError`.
 pr-log renders and merges Markdown only. Consumers decide whether that text is written to one file, separate target files, release notes, or another destination.
 pr-log does not compute target impact, map build artifacts to source files, publish packages, commit files, create tags, or create releases.
+
+`prLogEngine.extractChangelogReleaseSection()` reads changelog Markdown rendered by pr-log and returns the matching release section for a version and optional `targetName`.
+It returns a typed `ReleaseSectionNotFound` result when no non-empty matching section exists.

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -18,6 +18,8 @@ import {
     createPrLogEngineWithDependencies,
     type ChangelogBaseRef as ChangelogBaseRefValue,
     type CollectMergedPullRequestsOptions as CollectMergedPullRequestsOptionsValue,
+    type ExtractChangelogReleaseSectionInput as ExtractChangelogReleaseSectionInputValue,
+    type ExtractChangelogReleaseSectionResult as ExtractChangelogReleaseSectionResultValue,
     type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue,
     type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue,
     type PrLogEngine as PrLogEngineValue,
@@ -28,6 +30,7 @@ import {
     type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
     type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
+    type ReleaseSectionNotFound as ReleaseSectionNotFoundValue,
     type ResolveVersionNumberInput as ResolveVersionNumberInputValue,
     type ResolvePullRequestLabelsOptions as ResolvePullRequestLabelsOptionsValue,
     type TargetChangelogSection as TargetChangelogSectionValue,
@@ -72,6 +75,8 @@ export const defaultPrLogConfig: PrLogConfigValue = defaultPrLogConfigValue;
 export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type CollapseRule = CollapseRuleValue;
 export type CollectMergedPullRequestsOptions = CollectMergedPullRequestsOptionsValue;
+export type ExtractChangelogReleaseSectionInput = ExtractChangelogReleaseSectionInputValue;
+export type ExtractChangelogReleaseSectionResult = ExtractChangelogReleaseSectionResultValue;
 export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
 export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
 export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
@@ -85,6 +90,7 @@ export type ReadPullRequestLabelsOptions = ReadPullRequestLabelsOptionsValue;
 export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
 export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
 export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
+export type ReleaseSectionNotFound = ReleaseSectionNotFoundValue;
 export type ResolvePullRequestLabelsOptions = ResolvePullRequestLabelsOptionsValue;
 export type ResolveVersionNumberInput = ResolveVersionNumberInputValue;
 export type TargetChangelogSection = TargetChangelogSectionValue;


### PR DESCRIPTION
`@pr-log/core` can now recover a non-empty rendered release section for a version and optional target name from existing changelog Markdown.

The parser recognizes the release heading shapes rendered by pr-log, returns a typed not-found result, and stops at the next pr-log release heading.