### PR TITLE
Support changelog entries without PR links

### DIFF
--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -31,8 +31,10 @@ import {
     renderChangelogMarkdown,
     renderTargetChangelogMarkdown,
     extractChangelogReleaseSection as extractChangelogReleaseSectionValue,
+    type ChangelogEntryInput as ChangelogEntryInputValue,
     type ExtractChangelogReleaseSectionInput as ExtractChangelogReleaseSectionInputValue,
     type ExtractChangelogReleaseSectionResult as ExtractChangelogReleaseSectionResultValue,
+    type LinklessChangelogEntry as LinklessChangelogEntryValue,
     type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
     type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
     type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
@@ -267,6 +269,8 @@ export type ChangelogBaseRef = ChangelogBaseRefValue;
 export type ExtractChangelogReleaseSectionInput = ExtractChangelogReleaseSectionInputValue;
 export type ExtractChangelogReleaseSectionResult = ExtractChangelogReleaseSectionResultValue;
 export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
+export type ChangelogEntryInput = ChangelogEntryInputValue;
+export type LinklessChangelogEntry = LinklessChangelogEntryValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PullRequest = PullRequestValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;

--- a/source/lib/create-changelog.test.ts
+++ b/source/lib/create-changelog.test.ts
@@ -272,6 +272,44 @@ test('collapses repeated pull requests when a matching collapse rule is configur
     assert.ok(changelog.includes(expectedChangelog));
 });
 
+test('collapses linkless changelog entries without rendering pull request links', function () {
+    const validLabels = new Map([ [ 'upgrade', 'Dependency Upgrades' ] ]);
+    const createChangelog = createChangelogWithConfig({
+        ...createPrLogConfigFromPackageInfo(createUpgradeCollapseRulePackageInfo()),
+        validLabels,
+        versionBumps: { major: [], minor: [], patch: [ 'upgrade' ] }
+    });
+    const mergedPullRequests = [
+        {
+            id: undefined,
+            title: 'Update foo from 2 to 3',
+            label: 'upgrade'
+        },
+        {
+            id: undefined,
+            title: 'Update foo from 1 to 2',
+            label: 'upgrade'
+        }
+    ] as const;
+
+    const expectedChangelog = [
+        '### Dependency Upgrades',
+        '',
+        '* Update foo from 1 to 3',
+        ''
+    ]
+        .join('\n');
+
+    const options = changelogOptionsFactory.build({
+        mergedPullRequests,
+        githubRepo: 'any/repo'
+    });
+    const changelog = createChangelog(options);
+
+    assert.ok(changelog.includes(expectedChangelog));
+    assert.ok(!changelog.includes('pull/undefined'));
+});
+
 test('does not collapse pull requests when the configured version chain is incomplete', function () {
     const validLabels = new Map([ [ 'upgrade', 'Dependency Upgrades' ] ]);
     const createChangelog = createChangelogWithConfig({

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -3,7 +3,7 @@ import { isArray } from '@sindresorhus/is';
 import { enUS as enLocale } from 'date-fns/locale/en-US';
 import type { Just, Nothing } from 'true-myth/maybe';
 import type { CollapseRule, PrLogConfig } from './pr-log-config.ts';
-import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
+import type { ChangelogEntryInput } from './render-changelog-markdown.ts';
 
 function formatLinkToPullRequest(pullRequestId: number, repo: string): string {
     return `[#${pullRequestId}](https://github.com/${repo}/pull/${pullRequestId})`;
@@ -14,10 +14,14 @@ type ChangelogEntry = {
     readonly pullRequestIds: readonly number[];
 };
 
-function formatPullRequest(entry: ChangelogEntry, repo: string): string {
+function formatChangelogEntry(entry: ChangelogEntry, repo: string): string {
     const formattedLinks = entry.pullRequestIds.map(function (pullRequestId) {
         return formatLinkToPullRequest(pullRequestId, repo);
     });
+
+    if (formattedLinks.length === 0) {
+        return `* ${entry.title}\n`;
+    }
 
     return `* ${entry.title} (${formattedLinks.join(', ')})\n`;
 }
@@ -25,7 +29,7 @@ function formatPullRequest(entry: ChangelogEntry, repo: string): string {
 function formatListOfPullRequests(entries: readonly ChangelogEntry[], repo: string): string {
     return entries
         .map(function (entry) {
-            return formatPullRequest(entry, repo);
+            return formatChangelogEntry(entry, repo);
         })
         .join('');
 }
@@ -43,8 +47,8 @@ export function formatChangelogDate(dateFormat: string | undefined, date: Readon
     return formatDate(date, resolvedDateFormat, { locale: enLocale });
 }
 
-function groupByLabel(pullRequests: readonly PullRequestWithLabel[]): Record<string, PullRequestWithLabel[]> {
-    return pullRequests.reduce(function (groupedObject: Readonly<Record<string, PullRequestWithLabel[]>>, pullRequest) {
+function groupByLabel(pullRequests: readonly ChangelogEntryInput[]): Record<string, ChangelogEntryInput[]> {
+    return pullRequests.reduce(function (groupedObject: Readonly<Record<string, ChangelogEntryInput[]>>, pullRequest) {
         const { label } = pullRequest;
         const group = groupedObject[label];
 
@@ -93,11 +97,11 @@ type CollapseChainContext = {
     readonly ruleMatch: RuleMatch;
 };
 
-function createChangelogEntries(pullRequests: readonly PullRequestWithLabel[]): readonly ChangelogEntryWithLabel[] {
+function createChangelogEntries(pullRequests: readonly ChangelogEntryInput[]): readonly ChangelogEntryWithLabel[] {
     return pullRequests.map(function (pullRequest) {
         return {
             title: pullRequest.title,
-            pullRequestIds: [ pullRequest.id ],
+            pullRequestIds: pullRequest.id === undefined ? [] : [ pullRequest.id ],
             label: pullRequest.label
         };
     });
@@ -287,14 +291,14 @@ type Dependencies = {
 type ChangelogOptionsUnreleased = {
     readonly unreleased: true;
     readonly versionNumber: Nothing<string>;
-    readonly mergedPullRequests: readonly PullRequestWithLabel[];
+    readonly mergedPullRequests: readonly ChangelogEntryInput[];
     readonly githubRepo: string;
 };
 
 type ChangelogOptionsReleased = {
     readonly unreleased: false;
     readonly versionNumber: Just<string>;
-    readonly mergedPullRequests: readonly PullRequestWithLabel[];
+    readonly mergedPullRequests: readonly ChangelogEntryInput[];
     readonly githubRepo: string;
 };
 

--- a/source/lib/render-changelog-markdown.test.ts
+++ b/source/lib/render-changelog-markdown.test.ts
@@ -49,6 +49,22 @@ test('renders target changelog markdown', function () {
     assert.ok(changelog.includes('* Fix bug ([#1](https://github.com/owner/repo/pull/1))'));
 });
 
+test('renders linkless changelog entries', function () {
+    const changelog = renderTargetChangelogMarkdown({
+        config: defaultPrLogConfig,
+        currentDate: new Date(0),
+        targetName: 'pkg-a',
+        mergedPullRequests: [ { id: undefined, title: 'Update dependency to 1.2.3', label: 'bug' } ],
+        githubRepo: 'owner/repo',
+        unreleased: true,
+        versionNumber: undefined
+    });
+
+    assert.ok(changelog.includes('* Update dependency to 1.2.3\n'));
+    assert.ok(!changelog.includes('pull/undefined'));
+    assert.ok(!changelog.includes('(https://github.com/owner/repo/pull/'));
+});
+
 test('renders grouped target changelog markdown', function () {
     const changelog = renderGroupedTargetChangelogMarkdown({
         config: defaultPrLogConfig,

--- a/source/lib/render-changelog-markdown.ts
+++ b/source/lib/render-changelog-markdown.ts
@@ -5,10 +5,18 @@ import type { PrLogConfig } from './pr-log-config.ts';
 import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
 import { createVersionNumber } from './version-number.ts';
 
+export type LinklessChangelogEntry = {
+    readonly id: undefined;
+    readonly title: string;
+    readonly label: string;
+};
+
+export type ChangelogEntryInput = LinklessChangelogEntry | PullRequestWithLabel;
+
 type RenderChangelogMarkdownInputBase = {
     readonly config: PrLogConfig;
     readonly currentDate: Readonly<Date>;
-    readonly mergedPullRequests: readonly PullRequestWithLabel[];
+    readonly mergedPullRequests: readonly ChangelogEntryInput[];
     readonly githubRepo: string;
 };
 
@@ -28,7 +36,7 @@ export type RenderChangelogMarkdownInput =
 
 type TargetChangelogSectionBase = {
     readonly targetName: string;
-    readonly mergedPullRequests: readonly PullRequestWithLabel[];
+    readonly mergedPullRequests: readonly ChangelogEntryInput[];
 };
 
 type ReleasedTargetChangelogSection = TargetChangelogSectionBase & {

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -18,10 +18,12 @@ import {
     createPrLogEngineWithDependencies,
     type ChangelogBaseRef as ChangelogBaseRefValue,
     type CollectMergedPullRequestsOptions as CollectMergedPullRequestsOptionsValue,
+    type ChangelogEntryInput as ChangelogEntryInputValue,
     type ExtractChangelogReleaseSectionInput as ExtractChangelogReleaseSectionInputValue,
     type ExtractChangelogReleaseSectionResult as ExtractChangelogReleaseSectionResultValue,
     type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue,
     type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue,
+    type LinklessChangelogEntry as LinklessChangelogEntryValue,
     type PrLogEngine as PrLogEngineValue,
     type PullRequest as PullRequestValue,
     type PullRequestWithLabel as PullRequestWithLabelValue,
@@ -73,6 +75,7 @@ export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultVa
 export const defaultPrLogConfig: PrLogConfigValue = defaultPrLogConfigValue;
 
 export type ChangelogBaseRef = ChangelogBaseRefValue;
+export type ChangelogEntryInput = ChangelogEntryInputValue;
 export type CollapseRule = CollapseRuleValue;
 export type CollectMergedPullRequestsOptions = CollectMergedPullRequestsOptionsValue;
 export type ExtractChangelogReleaseSectionInput = ExtractChangelogReleaseSectionInputValue;
@@ -81,6 +84,7 @@ export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFil
 export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
 export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
+export type LinklessChangelogEntry = LinklessChangelogEntryValue;
 export type PrLogEngine = PrLogEngineValue;
 export type PrLogConfig = PrLogConfigValue;
 export type PullRequest = PullRequestValue;


### PR DESCRIPTION
Allows rendered changelog entries to use `id: undefined` when they represent generated release notes rather than a merged pull request. Those entries keep normal label grouping and collapse behavior, but render without a PR link.
