### PR TITLE
Remove obsolete `@packtory/cli` release Git config

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,7 +124,7 @@ jobs:
             (github.event_name == 'workflow_dispatch' && inputs.release_pull_request_number != '')
         uses: ./.github/workflows/release-publish.yml
         permissions:
-            contents: write # required to push release tags and create GitHub releases
+            contents: write # required to create release tags and GitHub releases
             id-token: write # required by npm trusted publishing to mint the OIDC token
             pull-requests: read # required to validate release PR identity before publishing
         with:
@@ -162,11 +162,6 @@ jobs:
 
             - name: Install dependencies
               run: npm clean-install --ignore-scripts
-
-            - name: Configure release author
-              run: |
-                  git config user.name 'github-actions[bot]'
-                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
             - name: Maintain release pull request
               env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Publish release
         permissions:
-            contents: write # required to push release tags and create GitHub releases
+            contents: write # required to create release tags and GitHub releases
             id-token: write # required by npm trusted publishing to mint the OIDC token
             pull-requests: read # required to validate release PR identity before publishing
         steps:
@@ -108,13 +108,6 @@ jobs:
                   }
                   NODE
 
-            - name: Configure release author
-              if: steps.publish-target.outputs.should_publish == 'true'
-              working-directory: target/release-source
-              run: |
-                  git config user.name 'github-actions[bot]'
-                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
             - name: Publish packages
               if: steps.publish-target.outputs.should_publish == 'true'
               working-directory: target/release-source
@@ -122,7 +115,6 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
               run: |
                   mkdir -p target/release
-                  git config remote.origin.push 'refs/tags/*:refs/tags/*'
 
                   set +e
                   "$GITHUB_WORKSPACE/node_modules/.bin/packtory" release --publish --tag --push --github-release --no-dry-run 2>&1 | tee target/release/publish.log


### PR DESCRIPTION
`@packtory/cli` now creates release PR commits, release tags, and GitHub releases through the GitHub API, so the workflows no longer need local Git author setup or a tag push refspec.

The release command still keeps `--push` because Packtory requires it with `--github-release`.