### PR TITLE
Detect single-parent (squash-merge-like) commits

### DIFF
--- a/source/core/pr-log-engine.test.ts
+++ b/source/core/pr-log-engine.test.ts
@@ -63,7 +63,14 @@ function createGitCommandRunner(overrides: Partial<GitCommandRunner> = {}): GitC
             return [];
         },
         async getFirstParentCommitLogs() {
-            return [ { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: 'Fix bug' } ];
+            return [
+                {
+                    hash: 'hash-1',
+                    parents: [ 'parent-1', 'parent-2' ],
+                    subject: 'Merge pull request #1 from branch',
+                    body: 'Fix bug'
+                }
+            ];
         },
         ...overrides
     };
@@ -74,7 +81,14 @@ function createDefaultEngineOverrides(): Required<EngineOverrides> {
         gitCommandRunner: createGitCommandRunner(),
         githubClient: {
             pulls: {
-                get: fake.resolves({ data: { title: 'GitHub title' } })
+                get: fake.resolves({
+                    data: {
+                        title: 'GitHub title',
+                        merged: true,
+                        merge_commit_sha: 'hash-1',
+                        labels: [ { name: 'bug' } ]
+                    }
+                })
             },
             issues: {
                 listLabelsOnIssue: fake.resolves({ data: [] })
@@ -144,7 +158,14 @@ test('collects merged pull requests', async function () {
 });
 
 test('reads fallback pull request titles from github', async function () {
-    const getPullRequest = fake.resolves({ data: { title: 'GitHub title' } });
+    const getPullRequest = fake.resolves({
+        data: {
+            title: 'GitHub title',
+            merged: true,
+            merge_commit_sha: 'hash-1',
+            labels: [ { name: 'bug' } ]
+        }
+    });
     const githubClient: PrLogEngineDependencies['githubClient'] = {
         pulls: {
             get: getPullRequest
@@ -157,7 +178,12 @@ test('reads fallback pull request titles from github', async function () {
         githubClient,
         gitCommandRunner: createGitCommandRunner({
             getFirstParentCommitLogs: fake.resolves([
-                { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: undefined }
+                {
+                    hash: 'hash-1',
+                    parents: [ 'parent-1', 'parent-2' ],
+                    subject: 'Merge pull request #1 from branch',
+                    body: undefined
+                }
             ])
         })
     });
@@ -170,11 +196,41 @@ test('reads fallback pull request titles from github', async function () {
     ]);
 });
 
+test('reuses verified pull request data when reading labels', async function () {
+    const getPullRequestLabels = fake.resolves([ 'bug' ]);
+    const engine = createEngine({
+        getPullRequestLabels,
+        gitCommandRunner: createGitCommandRunner({
+            getFirstParentCommitLogs: fake.resolves([
+                {
+                    hash: 'hash-1',
+                    parents: [ 'parent-1' ],
+                    subject: 'Open the starlit gate (#731)',
+                    body: undefined
+                }
+            ])
+        })
+    });
+
+    const pullRequests = await engine.collectMergedPullRequests({ githubRepo, baseRef: '1.0.0' });
+
+    assert.deepStrictEqual(
+        await engine.readPullRequestLabels({ githubRepo, pullRequests }),
+        new Map([ [ 731, [ 'bug' ] ] ])
+    );
+    assert.strictEqual(getPullRequestLabels.callCount, 0);
+});
+
 test('rejects fallback pull request titles without repo details', async function () {
     const engine = createEngine({
         gitCommandRunner: createGitCommandRunner({
             getFirstParentCommitLogs: fake.resolves([
-                { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: undefined }
+                {
+                    hash: 'hash-1',
+                    parents: [ 'parent-1', 'parent-2' ],
+                    subject: 'Merge pull request #1 from branch',
+                    body: undefined
+                }
             ])
         })
     });

--- a/source/core/pr-log-engine.ts
+++ b/source/core/pr-log-engine.ts
@@ -8,9 +8,11 @@ import {
 } from '../lib/changelog-base-ref.ts';
 import {
     collectMergedPullRequests as collectMergedPullRequestsValue,
+    createPullRequestDataReader,
     type GitRangeReader,
     type PullRequest as PullRequestValue,
-    type PullRequestTitleReader
+    type PullRequestDataGitHubClient,
+    type PullRequestDataReader
 } from '../lib/collect-merged-pull-requests.ts';
 import {
     filterPullRequestsByTargetFiles as filterPullRequestsByTargetFilesValue,
@@ -99,29 +101,9 @@ export type PrLogEngine = {
     updateChangelog: (input: UpdateChangelogMarkdownInputValue) => string;
 };
 
-export type PullRequestTitleGitHubClient = {
-    readonly pulls: {
-        readonly get: (options: PullRequestTitleRequest) => Promise<PullRequestTitleResponse>;
-    };
-};
-
-type PullRequestTitleRequest = {
-    readonly owner: string;
-    readonly repo: string;
-    readonly pull_number: number;
-};
-
-type PullRequestTitleResponse = {
-    readonly data: {
-        readonly title: string;
-    };
-};
-
-const repositoryPathPartLimit = 2;
-
 export type PrLogEngineDependencies = {
     readonly gitCommandRunner: GitCommandRunner;
-    readonly githubClient: GitHubPullRequestLabelClient & PullRequestTitleGitHubClient;
+    readonly githubClient: GitHubPullRequestLabelClient & PullRequestDataGitHubClient;
     readonly pullRequestChangedFilesReader: PullRequestChangedFilesReader;
     readonly getPullRequestLabels: GetPullRequestLabels;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
@@ -129,49 +111,22 @@ export type PrLogEngineDependencies = {
     readonly config: PrLogConfigValue;
 };
 
-function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo: string]> {
-    const [ owner, repo ] = githubRepo.split('/', repositoryPathPartLimit);
-
-    if (owner === undefined || repo === undefined) {
-        throw new TypeError('Could not find a repository');
-    }
-
-    return [ owner, repo ];
-}
-
-async function fetchPullRequestTitle(
-    githubClient: PullRequestTitleGitHubClient,
-    githubRepo: string,
-    pullRequestId: number
-): Promise<string> {
-    const [ owner, repo ] = determineRepoDetails(githubRepo);
-    const { data: pullRequest } = await githubClient.pulls.get({
-        owner,
-        repo,
-        pull_number: pullRequestId
-    });
-
-    return pullRequest.title;
-}
-
-function createPullRequestTitleReader(githubClient: PullRequestTitleGitHubClient): PullRequestTitleReader {
-    return {
-        async getTitle(githubRepo, pullRequestId) {
-            return fetchPullRequestTitle(githubClient, githubRepo, pullRequestId);
-        }
-    };
-}
-
 type EnginePullRequestLabelReader = {
     getLabels: (githubRepo: string, pullRequestId: number) => Promise<readonly string[]>;
 };
 
 function createPullRequestLabelReader(
     dependencies: PrLogEngineDependencies,
-    config: PrLogConfigValue
+    config: PrLogConfigValue,
+    pullRequestDataReader: PullRequestDataReader
 ): EnginePullRequestLabelReader {
     return {
         async getLabels(githubRepo: string, pullRequestId: number) {
+            const cachedLabels = pullRequestDataReader.readCachedPullRequestLabels(githubRepo, pullRequestId);
+            if (cachedLabels !== undefined) {
+                return cachedLabels;
+            }
+
             const labels = await dependencies.getPullRequestLabels(githubRepo, pullRequestId, {
                 githubClient: dependencies.githubClient,
                 waitForMilliseconds: dependencies.waitForMilliseconds,
@@ -193,10 +148,15 @@ async function waitBetweenLabelReads(dependencies: PrLogEngineDependencies, pull
 
 async function readPullRequestLabels(
     dependencies: PrLogEngineDependencies,
+    pullRequestDataReader: PullRequestDataReader,
     input: ReadPullRequestLabelsOptions
 ): Promise<ReadonlyMap<number, readonly string[]>> {
     const pullRequestLabels = new Map<number, readonly string[]>();
-    const pullRequestLabelReader = createPullRequestLabelReader(dependencies, dependencies.config);
+    const pullRequestLabelReader = createPullRequestLabelReader(
+        dependencies,
+        dependencies.config,
+        pullRequestDataReader
+    );
 
     for (const [ pullRequestIndex, pullRequest ] of input.pullRequests.entries()) {
         await waitBetweenLabelReads(dependencies, pullRequestIndex);
@@ -209,7 +169,7 @@ async function readPullRequestLabels(
 export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDependencies): PrLogEngine {
     const { gitCommandRunner, githubClient, pullRequestChangedFilesReader } = dependencies;
     const gitRangeReader: GitRangeReader = gitCommandRunner;
-    const pullRequestTitleReader = createPullRequestTitleReader(githubClient);
+    const pullRequestDataReader = createPullRequestDataReader(githubClient);
 
     return {
         async resolveLatestSemverChangelogBaseRef() {
@@ -225,7 +185,7 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
                 githubRepo: input.githubRepo,
                 baseRef: input.baseRef,
                 git: gitRangeReader,
-                pullRequestTitleReader
+                pullRequestDataReader
             });
         },
 
@@ -238,7 +198,7 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
         },
 
         async readPullRequestLabels(input) {
-            return readPullRequestLabels(dependencies, input);
+            return readPullRequestLabels(dependencies, pullRequestDataReader, input);
         },
 
         filterPullRequestsByTargetFiles: filterPullRequestsByTargetFilesValue,
@@ -249,7 +209,11 @@ export function createPrLogEngineWithDependencies(dependencies: PrLogEngineDepen
                 validLabels: input.config.validLabels,
                 ignoredLabels: input.config.ignoredLabels,
                 pullRequests: input.pullRequests,
-                pullRequestLabelReader: createPullRequestLabelReader(dependencies, input.config),
+                pullRequestLabelReader: createPullRequestLabelReader(
+                    dependencies,
+                    input.config,
+                    pullRequestDataReader
+                ),
                 waitForMilliseconds: dependencies.waitForMilliseconds,
                 labelLookupIntervalMilliseconds: input.config.labelLookupIntervalMilliseconds,
                 targetName: input.targetName,

--- a/source/lib/collect-merged-pull-requests.test.ts
+++ b/source/lib/collect-merged-pull-requests.test.ts
@@ -1,25 +1,60 @@
 import assert from 'node:assert';
 import { fake } from 'sinon';
-import { collectMergedPullRequests } from './collect-merged-pull-requests.ts';
+import { collectMergedPullRequests, type PullRequestDataReader } from './collect-merged-pull-requests.ts';
 
 const secondPullRequestId = 2;
 
+type TestPullRequestDataReader = {
+    readonly pullRequestDataReader: PullRequestDataReader;
+    readonly readPullRequestData: ReturnType<typeof fake>;
+};
+
+function createPullRequestDataReader(title: string): TestPullRequestDataReader {
+    const readPullRequestData = fake.resolves({
+        title,
+        merged: true,
+        mergeCommitSha: 'hash',
+        labels: []
+    });
+
+    return {
+        pullRequestDataReader: {
+            readPullRequestData,
+            readCachedPullRequestLabels: fake.returns(undefined)
+        },
+        readPullRequestData
+    };
+}
+
 test('collects merged pull requests for a base ref', async function () {
     const getFirstParentCommitLogs = fake.resolves([
-        { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: 'Use commit body title' },
-        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: undefined }
+        {
+            hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
+            subject: 'Merge pull request #1 from branch',
+            body: 'Use commit body title'
+        },
+        {
+            hash: 'hash-2',
+            parents: [ 'parent-3', 'parent-4' ],
+            subject: 'Merge pull request #2 from other',
+            body: undefined
+        }
     ]);
-    const getTitle = fake.resolves('Use GitHub title');
+    const { pullRequestDataReader, readPullRequestData } = createPullRequestDataReader('Use GitHub title');
 
     const pullRequests = await collectMergedPullRequests({
         githubRepo: 'owner/repo',
         baseRef: 'base-ref',
         git: { getFirstParentCommitLogs },
-        pullRequestTitleReader: { getTitle }
+        pullRequestDataReader
     });
 
     assert.deepStrictEqual(getFirstParentCommitLogs.firstCall.args, [ 'base-ref' ]);
-    assert.deepStrictEqual(getTitle.firstCall.args, [ 'owner/repo', secondPullRequestId ]);
+    assert.deepStrictEqual(readPullRequestData.firstCall.args, [
+        'owner/repo',
+        secondPullRequestId
+    ]);
     assert.deepStrictEqual(pullRequests, [
         { id: 1, title: 'Use commit body title' },
         { id: secondPullRequestId, title: 'Use GitHub title' }
@@ -31,17 +66,23 @@ test('removes a merge and its revert when both are in the range', async function
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            parents: [ 'parent-1' ],
             subject: 'Revert "Merge pull request #1 from branch"',
             body: `This reverts commit ${revertedMergeCommitHash}.`
         },
-        { hash: revertedMergeCommitHash, subject: 'Merge pull request #1 from branch', body: 'Use commit body title' }
+        {
+            hash: revertedMergeCommitHash,
+            parents: [ 'parent-2', 'parent-3' ],
+            subject: 'Merge pull request #1 from branch',
+            body: 'Use commit body title'
+        }
     ]);
 
     const pullRequests = await collectMergedPullRequests({
         githubRepo: 'owner/repo',
         baseRef: 'base-ref',
         git: { getFirstParentCommitLogs },
-        pullRequestTitleReader: { getTitle: fake.resolves('Use GitHub title') }
+        pullRequestDataReader: createPullRequestDataReader('Use GitHub title').pullRequestDataReader
     });
 
     assert.deepStrictEqual(pullRequests, []);
@@ -51,27 +92,53 @@ test('keeps a revert when the reverted merge is outside the range', async functi
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            parents: [ 'parent-1' ],
             subject: 'Revert "Merge pull request #1 from branch"',
             body: 'This reverts commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
         }
     ]);
-    const getTitle = fake.resolves('Use GitHub title');
+    const { pullRequestDataReader, readPullRequestData } = createPullRequestDataReader('Use GitHub title');
 
     const pullRequests = await collectMergedPullRequests({
         githubRepo: 'owner/repo',
         baseRef: 'base-ref',
         git: { getFirstParentCommitLogs },
-        pullRequestTitleReader: { getTitle }
+        pullRequestDataReader
     });
 
-    assert.deepStrictEqual(getTitle.firstCall.args, [ 'owner/repo', 1 ]);
+    assert.deepStrictEqual(readPullRequestData.firstCall.args, [ 'owner/repo', 1 ]);
     assert.deepStrictEqual(pullRequests, [ { id: 1, title: 'Revert "Use GitHub title"' } ]);
+});
+
+test('throws when fallback pull request title data is missing', async function () {
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            parents: [ 'parent-1', 'parent-2' ],
+            subject: 'Merge pull request #864 from branch',
+            body: undefined
+        }
+    ]);
+
+    await assert.rejects(
+        collectMergedPullRequests({
+            githubRepo: 'owner/repo',
+            baseRef: 'base-ref',
+            git: { getFirstParentCommitLogs },
+            pullRequestDataReader: {
+                readPullRequestData: fake.resolves(undefined),
+                readCachedPullRequestLabels: fake.returns(undefined)
+            }
+        }),
+        { message: 'Pull Request #864 was not found' }
+    );
 });
 
 test('throws when the reverted pull request cannot be extracted from the commit message', async function () {
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            parents: [ 'parent-1' ],
             subject: 'Revert "Merge pull request foo from branch"',
             body: 'This reverts commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
         }
@@ -82,8 +149,133 @@ test('throws when the reverted pull request cannot be extracted from the commit 
             githubRepo: 'owner/repo',
             baseRef: 'base-ref',
             git: { getFirstParentCommitLogs },
-            pullRequestTitleReader: { getTitle: fake.resolves('Use GitHub title') }
+            pullRequestDataReader: createPullRequestDataReader('Use GitHub title').pullRequestDataReader
         }),
         { message: 'Failed to extract pull request id from reverted merge commit log' }
+    );
+});
+
+test('collects single-parent pull request subject commits when the merge commit sha matches', async function () {
+    const readPullRequestData = fake.resolves({
+        title: 'Unused GitHub title',
+        merged: true,
+        mergeCommitSha: 'commit-hash',
+        labels: []
+    });
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'commit-hash',
+            parents: [ 'parent-hash' ],
+            subject: 'Open the starlit gate (#731)',
+            body: 'Expanded commit body'
+        }
+    ]);
+
+    const pullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base-ref',
+        git: { getFirstParentCommitLogs },
+        pullRequestDataReader: { readPullRequestData, readCachedPullRequestLabels: fake.returns(undefined) }
+    });
+
+    assert.deepStrictEqual(readPullRequestData.firstCall.args, [ 'owner/repo', 731 ]);
+    assert.deepStrictEqual(pullRequests, [ { id: 731, title: 'Open the starlit gate' } ]);
+});
+
+test('ignores pull request subject commits with more than one parent without reading GitHub data', async function () {
+    const readPullRequestData = fake.resolves({
+        title: 'Unused GitHub title',
+        merged: true,
+        mergeCommitSha: 'commit-hash',
+        labels: []
+    });
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'commit-hash',
+            parents: [ 'first-parent', 'second-parent' ],
+            subject: 'Chart the hidden realm (#274)',
+            body: undefined
+        }
+    ]);
+
+    const pullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base-ref',
+        git: { getFirstParentCommitLogs },
+        pullRequestDataReader: { readPullRequestData, readCachedPullRequestLabels: fake.returns(undefined) }
+    });
+
+    assert.strictEqual(readPullRequestData.callCount, 0);
+    assert.deepStrictEqual(pullRequests, []);
+});
+
+test('ignores single-parent pull request subject commits when GitHub has no matching pull request', async function () {
+    const readPullRequestData = fake.resolves(undefined);
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'commit-hash',
+            parents: [ 'parent-hash' ],
+            subject: 'Forge the crystal key (#618)',
+            body: undefined
+        }
+    ]);
+
+    const pullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base-ref',
+        git: { getFirstParentCommitLogs },
+        pullRequestDataReader: { readPullRequestData, readCachedPullRequestLabels: fake.returns(undefined) }
+    });
+
+    assert.deepStrictEqual(pullRequests, []);
+});
+
+test('ignores single-parent pull request subject commits when the merge commit sha differs', async function () {
+    const readPullRequestData = fake.resolves({
+        title: 'Unused GitHub title',
+        merged: true,
+        mergeCommitSha: 'different-hash',
+        labels: []
+    });
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'commit-hash',
+            parents: [ 'parent-hash' ],
+            subject: 'Banish the mirrored crown (#386)',
+            body: undefined
+        }
+    ]);
+
+    const pullRequests = await collectMergedPullRequests({
+        githubRepo: 'owner/repo',
+        baseRef: 'base-ref',
+        git: { getFirstParentCommitLogs },
+        pullRequestDataReader: { readPullRequestData, readCachedPullRequestLabels: fake.returns(undefined) }
+    });
+
+    assert.deepStrictEqual(pullRequests, []);
+});
+
+test('throws when reading pull request subject commit data fails', async function () {
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'commit-hash',
+            parents: [ 'parent-hash' ],
+            subject: 'Summon the silver beacon (#942)',
+            body: undefined
+        }
+    ]);
+
+    await assert.rejects(
+        collectMergedPullRequests({
+            githubRepo: 'owner/repo',
+            baseRef: 'base-ref',
+            git: { getFirstParentCommitLogs },
+            pullRequestDataReader: {
+                readPullRequestData: fake.rejects(new Error('GitHub failed')),
+                readCachedPullRequestLabels: fake.returns(undefined)
+            }
+        }),
+        { message: 'GitHub failed' }
     );
 });

--- a/source/lib/collect-merged-pull-requests.ts
+++ b/source/lib/collect-merged-pull-requests.ts
@@ -1,4 +1,170 @@
-import { isUndefined } from '@sindresorhus/is';
+import { isError, isFiniteNumber, isUndefined } from '@sindresorhus/is';
+import { splitByString } from './split.ts';
+
+type PullRequestDataRequest = {
+    readonly owner: string;
+    readonly repo: string;
+    readonly pull_number: number;
+};
+
+type GitHubLabel = {
+    readonly name: string;
+};
+
+type GitHubPullRequestData = {
+    readonly title: string;
+    readonly merged: boolean;
+    readonly merge_commit_sha: string | null;
+    readonly labels: readonly GitHubLabel[];
+};
+
+type PullRequestDataResponse = {
+    readonly data: GitHubPullRequestData;
+};
+
+export type PullRequestDataGitHubClient = {
+    readonly pulls: {
+        readonly get: (request: PullRequestDataRequest) => Promise<PullRequestDataResponse>;
+    };
+};
+
+export type PullRequestData = {
+    readonly title: string;
+    readonly merged: boolean;
+    readonly mergeCommitSha: string | null;
+    readonly labels: readonly string[];
+};
+
+export type PullRequestDataReader = {
+    readonly readPullRequestData: (
+        githubRepo: string,
+        pullRequestId: number
+    ) => Promise<PullRequestData | undefined>;
+    readonly readCachedPullRequestLabels: (
+        githubRepo: string,
+        pullRequestId: number
+    ) => readonly string[] | undefined;
+};
+
+type GitHubClientError = {
+    readonly status: number | undefined;
+};
+
+type ErrorStatusCarrier = Readonly<Record<'status', unknown>>;
+
+const notFoundStatusCode = 404;
+
+function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo: string]> {
+    const [ owner, repo ] = splitByString(githubRepo, '/');
+
+    if (repo === undefined) {
+        throw new TypeError('Could not find a repository');
+    }
+
+    return [ owner, repo ];
+}
+
+function createCacheKey(githubRepo: string, pullRequestId: number): string {
+    return `${githubRepo}#${pullRequestId}`;
+}
+
+function hasErrorStatus(error: unknown): error is ErrorStatusCarrier {
+    return isError(error) && Object.hasOwn(error, 'status');
+}
+
+function getGitHubClientError(error: unknown): GitHubClientError | undefined {
+    if (!isError(error)) {
+        return undefined;
+    }
+
+    const status = hasErrorStatus(error) ? error.status : undefined;
+    return { status: isFiniteNumber(status) ? status : undefined };
+}
+
+function createPullRequestData(data: GitHubPullRequestData): PullRequestData {
+    return {
+        title: data.title,
+        merged: data.merged,
+        mergeCommitSha: data.merge_commit_sha,
+        labels: data.labels.map(function (label) {
+            return label.name;
+        })
+    };
+}
+
+async function fetchPullRequestData(
+    githubClient: PullRequestDataGitHubClient,
+    githubRepo: string,
+    pullRequestId: number
+): Promise<PullRequestData | undefined> {
+    const [ owner, repo ] = determineRepoDetails(githubRepo);
+
+    try {
+        const { data } = await githubClient.pulls.get({
+            owner,
+            repo,
+            pull_number: pullRequestId
+        });
+        return createPullRequestData(data);
+    } catch (error) {
+        const githubClientError = getGitHubClientError(error);
+        if (githubClientError?.status === notFoundStatusCode) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export function createPullRequestDataReader(
+    githubClient: PullRequestDataGitHubClient
+): PullRequestDataReader {
+    const resolvedPullRequestData = new Map<string, PullRequestData | undefined>();
+    const pendingPullRequestData = new Map<string, Promise<PullRequestData | undefined>>();
+
+    async function readUncachedPullRequestData(
+        cacheKey: string,
+        githubRepo: string,
+        pullRequestId: number
+    ): Promise<PullRequestData | undefined> {
+        try {
+            const pullRequestData = await fetchPullRequestData(githubClient, githubRepo, pullRequestId);
+            resolvedPullRequestData.set(cacheKey, pullRequestData);
+            return pullRequestData;
+        } finally {
+            pendingPullRequestData.delete(cacheKey);
+        }
+    }
+
+    async function readPullRequestData(
+        githubRepo: string,
+        pullRequestId: number
+    ): Promise<PullRequestData | undefined> {
+        const cacheKey = createCacheKey(githubRepo, pullRequestId);
+        if (resolvedPullRequestData.has(cacheKey)) {
+            return resolvedPullRequestData.get(cacheKey);
+        }
+
+        const pendingData = pendingPullRequestData.get(cacheKey);
+        if (pendingData !== undefined) {
+            return pendingData;
+        }
+
+        const data = readUncachedPullRequestData(cacheKey, githubRepo, pullRequestId);
+        pendingPullRequestData.set(cacheKey, data);
+
+        return data;
+    }
+
+    function readCachedPullRequestLabels(
+        githubRepo: string,
+        pullRequestId: number
+    ): readonly string[] | undefined {
+        return resolvedPullRequestData.get(createCacheKey(githubRepo, pullRequestId))?.labels;
+    }
+
+    return { readPullRequestData, readCachedPullRequestLabels };
+}
 
 export type PullRequest = {
     readonly id: number;
@@ -7,6 +173,7 @@ export type PullRequest = {
 
 export type FirstParentCommitLogEntry = {
     readonly hash: string;
+    readonly parents: readonly string[];
     readonly subject: string;
     readonly body: string | undefined;
 };
@@ -15,15 +182,11 @@ export type GitRangeReader = {
     getFirstParentCommitLogs: (baseRef: string) => Promise<readonly FirstParentCommitLogEntry[]>;
 };
 
-export type PullRequestTitleReader = {
-    getTitle: (githubRepo: string, pullRequestId: number) => Promise<string>;
-};
-
 export type CollectMergedPullRequestsInput = {
     readonly githubRepo: string;
     readonly baseRef: string;
     readonly git: GitRangeReader;
-    readonly pullRequestTitleReader: PullRequestTitleReader;
+    readonly pullRequestDataReader: PullRequestDataReader;
 };
 
 type MergedPullRequestCommit = {
@@ -37,7 +200,22 @@ type RevertedPullRequestCommit = {
     readonly id: number;
 };
 
-type PullRequestCommit = MergedPullRequestCommit | RevertedPullRequestCommit;
+type PullRequestSubjectCommit = {
+    readonly type: 'pull-request-subject';
+    readonly id: number;
+    readonly title: string;
+    readonly hash: string;
+    readonly parentCount: number;
+};
+
+type PullRequestSubjectMatch = {
+    readonly pullRequestIdentifier: string;
+    readonly title: string;
+};
+
+type PullRequestCommit = MergedPullRequestCommit | PullRequestSubjectCommit | RevertedPullRequestCommit;
+
+const singleParentCommitParentCount = 1;
 
 function parsePullRequestId(value: string): number {
     return Number.parseInt(value, 10);
@@ -71,6 +249,36 @@ function extractRevertedPullRequestId(subject: string): number | undefined {
     }
 
     return parsePullRequestId(pullRequestIdentifier);
+}
+
+function getPullRequestSubjectMatch(subject: string): PullRequestSubjectMatch | undefined {
+    const groups = /^(?<title>.+) \(#(?<pullRequestIdentifier>\d+)\)$/u.exec(subject)?.groups;
+    const pullRequestIdentifier = groups?.pullRequestIdentifier;
+    const title = groups?.title;
+
+    if (isUndefined(pullRequestIdentifier) || isUndefined(title)) {
+        return undefined;
+    }
+
+    return { pullRequestIdentifier, title };
+}
+
+function extractPullRequestSubjectCommit(
+    firstParentCommitLog: FirstParentCommitLogEntry
+): PullRequestSubjectCommit | undefined {
+    const match = getPullRequestSubjectMatch(firstParentCommitLog.subject);
+
+    if (match === undefined) {
+        return undefined;
+    }
+
+    return {
+        type: 'pull-request-subject',
+        id: parsePullRequestId(match.pullRequestIdentifier),
+        title: match.title,
+        hash: firstParentCommitLog.hash,
+        parentCount: firstParentCommitLog.parents.length
+    };
 }
 
 function extractRevertedCommitHash(commitBody: string | undefined): string | undefined {
@@ -119,11 +327,49 @@ function createPullRequestCommit(firstParentCommitLog: FirstParentCommitLogEntry
         return { type: 'revert', id: revertedPullRequestId };
     }
 
-    return undefined;
+    return extractPullRequestSubjectCommit(firstParentCommitLog);
+}
+
+async function readPullRequestTitle(
+    input: Pick<CollectMergedPullRequestsInput, 'githubRepo' | 'pullRequestDataReader'>,
+    pullRequestId: number
+): Promise<string> {
+    const pullRequestData = await input.pullRequestDataReader.readPullRequestData(input.githubRepo, pullRequestId);
+    if (pullRequestData === undefined) {
+        throw new TypeError(`Pull Request #${pullRequestId} was not found`);
+    }
+
+    return pullRequestData.title;
+}
+
+async function createPullRequestFromSubjectCommit(
+    input: Pick<
+        CollectMergedPullRequestsInput,
+        'githubRepo' | 'pullRequestDataReader'
+    >,
+    pullRequestCommit: PullRequestSubjectCommit
+): Promise<PullRequest | undefined> {
+    if (pullRequestCommit.parentCount !== singleParentCommitParentCount) {
+        return undefined;
+    }
+
+    const pullRequestData = await input.pullRequestDataReader.readPullRequestData(
+        input.githubRepo,
+        pullRequestCommit.id
+    );
+    if (pullRequestData === undefined) {
+        return undefined;
+    }
+
+    if (!pullRequestData.merged || pullRequestData.mergeCommitSha !== pullRequestCommit.hash) {
+        return undefined;
+    }
+
+    return { id: pullRequestCommit.id, title: pullRequestCommit.title };
 }
 
 async function createPullRequest(
-    input: Pick<CollectMergedPullRequestsInput, 'githubRepo' | 'pullRequestTitleReader'>,
+    input: Pick<CollectMergedPullRequestsInput, 'githubRepo' | 'pullRequestDataReader'>,
     firstParentCommitLog: FirstParentCommitLogEntry
 ): Promise<PullRequest | undefined> {
     const pullRequestCommit = createPullRequestCommit(firstParentCommitLog);
@@ -133,12 +379,16 @@ async function createPullRequest(
     }
 
     if (pullRequestCommit.type === 'revert') {
-        const title = await input.pullRequestTitleReader.getTitle(input.githubRepo, pullRequestCommit.id);
+        const title = await readPullRequestTitle(input, pullRequestCommit.id);
         return { id: pullRequestCommit.id, title: `Revert "${title}"` };
     }
 
+    if (pullRequestCommit.type === 'pull-request-subject') {
+        return createPullRequestFromSubjectCommit(input, pullRequestCommit);
+    }
+
     const title = pullRequestCommit.title ??
-        await input.pullRequestTitleReader.getTitle(input.githubRepo, pullRequestCommit.id);
+        await readPullRequestTitle(input, pullRequestCommit.id);
 
     return { id: pullRequestCommit.id, title };
 }

--- a/source/lib/get-merged-pull-requests.test.ts
+++ b/source/lib/get-merged-pull-requests.test.ts
@@ -55,7 +55,14 @@ function createDefaultFactoryDependencies(): FactoryDependencies {
         getPullRequestLabels: fake.resolves([ 'bug' ]),
         githubClient: {
             pulls: {
-                get: fake.resolves({ data: { title: 'pull-request-title' } })
+                get: fake.resolves({
+                    data: {
+                        title: 'pull-request-title',
+                        merged: true,
+                        merge_commit_sha: 'hash-1',
+                        labels: [ { name: 'bug' } ]
+                    }
+                })
             }
         } as unknown as Octokit,
         waitForMilliseconds: fake.resolves(undefined)
@@ -168,6 +175,7 @@ test('throws when the pull request cannot be extracted from the commit message',
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
             subject: 'Merge pull request foo from branch',
             body: 'pr-1 message'
         }
@@ -180,20 +188,30 @@ test('throws when the pull request cannot be extracted from the commit message',
 });
 
 test('falls back to the GitHub API when the commit log does not have a body', async function () {
-    const get = fake.resolves({ data: { title: 'pull request title from github' } });
+    const get = fake.resolves({
+        data: {
+            title: 'pull request title from github',
+            merged: true,
+            merge_commit_sha: 'hash-1',
+            labels: [ { name: 'bug' } ]
+        }
+    });
     const githubClient = { pulls: { get } } as unknown as Octokit;
+    const getPullRequestLabels = fake.resolves([ 'documentation' ]);
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
             subject: 'Merge pull request #1 from branch',
             body: undefined
         }
     ]);
-    const getMergedPullRequests = factory({ getFirstParentCommitLogs, githubClient });
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels, githubClient });
 
     const pullRequests = await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
     assertSpyCalls(get, [ [ { owner: 'any', repo: 'repo', pull_number: 1 } ] ]);
+    assert.strictEqual(getPullRequestLabels.callCount, 0);
     assert.deepStrictEqual(pullRequests, [ { id: 1, title: 'pull request title from github', label: 'bug' } ]);
 });
 
@@ -206,6 +224,7 @@ test('throws when the title is missing in the commit log and the GitHub API requ
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
             subject: 'Merge pull request #1 from branch',
             body: undefined
         }
@@ -221,6 +240,7 @@ test('throws when the title is missing in the commit log and the repo is invalid
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
             subject: 'Merge pull request #1 from branch',
             body: undefined
         }
@@ -239,10 +259,16 @@ test('extracts id, title and label for merged pull requests', async function () 
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
             subject: 'Merge pull request #1 from branch',
             body: 'pr-1 message'
         },
-        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
+        {
+            hash: 'hash-2',
+            parents: [ 'parent-3', 'parent-4' ],
+            subject: 'Merge pull request #2 from other',
+            body: 'pr-2 message'
+        }
     ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
 
@@ -264,10 +290,16 @@ test('looks up pull request labels sequentially', async function () {
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
             subject: 'Merge pull request #1 from branch',
             body: 'pr-1 message'
         },
-        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: 'pr-2 message' }
+        {
+            hash: 'hash-2',
+            parents: [ 'parent-3', 'parent-4' ],
+            subject: 'Merge pull request #2 from other',
+            body: 'pr-2 message'
+        }
     ]);
     const { getPullRequestLabels, firstLabelLookupStarted, resolveFirstLabelLookup } = createControlledLabelLookup();
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
@@ -297,11 +329,22 @@ test('waits between pull request label lookups', async function () {
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'hash-1',
+            parents: [ 'parent-1', 'parent-2' ],
             subject: 'Merge pull request #1 from branch',
             body: 'pr-1 message'
         },
-        { hash: 'hash-2', subject: 'Merge pull request #2 from other', body: 'pr-2 message' },
-        { hash: 'hash-3', subject: 'Merge pull request #3 from third', body: 'pr-3 message' }
+        {
+            hash: 'hash-2',
+            parents: [ 'parent-3', 'parent-4' ],
+            subject: 'Merge pull request #2 from other',
+            body: 'pr-2 message'
+        },
+        {
+            hash: 'hash-3',
+            parents: [ 'parent-5', 'parent-6' ],
+            subject: 'Merge pull request #3 from third',
+            body: 'pr-3 message'
+        }
     ]);
     const waitForMilliseconds = fake.resolves(undefined);
     const labelLookupIntervalMilliseconds = 123;
@@ -320,8 +363,13 @@ test('waits between pull request label lookups', async function () {
 
 test('ignores first-parent commits that are not merge commits', async function () {
     const getFirstParentCommitLogs = fake.resolves([
-        { hash: 'hash-2', subject: 'chore: prepare release', body: 'release housekeeping' },
-        { hash: 'hash-1', subject: 'Merge pull request #1 from branch', body: 'pr-1 message' }
+        { hash: 'hash-2', parents: [ 'parent-1' ], subject: 'chore: prepare release', body: 'release housekeeping' },
+        {
+            hash: 'hash-1',
+            parents: [ 'parent-2', 'parent-3' ],
+            subject: 'Merge pull request #1 from branch',
+            body: 'pr-1 message'
+        }
     ]);
     const getPullRequestLabels = fake.resolves([ 'bug' ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
@@ -332,20 +380,80 @@ test('ignores first-parent commits that are not merge commits', async function (
     assert.deepStrictEqual(pullRequests, [ { id: 1, title: 'pr-1 message', label: 'bug' } ]);
 });
 
+test('collects verified single-parent pull request subject commits', async function () {
+    const get = fake.resolves({
+        data: {
+            title: 'Unused GitHub title',
+            merged: true,
+            merge_commit_sha: 'quest-hash',
+            labels: [ { name: 'feature' } ]
+        }
+    });
+    const getPullRequestLabels = fake.resolves([ 'bug' ]);
+    const githubClient = { pulls: { get } } as unknown as Octokit;
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'quest-hash',
+            parents: [ 'parent-1' ],
+            subject: 'Open the starlit gate (#731)',
+            body: undefined
+        }
+    ]);
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels, githubClient });
+
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultPrLogConfig);
+
+    assert.strictEqual(getPullRequestLabels.callCount, 0);
+    assert.deepStrictEqual(pullRequests, [ { id: 731, title: 'Open the starlit gate', label: 'feature' } ]);
+});
+
+test('ignores two-parent pull request subject commits without reading GitHub data', async function () {
+    const get = fake.resolves({
+        data: {
+            title: 'Unused GitHub title',
+            merged: true,
+            merge_commit_sha: 'quest-hash',
+            labels: [ { name: 'feature' } ]
+        }
+    });
+    const githubClient = { pulls: { get } } as unknown as Octokit;
+    const getFirstParentCommitLogs = fake.resolves([
+        {
+            hash: 'quest-hash',
+            parents: [ 'parent-1', 'parent-2' ],
+            subject: 'Chart the hidden realm (#274)',
+            body: undefined
+        }
+    ]);
+    const getMergedPullRequests = factory({ getFirstParentCommitLogs, githubClient });
+
+    const pullRequests = await getMergedPullRequests(anyRepo, defaultPrLogConfig);
+
+    assert.strictEqual(get.callCount, 0);
+    assert.deepStrictEqual(pullRequests, []);
+});
+
 test('ignores merge commits that were reverted later', async function () {
     const revertedMergeCommitHash = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'cccccccccccccccccccccccccccccccccccccccc',
+            parents: [ 'parent-1' ],
             subject: 'Revert "Merge pull request #1 from branch"',
             body: `This reverts commit ${revertedMergeCommitHash}.`
         },
         {
             hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            parents: [ 'parent-2', 'parent-3' ],
             subject: 'Merge pull request #2 from other',
             body: 'pr-2 message'
         },
-        { hash: revertedMergeCommitHash, subject: 'Merge pull request #1 from branch', body: 'pr-1 message' }
+        {
+            hash: revertedMergeCommitHash,
+            parents: [ 'parent-4', 'parent-5' ],
+            subject: 'Merge pull request #1 from branch',
+            body: 'pr-1 message'
+        }
     ]);
     const getPullRequestLabels = fake.resolves([ 'bug' ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
@@ -366,15 +474,22 @@ test('includes a merge commit again when its revert was reverted later', async f
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'cccccccccccccccccccccccccccccccccccccccc',
+            parents: [ 'parent-1' ],
             subject: 'Revert "Revert \\"Merge pull request #1 from branch\\""',
             body: `This reverts commit ${revertCommitHash}.`
         },
         {
             hash: revertCommitHash,
+            parents: [ 'parent-2' ],
             subject: 'Revert "Merge pull request #1 from branch"',
             body: `This reverts commit ${revertedMergeCommitHash}.`
         },
-        { hash: revertedMergeCommitHash, subject: 'Merge pull request #1 from branch', body: 'pr-1 message' }
+        {
+            hash: revertedMergeCommitHash,
+            parents: [ 'parent-3', 'parent-4' ],
+            subject: 'Merge pull request #1 from branch',
+            body: 'pr-1 message'
+        }
     ]);
     const getPullRequestLabels = fake.resolves([ 'bug' ]);
     const getMergedPullRequests = factory({ getFirstParentCommitLogs, getPullRequestLabels });
@@ -386,11 +501,19 @@ test('includes a merge commit again when its revert was reverted later', async f
 });
 
 test('includes a revert commit when the reverted merge was already released', async function () {
-    const get = fake.resolves({ data: { title: 'pr-1 message' } });
+    const get = fake.resolves({
+        data: {
+            title: 'pr-1 message',
+            merged: true,
+            merge_commit_sha: 'hash-1',
+            labels: [ { name: 'bug' } ]
+        }
+    });
     const githubClient = { pulls: { get } } as unknown as Octokit;
     const getFirstParentCommitLogs = fake.resolves([
         {
             hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            parents: [ 'parent-1' ],
             subject: 'Revert "Merge pull request #1 from branch"',
             body: 'This reverts commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
         }
@@ -401,7 +524,6 @@ test('includes a revert commit when the reverted merge was already released', as
     const pullRequests = await getMergedPullRequests(anyRepo, defaultPrLogConfig);
 
     assert.deepStrictEqual(get.firstCall.args, [ { owner: 'any', repo: 'repo', pull_number: 1 } ]);
-    assert.strictEqual(getPullRequestLabels.callCount, 1);
-    assert.deepStrictEqual(getPullRequestLabels.firstCall.args.slice(0, comparedArgumentCount), [ 'any/repo', 1 ]);
+    assert.strictEqual(getPullRequestLabels.callCount, 0);
     assert.deepStrictEqual(pullRequests, [ { id: 1, title: 'Revert "pr-1 message"', label: 'bug' } ]);
 });

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -4,8 +4,9 @@ import type { GitCommandRunner } from './git-command-runner.ts';
 import { resolveLatestSemverTagBaseRef } from './changelog-base-ref.ts';
 import {
     collectMergedPullRequests,
-    type PullRequest as PullRequestValue,
-    type PullRequestTitleReader
+    createPullRequestDataReader,
+    type PullRequestDataReader,
+    type PullRequest as PullRequestValue
 } from './collect-merged-pull-requests.ts';
 import {
     resolvePullRequestLabels,
@@ -29,37 +30,9 @@ export type GetMergedPullRequests = (
     config: PrLogConfig
 ) => Promise<readonly PullRequestWithLabel[]>;
 
-type PullRequestData = Readonly<Awaited<ReturnType<Octokit['pulls']['get']>>['data']>;
-
-const repositoryPathPartLimit = 2;
-
-function determineRepoDetails(githubRepo: string): Readonly<[owner: string, repo: string]> {
-    const [ owner, repo ] = githubRepo.split('/', repositoryPathPartLimit);
-
-    if (owner === undefined || repo === undefined) {
-        throw new TypeError('Could not find a repository');
-    }
-
-    return [ owner, repo ];
-}
-
-async function fetchPullRequestTitle(
-    githubClient: Readonly<Octokit>,
-    githubRepo: string,
-    pullRequestId: number
-): Promise<string> {
-    const [ owner, repo ] = determineRepoDetails(githubRepo);
-    const { data: pullRequest } = await githubClient.pulls.get({
-        owner,
-        repo,
-        pull_number: pullRequestId
-    });
-
-    return (pullRequest as PullRequestData).title;
-}
-
 export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequestsDependencies): GetMergedPullRequests {
     const { gitCommandRunner, getPullRequestLabels, githubClient, waitForMilliseconds } = dependencies;
+    const pullRequestDataReader = createPullRequestDataReader(githubClient);
 
     async function getLatestVersionTag(): Promise<string> {
         const tags = await gitCommandRunner.listTags();
@@ -67,17 +40,28 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
     }
 
     async function getPullRequests(fromTag: string, githubRepo: string): Promise<readonly PullRequest[]> {
-        const pullRequestTitleReader: PullRequestTitleReader = {
-            async getTitle(repo, pullRequestId) {
-                return fetchPullRequestTitle(githubClient, repo, pullRequestId);
-            }
-        };
-
         return collectMergedPullRequests({
             githubRepo,
             baseRef: fromTag,
             git: gitCommandRunner,
-            pullRequestTitleReader
+            pullRequestDataReader
+        });
+    }
+
+    async function readLabels(
+        config: PrLogConfig,
+        githubRepo: string,
+        pullRequestId: number,
+        reader: PullRequestDataReader
+    ): Promise<readonly string[]> {
+        const cachedLabels = reader.readCachedPullRequestLabels(githubRepo, pullRequestId);
+        if (cachedLabels !== undefined) {
+            return cachedLabels;
+        }
+
+        return getPullRequestLabels(githubRepo, pullRequestId, {
+            ...dependencies,
+            maximumRateLimitRetryCount: config.maximumRateLimitRetryCount
         });
     }
 
@@ -98,10 +82,7 @@ export function getMergedPullRequestsFactory(dependencies: GetMergedPullRequests
             targetScopedLabelPattern: undefined,
             pullRequestLabelReader: {
                 async getLabels(repo, pullRequestId) {
-                    return getPullRequestLabels(repo, pullRequestId, {
-                        ...dependencies,
-                        maximumRateLimitRetryCount: config.maximumRateLimitRetryCount
-                    });
+                    return readLabels(config, repo, pullRequestId, pullRequestDataReader);
                 }
             }
         });

--- a/source/lib/git-command-runner.test.ts
+++ b/source/lib/git-command-runner.test.ts
@@ -272,68 +272,88 @@ test('getFirstParentCommitLogs() executes "git log" with the correct options', a
 
     assertExecutedCommand(
         execute,
-        'git log --first-parent --no-color --pretty=format:%H__||__%s__||__%b##$$@@$$## foo..HEAD'
+        'git log --first-parent --no-color --pretty=format:%H__||__%P__||__%s__||__%b##$$@@$$## foo..HEAD'
     );
 });
 
 test('getFirstParentCommitLogs() returns the parsed command output', async function () {
     const execute = fake.resolves({
-        stdout: 'hash-1__||__foo__||__bar##$$@@$$##\nhash-2__||__baz__||__qux##$$@@$$##\n\n'
+        stdout: [
+            'hash-1__||__parent-1__||__foo__||__bar##$$@@$$##',
+            'hash-2__||__parent-2 parent-3__||__baz__||__qux##$$@@$$##',
+            '',
+            ''
+        ]
+            .join('\n')
     });
     const runner = gitCommandRunnerFactory({ execute });
 
     const result = await runner.getFirstParentCommitLogs('');
 
     assert.deepStrictEqual(result, [
-        { hash: 'hash-1', subject: 'foo', body: 'bar' },
-        { hash: 'hash-2', subject: 'baz', body: 'qux' }
+        { hash: 'hash-1', parents: [ 'parent-1' ], subject: 'foo', body: 'bar' },
+        { hash: 'hash-2', parents: [ 'parent-2', 'parent-3' ], subject: 'baz', body: 'qux' }
     ]);
 });
 
 test('getFirstParentCommitLogs() parses multi-line message bodies correctly', async function () {
     const execute = fake.resolves({
-        stdout: 'hash-1__||__foo__||__bar\nbaz\nqux##$$@@$$##\nhash-2__||__baz__||__qux##$$@@$$##\n\n'
+        stdout: [
+            'hash-1__||__parent-1__||__foo__||__bar',
+            'baz',
+            'qux##$$@@$$##',
+            'hash-2__||__parent-2__||__baz__||__qux##$$@@$$##',
+            '',
+            ''
+        ]
+            .join('\n')
     });
     const runner = gitCommandRunnerFactory({ execute });
 
     const result = await runner.getFirstParentCommitLogs('');
 
     assert.deepStrictEqual(result, [
-        { hash: 'hash-1', subject: 'foo', body: 'bar\nbaz\nqux' },
-        { hash: 'hash-2', subject: 'baz', body: 'qux' }
+        { hash: 'hash-1', parents: [ 'parent-1' ], subject: 'foo', body: 'bar\nbaz\nqux' },
+        { hash: 'hash-2', parents: [ 'parent-2' ], subject: 'baz', body: 'qux' }
     ]);
 });
 
 test('getFirstParentCommitLogs() parses multi-line bodies correctly when it doesn’t end with a line break', async function () {
     const execute = fake.resolves({
-        stdout: 'hash-1__||__foo__||__bar\nbaz\nqux##$$@@$$##\nhash-2__||__baz__||__qux##$$@@$$##'
+        stdout: [
+            'hash-1__||__parent-1__||__foo__||__bar',
+            'baz',
+            'qux##$$@@$$##',
+            'hash-2__||__parent-2__||__baz__||__qux##$$@@$$##'
+        ]
+            .join('\n')
     });
     const runner = gitCommandRunnerFactory({ execute });
 
     const result = await runner.getFirstParentCommitLogs('');
 
     assert.deepStrictEqual(result, [
-        { hash: 'hash-1', subject: 'foo', body: 'bar\nbaz\nqux' },
-        { hash: 'hash-2', subject: 'baz', body: 'qux' }
+        { hash: 'hash-1', parents: [ 'parent-1' ], subject: 'foo', body: 'bar\nbaz\nqux' },
+        { hash: 'hash-2', parents: [ 'parent-2' ], subject: 'baz', body: 'qux' }
     ]);
 });
 
 test('getFirstParentCommitLogs() falls back to undefined when the body couldn’t be extracted', async function () {
-    const execute = fake.resolves({ stdout: 'hash-1__||__foo##$$@@$$##\n\n\n' });
+    const execute = fake.resolves({ stdout: 'hash-1__||__parent-1__||__foo##$$@@$$##\n\n\n' });
     const runner = gitCommandRunnerFactory({ execute });
 
     const result = await runner.getFirstParentCommitLogs('');
 
-    assert.deepStrictEqual(result, [ { hash: 'hash-1', subject: 'foo', body: undefined } ]);
+    assert.deepStrictEqual(result, [ { hash: 'hash-1', parents: [ 'parent-1' ], subject: 'foo', body: undefined } ]);
 });
 
 test('getFirstParentCommitLogs() falls back to undefined when the body is an empty string', async function () {
-    const execute = fake.resolves({ stdout: 'hash-1__||__foo__||__##$$@@$$##\n\n\n' });
+    const execute = fake.resolves({ stdout: 'hash-1__||__parent-1__||__foo__||__##$$@@$$##\n\n\n' });
     const runner = gitCommandRunnerFactory({ execute });
 
     const result = await runner.getFirstParentCommitLogs('');
 
-    assert.deepStrictEqual(result, [ { hash: 'hash-1', subject: 'foo', body: undefined } ]);
+    assert.deepStrictEqual(result, [ { hash: 'hash-1', parents: [ 'parent-1' ], subject: 'foo', body: undefined } ]);
 });
 
 test('getFirstParentCommitLogs() throws when the commit subject cannot be determined', async function () {

--- a/source/lib/git-command-runner.ts
+++ b/source/lib/git-command-runner.ts
@@ -14,12 +14,23 @@ type MergeCommitLogEntry = {
 
 type FirstParentCommitLogEntry = {
     readonly hash: string;
+    readonly parents: readonly string[];
     readonly subject: string;
     readonly body: string | undefined;
 };
 
-type FirstParentCommitLogFields = readonly [hash: string, subject: string, body: string | undefined];
-type FirstParentCommitLogParts = readonly [hash: string, subject: string, ...remainingFields: readonly string[]];
+type FirstParentCommitLogFields = readonly [
+    hash: string,
+    parents: readonly string[],
+    subject: string,
+    body: string | undefined
+];
+type FirstParentCommitLogParts = readonly [
+    hash: string,
+    parents: string,
+    subject: string,
+    ...remainingFields: readonly string[]
+];
 
 export type GitCommandRunner = {
     getShortStatus: () => Promise<string>;
@@ -72,8 +83,8 @@ function splitLines(value: string, lineSeparator = '\n'): readonly string[] {
 
 const lineSeparator = '##$$@@$$##';
 const fieldSeparator = '__||__';
-const minimumCommitLogFieldCount = 2;
-const bodyFieldIndex = 2;
+const minimumCommitLogFieldCount = 3;
+const bodyFieldIndex = 3;
 
 function createParsableMergeGitLogFormat(): string {
     const subjectPlaceholder = '%s';
@@ -85,9 +96,10 @@ function createParsableMergeGitLogFormat(): string {
 
 function createParsableFirstParentGitLogFormat(): string {
     const hashPlaceholder = '%H';
+    const parentPlaceholder = '%P';
     const subjectPlaceholder = '%s';
     const bodyPlaceholder = '%b';
-    const fields = [ hashPlaceholder, subjectPlaceholder, bodyPlaceholder ];
+    const fields = [ hashPlaceholder, parentPlaceholder, subjectPlaceholder, bodyPlaceholder ];
 
     return `${fields.join(fieldSeparator)}${lineSeparator}`;
 }
@@ -113,10 +125,11 @@ function parseFirstParentCommitLogFields(log: string): FirstParentCommitLogField
         throw new TypeError('Failed to determine git commit log entry');
     }
 
-    const [ hash, subject ] = parts;
+    const [ hash, parentsField, subject ] = parts;
     const body = parts[bodyFieldIndex];
+    const parents = splitByString(parentsField, ' ').filter(isNonEmptyString);
 
-    return [ hash, subject, body ];
+    return [ hash, parents, subject, body ];
 }
 
 async function readShortStatus(execute: GitCommandExecutor): Promise<string> {
@@ -186,8 +199,8 @@ async function readFirstParentCommitLogs(
 
     const logs = splitLines(result.stdout, lineSeparator);
     return logs.map(function (log) {
-        const [ hash, subject, body ] = parseFirstParentCommitLogFields(log);
-        return { hash, subject, body: body === '' ? undefined : body };
+        const [ hash, parents, subject, body ] = parseFirstParentCommitLogFields(log);
+        return { hash, parents, subject, body: body === '' ? undefined : body };
     });
 }
 

--- a/source/lib/pull-request-data.test.ts
+++ b/source/lib/pull-request-data.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert';
+import { fake, stub } from 'sinon';
+import { createPullRequestDataReader } from './collect-merged-pull-requests.ts';
+
+type GitHubPullRequestDataOverrides = {
+    readonly title: string;
+    readonly merged: boolean;
+    readonly mergeCommitSha: string | null;
+    readonly labels: readonly string[];
+};
+
+type GitHubPullRequestData = {
+    readonly title: string;
+    readonly merged: boolean;
+    readonly merge_commit_sha: string | null;
+    readonly labels: readonly { readonly name: string; }[];
+};
+
+type GitHubPullRequestDataResponse = {
+    readonly data: GitHubPullRequestData;
+};
+
+type ResolveGitHubPullRequestData = (response: GitHubPullRequestDataResponse) => void;
+
+type RejectGitHubPullRequestData = (reason: unknown) => void;
+
+type GitHubPullRequestDataThenable = {
+    readonly then: (
+        resolve: ResolveGitHubPullRequestData,
+        reject: RejectGitHubPullRequestData
+    ) => void;
+};
+
+function createGitHubPullRequestData(overrides: GitHubPullRequestDataOverrides): GitHubPullRequestData {
+    return {
+        title: overrides.title,
+        merged: overrides.merged,
+        merge_commit_sha: overrides.mergeCommitSha,
+        labels: overrides.labels.map(function (label) {
+            return { name: label };
+        })
+    };
+}
+
+function failUninitializedPullRequestDataResolution(): never {
+    throw new Error('Pull request data resolution was called before initialization');
+}
+
+test('reads pull request data from GitHub', async function () {
+    const get = fake.resolves({
+        data: createGitHubPullRequestData({
+            title: 'Open the starlit gate',
+            merged: true,
+            mergeCommitSha: 'quest-hash',
+            labels: [ 'feature', 'enchanted' ]
+        })
+    });
+    const reader = createPullRequestDataReader({ pulls: { get } });
+
+    assert.deepStrictEqual(await reader.readPullRequestData('owner/repo', 731), {
+        title: 'Open the starlit gate',
+        merged: true,
+        mergeCommitSha: 'quest-hash',
+        labels: [ 'feature', 'enchanted' ]
+    });
+    assert.deepStrictEqual(get.firstCall.args, [ { owner: 'owner', repo: 'repo', pull_number: 731 } ]);
+});
+
+test('returns undefined when GitHub returns not found', async function () {
+    const get = stub().rejects(Object.assign(new Error('Not Found'), { status: 404 }));
+    const reader = createPullRequestDataReader({ pulls: { get } });
+
+    assert.strictEqual(await reader.readPullRequestData('owner/repo', 618), undefined);
+});
+
+test('throws when GitHub returns an error other than not found', async function () {
+    const get = stub().rejects(Object.assign(new Error('GitHub failed'), { status: 500 }));
+    const reader = createPullRequestDataReader({ pulls: { get } });
+
+    await assert.rejects(reader.readPullRequestData('owner/repo', 942), { message: 'GitHub failed' });
+});
+
+test('throws when GitHub returns a non-error rejection', async function () {
+    const rejectedPullRequestData: GitHubPullRequestDataThenable = {
+        then(_resolve, reject) {
+            reject({ message: 'GitHub failed' });
+        }
+    };
+    const get = fake(async function (): Promise<GitHubPullRequestDataResponse> {
+        return rejectedPullRequestData as unknown as GitHubPullRequestDataResponse;
+    });
+    const reader = createPullRequestDataReader({ pulls: { get } });
+
+    await assert.rejects(
+        reader.readPullRequestData('owner/repo', 853),
+        { message: 'GitHub failed' }
+    );
+});
+
+test('reuses cached pull request data', async function () {
+    const get = fake.resolves({
+        data: createGitHubPullRequestData({
+            title: 'Summon the silver beacon',
+            merged: true,
+            mergeCommitSha: 'beacon-hash',
+            labels: [ 'bug' ]
+        })
+    });
+    const reader = createPullRequestDataReader({ pulls: { get } });
+
+    await reader.readPullRequestData('owner/repo', 386);
+    await reader.readPullRequestData('owner/repo', 386);
+
+    assert.strictEqual(get.callCount, 1);
+    assert.deepStrictEqual(reader.readCachedPullRequestLabels('owner/repo', 386), [ 'bug' ]);
+});
+
+test('reuses pending pull request data reads', async function () {
+    let resolvePullRequestData: (response: GitHubPullRequestDataResponse) => void =
+        failUninitializedPullRequestDataResolution;
+    const pullRequestData = new Promise<GitHubPullRequestDataResponse>(function (resolve) {
+        resolvePullRequestData = resolve;
+    });
+    const get = fake.returns(pullRequestData);
+    const reader = createPullRequestDataReader({ pulls: { get } });
+
+    const firstRead = reader.readPullRequestData('owner/repo', 274);
+    const secondRead = reader.readPullRequestData('owner/repo', 274);
+    resolvePullRequestData({
+        data: createGitHubPullRequestData({
+            title: 'Chart the hidden realm',
+            merged: true,
+            mergeCommitSha: 'realm-hash',
+            labels: [ 'feature' ]
+        })
+    });
+
+    assert.deepStrictEqual(await firstRead, await secondRead);
+    assert.strictEqual(get.callCount, 1);
+});

--- a/source/packages/command-line-interface/README.md
+++ b/source/packages/command-line-interface/README.md
@@ -49,6 +49,11 @@ To use `pr-log` your GitHub project needs some small configuration:
 - Set the correct label on your pull requests. You need to set exactly one label. Multiple labels or one that is not recognized will throw an error.
 - Use correct semver versioning for your tags, for example `2.4.7`.
 
+`pr-log` collects pull requests from the first-parent Git history.
+It supports standard GitHub merge commits and single-parent commits whose subject ends with `(#123)`.
+For those suffix commits, `pr-log` verifies that GitHub reports the pull request as merged and that its `merge_commit_sha` matches the commit hash.
+Two-parent commits with custom `Title (#123)` messages are ignored.
+
 ### Project
 
 As `pr-log` reads repository information from your project you have to add the `repository` information in your `package.json`.

--- a/source/packages/core/README.md
+++ b/source/packages/core/README.md
@@ -26,6 +26,11 @@ Set `githubApiBaseUrl` only when GitHub API requests must be routed to a compati
 `@pr-log/core` owns Git/GitHub range resolution, pull request collection, label resolution, changed-file lookup, changelog rendering, release-section extraction, and changelog Markdown merging.
 Target impact and release planning stay outside pr-log. Consumers pass target source files into pr-log when they need target-specific changelogs.
 
+Pull request collection reads first-parent Git history.
+It supports standard GitHub merge commits and single-parent commits whose subject ends with `(#123)`.
+For those suffix commits, pr-log verifies that GitHub reports the pull request as merged and that its `merge_commit_sha` matches the commit hash.
+Two-parent commits with custom `Title (#123)` messages are ignored.
+
 A target-aware integration usually follows this flow:
 
 1. Compute release targets and their source files.


### PR DESCRIPTION
Treat `Title (#123)` commits as merged pull requests only when the first-parent log shows a single parent and the GitHub PR response confirms that `merge_commit_sha` is the commit hash.

This filters regular merge commits with custom `(#123)` subjects before API lookup, while reusing fetched PR data for labels.