### PR TITLE
Add configurable GitHub API base URL

### DIFF
--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -2,6 +2,8 @@ import {
     resolveChangelogBaseRef as resolveChangelogBaseRefValue,
     resolveLatestSemverTagBaseRef as resolveLatestSemverTagBaseRefValue,
     type ChangelogBaseRef as ChangelogBaseRefValue,
+    type MissingChangelogBaseRefError as MissingChangelogBaseRefErrorValue,
+    type MissingChangelogBaseRefReason as MissingChangelogBaseRefReasonValue,
     type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue
 } from '../lib/changelog-base-ref.ts';
 import {
@@ -49,6 +51,9 @@ export type CollectMergedPullRequestsOptions = {
     readonly githubRepo: string;
     readonly baseRef: string;
 };
+
+export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
+export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
 
 export type ReadPullRequestChangedFilesOptions = {
     readonly githubRepo: string;

--- a/source/packages/core/README.md
+++ b/source/packages/core/README.md
@@ -15,10 +15,13 @@ import { createPrLogEngine, defaultPrLogConfig } from '@pr-log/core';
 
 const prLogEngine = createPrLogEngine({
     githubToken: process.env.GH_TOKEN,
+    githubApiBaseUrl: undefined,
     workingDirectory: process.cwd(),
     config: defaultPrLogConfig
 });
 ```
+
+Set `githubApiBaseUrl` only when GitHub API requests must be routed to a compatible API endpoint.
 
 `@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, changelog rendering, release-section extraction, and changelog Markdown merging.
 Target impact and release planning stay outside pr-log. Consumers pass target source files into pr-log when they need target-specific changelogs.

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -9,10 +9,6 @@ import {
     type CollapseRule as CollapseRuleValue,
     type PrLogConfig as PrLogConfigValue
 } from '../../lib/pr-log-config.ts';
-import type {
-    MissingChangelogBaseRefError as MissingChangelogBaseRefErrorValue,
-    MissingChangelogBaseRefReason as MissingChangelogBaseRefReasonValue
-} from '../../lib/changelog-base-ref.ts';
 import { defaultValidLabels as defaultValidLabelsValue } from '../../lib/valid-labels.ts';
 import {
     createPrLogEngineWithDependencies,
@@ -22,6 +18,8 @@ import {
     type ExtractChangelogReleaseSectionInput as ExtractChangelogReleaseSectionInputValue,
     type ExtractChangelogReleaseSectionResult as ExtractChangelogReleaseSectionResultValue,
     type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue,
+    type MissingChangelogBaseRefError as MissingChangelogBaseRefErrorValue,
+    type MissingChangelogBaseRefReason as MissingChangelogBaseRefReasonValue,
     type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue,
     type LinklessChangelogEntry as LinklessChangelogEntryValue,
     type PrLogEngine as PrLogEngineValue,
@@ -39,9 +37,13 @@ import {
     type TargetChangelogSection as TargetChangelogSectionValue,
     type UpdateChangelogInput as UpdateChangelogInputValue
 } from '../../core/pr-log-engine.ts';
+import {
+    createGitHubClient,
+    type GitHubClientDependencies,
+    type GitHubClientOptions
+} from './github-client.ts';
 
-export type PrLogEngineOptions = {
-    readonly githubToken: string | undefined;
+export type PrLogEngineOptions = GitHubClientOptions & {
     readonly workingDirectory: string;
     readonly config: PrLogConfigValue;
 };
@@ -50,12 +52,10 @@ function createCurrentDate(): Readonly<Date> {
     return new Date();
 }
 
-function createGitHubClient(options: Readonly<PrLogEngineOptions>): Readonly<Octokit> {
-    return new Octokit({ auth: options.githubToken });
-}
+const gitHubClientDependencies: GitHubClientDependencies = { Octokit };
 
 export function createPrLogEngine(options: Readonly<PrLogEngineOptions>): PrLogEngineValue {
-    const githubClient = createGitHubClient(options);
+    const githubClient = createGitHubClient(gitHubClientDependencies, options);
     const execute: GitCommandExecutor = async function (command) {
         return execaCommand(command, { cwd: options.workingDirectory });
     };

--- a/source/packages/core/github-client.test.ts
+++ b/source/packages/core/github-client.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import { Octokit } from '@octokit/rest';
+import { stub, type SinonStub } from 'sinon';
+import { createGitHubClient, type GitHubClientDependencies } from './github-client.ts';
+
+function createOctokitStub(client: Readonly<Octokit>): GitHubClientDependencies['Octokit'] & SinonStub {
+    return stub().returns(client) as unknown as GitHubClientDependencies['Octokit'] & SinonStub;
+}
+
+test('creates the default GitHub client when no API base URL is configured', function () {
+    const expectedClient = new Octokit({ auth: 'expected' });
+    const OctokitConstructor = createOctokitStub(expectedClient);
+
+    const client = createGitHubClient(
+        { Octokit: OctokitConstructor },
+        { githubToken: 'token', githubApiBaseUrl: undefined }
+    );
+
+    assert.strictEqual(client, expectedClient);
+    assert.strictEqual(OctokitConstructor.calledWithNew(), true);
+    assert.deepStrictEqual(OctokitConstructor.firstCall.args, [ { auth: 'token' } ]);
+});
+
+test('creates a GitHub client with the configured API base URL', function () {
+    const expectedClient = new Octokit({ auth: 'expected' });
+    const OctokitConstructor = createOctokitStub(expectedClient);
+
+    const client = createGitHubClient(
+        { Octokit: OctokitConstructor },
+        { githubToken: 'token', githubApiBaseUrl: 'https://github.example/api' }
+    );
+
+    assert.strictEqual(client, expectedClient);
+    assert.strictEqual(OctokitConstructor.calledWithNew(), true);
+    assert.strictEqual(
+        OctokitConstructor.calledWith({
+            auth: 'token',
+            baseUrl: 'https://github.example/api'
+        }),
+        true
+    );
+});

--- a/source/packages/core/github-client.ts
+++ b/source/packages/core/github-client.ts
@@ -1,0 +1,22 @@
+import type { Octokit, Octokit as OctokitConstructor } from '@octokit/rest';
+
+export type GitHubClientOptions = {
+    readonly githubToken: string | undefined;
+    readonly githubApiBaseUrl?: string | undefined;
+};
+
+export type GitHubClientDependencies = {
+    readonly Octokit: new (
+        options: ConstructorParameters<typeof OctokitConstructor>[0]
+    ) => Readonly<Octokit>;
+};
+
+export function createGitHubClient(
+    dependencies: GitHubClientDependencies,
+    options: GitHubClientOptions
+): Readonly<Octokit> {
+    if (options.githubApiBaseUrl === undefined) {
+        return new dependencies.Octokit({ auth: options.githubToken });
+    }
+    return new dependencies.Octokit({ auth: options.githubToken, baseUrl: options.githubApiBaseUrl });
+}


### PR DESCRIPTION
Adds a `githubApiBaseUrl` option to `createPrLogEngine` so tests and compatible GitHub API deployments can route requests away from `api.github.com`. The default remains unchanged when the option is omitted.
