### PR TITLE
Configure Packtory changelogs to collapse `upgrade` entries

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -114,6 +114,16 @@ export async function buildConfig() {
         registrySettings: registrySettings(),
         changelog: {
             packageTagFormat: '{packageName}@{version}',
+            prLog: {
+                ignoredLabels: [ 'release' ],
+                collapseRules: [
+                    {
+                        label: 'upgrade',
+                        pattern: '^⬆️ Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
+                        replace: '⬆️ Update dependency $<dependency> from $<from> to $<to>'
+                    }
+                ]
+            },
             outputs: [
                 {
                     kind: 'package-file',


### PR DESCRIPTION
Packtory now passes `pr-log` settings that ignore release PRs and collapse consecutive dependency upgrade PRs into one changelog entry. This keeps generated package changelogs concise when a release includes multiple incremental dependency updates.