### PR TITLE
Expose pull request changed file metadata

### DIFF
--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -4,7 +4,7 @@ import { ok } from 'true-myth/result';
 import { defaultPrLogConfig, type PrLogConfig } from '../lib/pr-log-config.ts';
 import type { GitCommandRunner } from '../lib/git-command-runner.ts';
 import type { GetPullRequestLabels } from '../lib/get-pull-request-label.ts';
-import type { PullRequestChangedFilesReader } from '../lib/pull-request-changed-files.ts';
+import type { PullRequestChangedFile, PullRequestChangedFilesReader } from '../lib/pull-request-changed-files.ts';
 import {
     createPrLogEngineWithDependencies,
     type PrLogEngine,
@@ -15,6 +15,17 @@ const githubRepo = 'owner/repo';
 const pullRequestId = 1;
 const documentationPullRequestId = 2;
 const waitDurationMilliseconds = 25;
+
+function changedFile(path: string): PullRequestChangedFile {
+    return {
+        path,
+        previousPath: undefined,
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        changes: 1
+    };
+}
 
 type EngineOverrides = {
     readonly gitCommandRunner?: GitCommandRunner;
@@ -70,7 +81,7 @@ function createDefaultEngineOverrides(): Required<EngineOverrides> {
             }
         },
         pullRequestChangedFilesReader: {
-            getChangedFiles: fake.resolves([ 'source/index.ts' ])
+            getChangedFiles: fake.resolves([ changedFile('source/index.ts') ])
         },
         async getPullRequestLabels() {
             return [ 'bug' ];
@@ -181,7 +192,7 @@ test('reads pull request changed files', async function () {
             githubRepo,
             pullRequests: [ { id: pullRequestId, title: 'Fix bug' } ]
         }),
-        new Map([ [ pullRequestId, [ 'source/index.ts' ] ] ])
+        new Map([ [ pullRequestId, [ changedFile('source/index.ts') ] ] ])
     );
 });
 
@@ -197,8 +208,8 @@ test('filters pull requests by target files', function () {
                 { id: documentationPullRequestId, title: 'Add docs' }
             ],
             changedFilesByPullRequest: new Map([
-                [ pullRequestId, [ 'source/index.ts' ] ],
-                [ documentationPullRequestId, [ 'README.md' ] ]
+                [ pullRequestId, [ changedFile('source/index.ts') ] ],
+                [ documentationPullRequestId, [ changedFile('README.md') ] ]
             ]),
             ignoredAttributionPaths: []
         }),

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -19,6 +19,7 @@ import type { GetPullRequestLabels, GitHubPullRequestLabelClient } from '../lib/
 import type { PrLogConfig as PrLogConfigValue } from '../lib/pr-log-config.ts';
 import {
     fetchPullRequestChangedFiles as fetchPullRequestChangedFilesValue,
+    type PullRequestChangedFile as PullRequestChangedFileValue,
     type PullRequestChangedFilesReader
 } from '../lib/pull-request-changed-files.ts';
 import { proposeVersionNumber as proposeVersionNumberValue } from '../lib/propose-version-number.ts';
@@ -77,7 +78,7 @@ export type PrLogEngine = {
     collectMergedPullRequests: (input: CollectMergedPullRequestsOptions) => Promise<readonly PullRequestValue[]>;
     readPullRequestChangedFiles: (
         input: ReadPullRequestChangedFilesOptions
-    ) => Promise<ReadonlyMap<number, readonly string[]>>;
+    ) => Promise<ReadonlyMap<number, readonly PullRequestChangedFileValue[]>>;
     readPullRequestLabels: (input: ReadPullRequestLabelsOptions) => Promise<ReadonlyMap<number, readonly string[]>>;
     filterPullRequestsByTargetFiles: (input: FilterPullRequestsByTargetFilesInputValue) => readonly PullRequestValue[];
     resolvePullRequestLabels: (input: ResolvePullRequestLabelsOptions) => Promise<readonly PullRequestWithLabelValue[]>;
@@ -269,6 +270,7 @@ export type ExtractChangelogReleaseSectionResult = ExtractChangelogReleaseSectio
 export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
 export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PullRequest = PullRequestValue;
+export type PullRequestChangedFile = PullRequestChangedFileValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;
 export type PrLogConfig = PrLogConfigValue;
 export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;

--- a/source/lib/filter-pull-requests-by-target-files.test.ts
+++ b/source/lib/filter-pull-requests-by-target-files.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { filterPullRequestsByTargetFiles } from './filter-pull-requests-by-target-files.ts';
 import type { PullRequest } from './collect-merged-pull-requests.ts';
+import type { PullRequestChangedFile } from './pull-request-changed-files.ts';
 
 const pullRequests: readonly PullRequest[] = [
     { id: 1, title: 'Fix target' },
@@ -10,10 +11,21 @@ const pullRequests: readonly PullRequest[] = [
 const unrelatedPullRequestId = 2;
 const changelogPullRequestId = 3;
 
+function changedFile(path: string, previousPath?: string): PullRequestChangedFile {
+    return {
+        path,
+        previousPath,
+        status: previousPath === undefined ? 'modified' : 'renamed',
+        additions: 1,
+        deletions: 0,
+        changes: 1
+    };
+}
+
 test('keeps pull requests that changed target source files', function () {
-    const changedFilesByPullRequest = new Map<number, readonly string[]>([
-        [ 1, [ 'source/index.ts' ] ],
-        [ unrelatedPullRequestId, [ 'test/index.test.ts' ] ]
+    const changedFilesByPullRequest = new Map<number, readonly PullRequestChangedFile[]>([
+        [ 1, [ changedFile('source/index.ts') ] ],
+        [ unrelatedPullRequestId, [ changedFile('test/index.test.ts') ] ]
     ]);
 
     const filteredPullRequests = filterPullRequestsByTargetFiles({
@@ -28,7 +40,9 @@ test('keeps pull requests that changed target source files', function () {
 });
 
 test('normalizes repository paths before matching target files', function () {
-    const changedFilesByPullRequest = new Map<number, readonly string[]>([ [ 1, [ '.\\source\\index.ts' ] ] ]);
+    const changedFilesByPullRequest = new Map<number, readonly PullRequestChangedFile[]>([
+        [ 1, [ changedFile('.\\source\\index.ts') ] ]
+    ]);
 
     const filteredPullRequests = filterPullRequestsByTargetFiles({
         targetName: 'target',
@@ -41,10 +55,26 @@ test('normalizes repository paths before matching target files', function () {
     assert.deepStrictEqual(filteredPullRequests, [ { id: 1, title: 'Fix target' } ]);
 });
 
+test('keeps pull requests that renamed target source files', function () {
+    const changedFilesByPullRequest = new Map<number, readonly PullRequestChangedFile[]>([
+        [ 1, [ changedFile('source/new.ts', 'source/index.ts') ] ]
+    ]);
+
+    const filteredPullRequests = filterPullRequestsByTargetFiles({
+        targetName: 'target',
+        targetSourceFiles: [ 'source/index.ts' ],
+        pullRequests: [ { id: 1, title: 'Rename target' } ],
+        changedFilesByPullRequest,
+        ignoredAttributionPaths: []
+    });
+
+    assert.deepStrictEqual(filteredPullRequests, [ { id: 1, title: 'Rename target' } ]);
+});
+
 test('ignores supplied attribution paths', function () {
-    const changedFilesByPullRequest = new Map<number, readonly string[]>([
-        [ 1, [ 'source/index.ts' ] ],
-        [ changelogPullRequestId, [ 'CHANGELOG.md' ] ]
+    const changedFilesByPullRequest = new Map<number, readonly PullRequestChangedFile[]>([
+        [ 1, [ changedFile('source/index.ts') ] ],
+        [ changelogPullRequestId, [ changedFile('CHANGELOG.md') ] ]
     ]);
 
     const filteredPullRequests = filterPullRequestsByTargetFiles({

--- a/source/lib/filter-pull-requests-by-target-files.ts
+++ b/source/lib/filter-pull-requests-by-target-files.ts
@@ -1,10 +1,11 @@
 import type { PullRequest } from './collect-merged-pull-requests.ts';
+import type { PullRequestChangedFile } from './pull-request-changed-files.ts';
 
 export type FilterPullRequestsByTargetFilesInput = {
     readonly targetName: string;
     readonly targetSourceFiles: readonly string[];
     readonly pullRequests: readonly PullRequest[];
-    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly string[]>;
+    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly PullRequestChangedFile[]>;
     readonly ignoredAttributionPaths: readonly string[];
 };
 
@@ -17,18 +18,27 @@ function createNormalizedPathSet(paths: readonly string[]): ReadonlySet<string> 
 }
 
 type TargetFileChangeInput = {
-    readonly changedFiles: readonly string[];
+    readonly changedFiles: readonly PullRequestChangedFile[];
     readonly targetSourceFiles: ReadonlySet<string>;
     readonly ignoredAttributionPaths: ReadonlySet<string>;
 };
+
+function changedFilePaths(changedFile: PullRequestChangedFile): readonly string[] {
+    if (changedFile.previousPath === undefined) {
+        return [ changedFile.path ];
+    }
+    return [ changedFile.path, changedFile.previousPath ];
+}
 
 function hasTargetFileChange(options: TargetFileChangeInput): boolean {
     const { changedFiles, targetSourceFiles, ignoredAttributionPaths } = options;
 
     return changedFiles.some(function (changedFile) {
-        const normalizedChangedFile = normalizeRepositoryPath(changedFile);
+        const normalizedChangedFiles = changedFilePaths(changedFile).map(normalizeRepositoryPath);
 
-        return targetSourceFiles.has(normalizedChangedFile) && !ignoredAttributionPaths.has(normalizedChangedFile);
+        return normalizedChangedFiles.some(function (normalizedChangedFile) {
+            return targetSourceFiles.has(normalizedChangedFile) && !ignoredAttributionPaths.has(normalizedChangedFile);
+        });
     });
 }
 

--- a/source/lib/github-pull-request-changed-files.test.ts
+++ b/source/lib/github-pull-request-changed-files.test.ts
@@ -7,7 +7,25 @@ const pullRequestId = 123;
 
 test('creates a GitHub changed files reader', async function () {
     const listFiles = fake();
-    const paginate = fake.resolves([ { filename: 'source/a.ts' }, { filename: 'README.md' } ]);
+    const paginate = fake.resolves([
+        {
+            filename: 'source/a.ts',
+            previous_filename: 'src/a.ts',
+            status: 'renamed',
+            additions: 2,
+            deletions: 1,
+            changes: 3,
+            patch: 'ignored'
+        },
+        {
+            filename: 'README.md',
+            status: 'modified',
+            additions: 1,
+            deletions: 0,
+            changes: 1,
+            patch: 'ignored'
+        }
+    ]);
     const githubClient = {
         paginate,
         pulls: { listFiles }
@@ -20,7 +38,24 @@ test('creates a GitHub changed files reader', async function () {
         listFiles,
         { owner: 'owner', repo: 'repo', pull_number: pullRequestId }
     ]);
-    assert.deepStrictEqual(changedFiles, [ 'source/a.ts', 'README.md' ]);
+    assert.deepStrictEqual(changedFiles, [
+        {
+            path: 'source/a.ts',
+            previousPath: 'src/a.ts',
+            status: 'renamed',
+            additions: 2,
+            deletions: 1,
+            changes: 3
+        },
+        {
+            path: 'README.md',
+            previousPath: undefined,
+            status: 'modified',
+            additions: 1,
+            deletions: 0,
+            changes: 1
+        }
+    ]);
 });
 
 test('throws when the GitHub repo cannot be split', async function () {

--- a/source/lib/github-pull-request-changed-files.ts
+++ b/source/lib/github-pull-request-changed-files.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 import { splitByString } from './split.ts';
-import type { PullRequestChangedFilesReader } from './pull-request-changed-files.ts';
+import type { PullRequestChangedFile, PullRequestChangedFilesReader } from './pull-request-changed-files.ts';
 
 type PullRequestFile = Readonly<Awaited<ReturnType<Octokit['pulls']['listFiles']>>['data'][number]>;
 
@@ -18,7 +18,7 @@ async function getPullRequestChangedFiles(
     githubClient: Readonly<Octokit>,
     githubRepo: string,
     pullRequestId: number
-): Promise<readonly string[]> {
+): Promise<readonly PullRequestChangedFile[]> {
     const [ owner, repo ] = determineRepoDetails(githubRepo);
     const files = (await githubClient.paginate(githubClient.pulls.listFiles, {
         owner,
@@ -27,7 +27,14 @@ async function getPullRequestChangedFiles(
     })) as PullRequestFile[];
 
     return files.map(function (file) {
-        return file.filename;
+        return {
+            path: file.filename,
+            previousPath: file.previous_filename ?? undefined,
+            status: file.status,
+            additions: file.additions,
+            deletions: file.deletions,
+            changes: file.changes
+        };
     });
 }
 

--- a/source/lib/pull-request-changed-files.test.ts
+++ b/source/lib/pull-request-changed-files.test.ts
@@ -1,12 +1,23 @@
 import assert from 'node:assert';
 import { fake } from 'sinon';
-import { fetchPullRequestChangedFiles } from './pull-request-changed-files.ts';
+import { fetchPullRequestChangedFiles, type PullRequestChangedFile } from './pull-request-changed-files.ts';
 
 const secondPullRequestId = 2;
 
+function changedFile(path: string): PullRequestChangedFile {
+    return {
+        path,
+        previousPath: undefined,
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        changes: 1
+    };
+}
+
 test('fetches changed files for pull requests', async function () {
     const getChangedFiles = fake(async function (_githubRepo, pullRequestId: number) {
-        return pullRequestId === 1 ? [ 'source/a.ts' ] : [ 'source/b.ts' ];
+        return pullRequestId === 1 ? [ changedFile('source/a.ts') ] : [ changedFile('source/b.ts') ];
     });
 
     const changedFiles = await fetchPullRequestChangedFiles({
@@ -19,7 +30,7 @@ test('fetches changed files for pull requests', async function () {
     });
 
     assert.deepStrictEqual(Array.from(changedFiles), [
-        [ 1, [ 'source/a.ts' ] ],
-        [ secondPullRequestId, [ 'source/b.ts' ] ]
+        [ 1, [ changedFile('source/a.ts') ] ],
+        [ secondPullRequestId, [ changedFile('source/b.ts') ] ]
     ]);
 });

--- a/source/lib/pull-request-changed-files.ts
+++ b/source/lib/pull-request-changed-files.ts
@@ -1,7 +1,16 @@
 import type { PullRequest } from './collect-merged-pull-requests.ts';
 
+export type PullRequestChangedFile = {
+    readonly path: string;
+    readonly previousPath: string | undefined;
+    readonly status: string;
+    readonly additions: number;
+    readonly deletions: number;
+    readonly changes: number;
+};
+
 export type PullRequestChangedFilesReader = {
-    getChangedFiles: (githubRepo: string, pullRequestId: number) => Promise<readonly string[]>;
+    getChangedFiles: (githubRepo: string, pullRequestId: number) => Promise<readonly PullRequestChangedFile[]>;
 };
 
 export type FetchPullRequestChangedFilesInput = {
@@ -12,8 +21,8 @@ export type FetchPullRequestChangedFilesInput = {
 
 export async function fetchPullRequestChangedFiles(
     input: FetchPullRequestChangedFilesInput
-): Promise<ReadonlyMap<number, readonly string[]>> {
-    const filesByPullRequest = new Map<number, readonly string[]>();
+): Promise<ReadonlyMap<number, readonly PullRequestChangedFile[]>> {
+    const filesByPullRequest = new Map<number, readonly PullRequestChangedFile[]>();
 
     for (const pullRequest of input.pullRequests) {
         filesByPullRequest.set(

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -24,6 +24,7 @@ import {
     type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue,
     type PrLogEngine as PrLogEngineValue,
     type PullRequest as PullRequestValue,
+    type PullRequestChangedFile as PullRequestChangedFileValue,
     type PullRequestWithLabel as PullRequestWithLabelValue,
     type ReadPullRequestChangedFilesOptions as ReadPullRequestChangedFilesOptionsValue,
     type ReadPullRequestLabelsOptions as ReadPullRequestLabelsOptionsValue,
@@ -84,6 +85,7 @@ export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
 export type PrLogEngine = PrLogEngineValue;
 export type PrLogConfig = PrLogConfigValue;
 export type PullRequest = PullRequestValue;
+export type PullRequestChangedFile = PullRequestChangedFileValue;
 export type PullRequestWithLabel = PullRequestWithLabelValue;
 export type ReadPullRequestChangedFilesOptions = ReadPullRequestChangedFilesOptionsValue;
 export type ReadPullRequestLabelsOptions = ReadPullRequestLabelsOptionsValue;


### PR DESCRIPTION
Replaces string-only changed-file results with structured metadata from the GitHub files API: current path, previous path, status, and change counts. Patch bodies are intentionally not carried forward.
