### PR TITLE
Constrain Renovate `npm` tool updates to `npm@10`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "automergeType": "pr",
     "dependencyDashboard": false,
     "constraints": {
-        "npm": "12.0.1"
+        "npm": "10.9.8"
     },
     "lockFileMaintenance": {
         "enabled": true
@@ -16,6 +16,11 @@
         {
             "matchPackagePatterns": ["^@enormora/eslint-config", "^eslint$"],
             "groupName": "eslint"
+        },
+        {
+            "matchDatasources": ["npm"],
+            "matchPackageNames": ["npm"],
+            "allowedVersions": "<11.0.0"
         }
     ]
 }


### PR DESCRIPTION
Renovate uses `constraints.npm` to choose the npm version for lockfile updates. This restores the tool constraint to `10.9.8`, matching the npm bundled with the Node 22 CI job, and caps Renovate `npm` package updates below `11.0.0` so future lockfiles remain installable there.