### PR TITLE
Revert Packtory declaration workarounds

### DIFF
--- a/source/lib/cli-run-options.ts
+++ b/source/lib/cli-run-options.ts
@@ -1,13 +1,13 @@
-import { nothing, of } from 'true-myth/maybe';
+import { nothing, of, type Just, type Nothing } from 'true-myth/maybe';
 import { err, ok, type Result } from 'true-myth/result';
 import { isString } from '@sindresorhus/is';
 import { InvalidArgumentError } from 'commander';
-import { createVersionNumber, type MissingVersionNumber, type VersionNumber } from './version-number.ts';
+import { createVersionNumber } from './version-number.ts';
 
 type CliRunOptionsUnreleased = {
     readonly unreleased: true;
     readonly autoVersion: false;
-    readonly versionNumber: MissingVersionNumber;
+    readonly versionNumber: Nothing<string>;
     readonly changelogPath: string;
     readonly sloppy: boolean;
     readonly stdout: boolean;
@@ -16,7 +16,7 @@ type CliRunOptionsUnreleased = {
 type CliRunOptionsReleasedExplicit = {
     readonly unreleased: false;
     readonly autoVersion: false;
-    readonly versionNumber: VersionNumber;
+    readonly versionNumber: Just<string>;
     readonly changelogPath: string;
     readonly sloppy: boolean;
     readonly stdout: boolean;
@@ -25,7 +25,7 @@ type CliRunOptionsReleasedExplicit = {
 type CliRunOptionsReleasedAuto = {
     readonly unreleased: false;
     readonly autoVersion: true;
-    readonly versionNumber: MissingVersionNumber;
+    readonly versionNumber: Nothing<string>;
     readonly changelogPath: string;
     readonly sloppy: boolean;
     readonly stdout: boolean;

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -1,9 +1,9 @@
 import { format as formatDate } from 'date-fns';
 import { isArray } from '@sindresorhus/is';
 import { enUS as enLocale } from 'date-fns/locale/en-US';
+import type { Just, Nothing } from 'true-myth/maybe';
 import type { CollapseRule, PrLogConfig } from './pr-log-config.ts';
 import type { ChangelogEntryInput } from './render-changelog-markdown.ts';
-import type { MissingVersionNumber, VersionNumber } from './version-number.ts';
 
 function formatLinkToPullRequest(pullRequestId: number, repo: string): string {
     return `[#${pullRequestId}](https://github.com/${repo}/pull/${pullRequestId})`;
@@ -290,14 +290,14 @@ type Dependencies = {
 
 type ChangelogOptionsUnreleased = {
     readonly unreleased: true;
-    readonly versionNumber: MissingVersionNumber;
+    readonly versionNumber: Nothing<string>;
     readonly mergedPullRequests: readonly ChangelogEntryInput[];
     readonly githubRepo: string;
 };
 
 type ChangelogOptionsReleased = {
     readonly unreleased: false;
-    readonly versionNumber: VersionNumber;
+    readonly versionNumber: Just<string>;
     readonly mergedPullRequests: readonly ChangelogEntryInput[];
     readonly githubRepo: string;
 };

--- a/source/lib/filter-pull-requests-by-target-files.ts
+++ b/source/lib/filter-pull-requests-by-target-files.ts
@@ -1,12 +1,5 @@
-type PullRequest = {
-    readonly id: number;
-    readonly title: string;
-};
-
-type PullRequestChangedFile = {
-    readonly path: string;
-    readonly previousPath: string | undefined;
-};
+import type { PullRequest } from './collect-merged-pull-requests.ts';
+import type { PullRequestChangedFile } from './pull-request-changed-files.ts';
 
 export type FilterPullRequestsByTargetFilesInput = {
     readonly targetName: string;

--- a/source/lib/get-merged-pull-requests.ts
+++ b/source/lib/get-merged-pull-requests.ts
@@ -1,106 +1,26 @@
+import type { Octokit } from '@octokit/rest';
+import type { GetPullRequestLabels } from './get-pull-request-label.ts';
+import type { GitCommandRunner } from './git-command-runner.ts';
 import { resolveLatestSemverTagBaseRef } from './changelog-base-ref.ts';
 import {
     collectMergedPullRequests,
     createPullRequestDataReader,
-    type PullRequestDataReader
+    type PullRequestDataReader,
+    type PullRequest as PullRequestValue
 } from './collect-merged-pull-requests.ts';
-import { resolvePullRequestLabels } from './resolve-pull-request-labels.ts';
+import {
+    resolvePullRequestLabels,
+    type PullRequestWithLabel as PullRequestWithLabelValue
+} from './resolve-pull-request-labels.ts';
+import type { PrLogConfig } from './pr-log-config.ts';
 
-type GitHubLabel = {
-    readonly name: string;
-};
-
-type PullRequestDataRequest = {
-    readonly owner: string;
-    readonly repo: string;
-    readonly pull_number: number;
-};
-
-type PullRequestLabelRequest = {
-    readonly owner: string;
-    readonly repo: string;
-    readonly issue_number: number;
-};
-
-type GitHubPullRequestData = {
-    readonly title: string;
-    readonly merged: boolean;
-    readonly merge_commit_sha: string | null;
-    readonly labels: readonly GitHubLabel[];
-};
-
-type GitHubClient = {
-    readonly pulls: {
-        readonly get: (request: PullRequestDataRequest) => Promise<{
-            readonly data: GitHubPullRequestData;
-        }>;
-    };
-    readonly issues: {
-        readonly listLabelsOnIssue: (request: PullRequestLabelRequest) => Promise<{
-            readonly data: readonly GitHubLabel[];
-        }>;
-    };
-};
-
-type GitCommandRunner = {
-    listTags: () => Promise<readonly string[]>;
-    getFirstParentCommitLogs: (from: string) => Promise<readonly FirstParentCommitLogEntry[]>;
-};
-
-type FirstParentCommitLogEntry = {
-    readonly hash: string;
-    readonly parents: readonly string[];
-    readonly subject: string;
-    readonly body: string | undefined;
-};
-
-type GetPullRequestLabelsDependencies = {
-    readonly githubClient: GitHubClient;
-    readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
-    readonly getCurrentDate: () => Readonly<Date>;
-    readonly maximumRateLimitRetryCount: number;
-};
-
-type GetPullRequestLabels = (
-    githubRepo: string,
-    pullRequestId: number,
-    dependencies: GetPullRequestLabelsDependencies
-) => Promise<readonly string[]>;
-
-type VersionBumpLevel = 'major' | 'minor' | 'patch';
-type VersionBumpConfig = Readonly<Record<VersionBumpLevel, readonly string[]>>;
-type CollapseRule = {
-    readonly label: string;
-    readonly pattern: RegExp;
-    readonly replace: string;
-    readonly keyGroup: string;
-    readonly fromGroup: string;
-    readonly toGroup: string;
-};
-
-type PrLogConfig = {
-    readonly validLabels: ReadonlyMap<string, string>;
-    readonly ignoredLabels: readonly string[];
-    readonly versionBumps: VersionBumpConfig;
-    readonly dateFormat: string | undefined;
-    readonly collapseRules: readonly CollapseRule[];
-    readonly labelLookupIntervalMilliseconds: number;
-    readonly maximumRateLimitRetryCount: number;
-};
-
-export type PullRequest = {
-    readonly id: number;
-    readonly title: string;
-};
-
-export type PullRequestWithLabel = PullRequest & {
-    readonly label: string;
-};
+export type PullRequest = PullRequestValue;
+export type PullRequestWithLabel = PullRequestWithLabelValue;
 
 export type GetMergedPullRequestsDependencies = {
     readonly gitCommandRunner: GitCommandRunner;
     readonly getPullRequestLabels: GetPullRequestLabels;
-    readonly githubClient: GitHubClient;
+    readonly githubClient: Octokit;
     readonly waitForMilliseconds: (durationMilliseconds: number) => Promise<void>;
     readonly getCurrentDate: () => Readonly<Date>;
 };

--- a/source/lib/get-pull-request-label.ts
+++ b/source/lib/get-pull-request-label.ts
@@ -1,10 +1,7 @@
 import { isError, isFiniteNumber, isString } from '@sindresorhus/is';
 import { of } from 'true-myth/maybe';
 import { splitByString } from './split.ts';
-
-type PullRequestLabelReader = {
-    getLabels: (githubRepo: string, pullRequestId: number) => Promise<readonly string[]>;
-};
+import type { PullRequestLabelReader } from './resolve-pull-request-labels.ts';
 
 export type GitHubPullRequestLabelReaderDependencies = {
     readonly githubClient: GitHubPullRequestLabelClient;

--- a/source/lib/pr-log-config.ts
+++ b/source/lib/pr-log-config.ts
@@ -2,12 +2,11 @@ import { isArray, isPlainObject, isString } from '@sindresorhus/is';
 import { defaultValidLabels } from './valid-labels.ts';
 import {
     createDefaultVersionBumpConfig,
-    parseVersionBumpConfig
+    parseVersionBumpConfig,
+    type VersionBumpConfig
 } from './version-bump-config.ts';
 
 type PackageInfo = Readonly<Record<string, unknown>>;
-type VersionBumpLevel = 'major' | 'minor' | 'patch';
-type VersionBumpConfig = Readonly<Record<VersionBumpLevel, readonly string[]>>;
 
 export type CollapseRule = {
     readonly label: string;

--- a/source/lib/propose-version-number.ts
+++ b/source/lib/propose-version-number.ts
@@ -1,12 +1,6 @@
 import semver from 'semver';
-
-type VersionBumpLevel = 'major' | 'minor' | 'patch';
-type VersionBumpConfig = Readonly<Record<VersionBumpLevel, readonly string[]>>;
-type PullRequestWithLabel = {
-    readonly id: number | undefined;
-    readonly title: string;
-    readonly label: string;
-};
+import type { PullRequestWithLabel } from './get-merged-pull-requests.ts';
+import type { VersionBumpConfig, VersionBumpLevel } from './version-bump-config.ts';
 
 const orderedVersionBumpLevels: readonly VersionBumpLevel[] = [ 'major', 'minor', 'patch' ];
 

--- a/source/lib/pull-request-changed-files.ts
+++ b/source/lib/pull-request-changed-files.ts
@@ -1,7 +1,4 @@
-type PullRequest = {
-    readonly id: number;
-    readonly title: string;
-};
+import type { PullRequest } from './collect-merged-pull-requests.ts';
 
 export type PullRequestChangedFile = {
     readonly path: string;

--- a/source/lib/render-changelog-markdown.ts
+++ b/source/lib/render-changelog-markdown.ts
@@ -1,5 +1,5 @@
 import { nothing } from 'true-myth/maybe';
-import { err, ok } from 'true-myth/result';
+import { err, ok, type Result } from 'true-myth/result';
 import { createChangelogFactory, formatChangelogDate } from './create-changelog.ts';
 import type { PrLogConfig } from './pr-log-config.ts';
 import type { PullRequestWithLabel } from './resolve-pull-request-labels.ts';
@@ -77,21 +77,7 @@ export type ReleaseSectionNotFound = {
     readonly versionNumber: string;
 };
 
-type SuccessfulResult<Value> = {
-    readonly isOk: true;
-    readonly isErr: false;
-    readonly value: Value;
-};
-
-type FailedResult<ErrorValue> = {
-    readonly isOk: false;
-    readonly isErr: true;
-    readonly error: ErrorValue;
-};
-
-export type ExtractChangelogReleaseSectionResult =
-    | FailedResult<ReleaseSectionNotFound>
-    | SuccessfulResult<string>;
+export type ExtractChangelogReleaseSectionResult = Result<string, ReleaseSectionNotFound>;
 
 type ChangelogReleaseHeading = {
     readonly startIndex: number;

--- a/source/lib/resolve-pull-request-labels.ts
+++ b/source/lib/resolve-pull-request-labels.ts
@@ -1,7 +1,4 @@
-type PullRequest = {
-    readonly id: number;
-    readonly title: string;
-};
+import type { PullRequest } from './collect-merged-pull-requests.ts';
 
 export type PullRequestWithLabel = PullRequest & {
     readonly label: string;

--- a/source/lib/resolve-version-number.ts
+++ b/source/lib/resolve-version-number.ts
@@ -1,7 +1,8 @@
+import type { Just } from 'true-myth/maybe';
 import type { PullRequestWithLabel } from './get-merged-pull-requests.ts';
 import type { PrLogConfig } from './pr-log-config.ts';
 import { proposeVersionNumber } from './propose-version-number.ts';
-import { createVersionNumber, type VersionNumber } from './version-number.ts';
+import { createVersionNumber } from './version-number.ts';
 
 export type GetLatestVersionTag = () => Promise<string>;
 
@@ -9,7 +10,7 @@ export async function resolveReleasedVersionNumber(
     config: PrLogConfig,
     getLatestVersionTag: GetLatestVersionTag,
     mergedPullRequests: readonly PullRequestWithLabel[]
-): Promise<VersionNumber> {
+): Promise<Just<string>> {
     const versionNumber = proposeVersionNumber(
         await getLatestVersionTag(),
         mergedPullRequests,

--- a/source/lib/version-number.ts
+++ b/source/lib/version-number.ts
@@ -1,38 +1,25 @@
 import assert from 'node:assert';
 import semver from 'semver';
-import { just } from 'true-myth/maybe';
-import { err, ok } from 'true-myth/result';
+import { just, type Just, type Nothing } from 'true-myth/maybe';
+import { err, ok, type Result } from 'true-myth/result';
 import { Unit } from 'true-myth/unit';
-
-export type MissingVersionNumber = {
-    readonly isJust: false;
-    readonly isNothing: true;
-    unwrapOr: (defaultValue: unknown) => unknown;
-};
-
-export type VersionNumber = {
-    readonly isJust: true;
-    readonly isNothing: false;
-    readonly value: string;
-    unwrapOr: (defaultValue: unknown) => unknown;
-};
 
 type ValidateVersionNumberOptionsUnreleased = {
     readonly unreleased: true;
     readonly autoVersion: false;
-    readonly versionNumber: MissingVersionNumber;
+    readonly versionNumber: Nothing<string>;
 };
 
 type ValidateVersionNumberOptionsAuto = {
     readonly unreleased: false;
     readonly autoVersion: true;
-    readonly versionNumber: MissingVersionNumber;
+    readonly versionNumber: Nothing<string>;
 };
 
 type ValidateVersionNumberOptionsReleased = {
     readonly unreleased: false;
     readonly autoVersion: false;
-    readonly versionNumber: VersionNumber;
+    readonly versionNumber: Just<string>;
 };
 
 export type ValidateVersionNumberOptions =
@@ -40,11 +27,7 @@ export type ValidateVersionNumberOptions =
     | ValidateVersionNumberOptionsReleased
     | ValidateVersionNumberOptionsUnreleased;
 
-type VersionNumberValidationResult = {
-    unwrapOrElse: (onError: (error: Error) => unknown) => unknown;
-};
-
-export function createVersionNumber(value: string): VersionNumber {
+export function createVersionNumber(value: string): Just<string> {
     const versionNumber = just(value);
 
     assert.ok(versionNumber.isJust);
@@ -52,7 +35,7 @@ export function createVersionNumber(value: string): VersionNumber {
     return versionNumber;
 }
 
-export function validateVersionNumber(options: ValidateVersionNumberOptions): VersionNumberValidationResult {
+export function validateVersionNumber(options: ValidateVersionNumberOptions): Result<Unit, Error> {
     if (options.unreleased || options.autoVersion) {
         return ok(Unit);
     }

--- a/source/packages/core/core.entry-point.ts
+++ b/source/packages/core/core.entry-point.ts
@@ -4,234 +4,57 @@ import { execa } from 'execa';
 import { createGitHubPullRequestChangedFilesReader } from '../../lib/github-pull-request-changed-files.ts';
 import { createCommandStringExecutor, createGitCommandRunner } from '../../lib/git-command-runner.ts';
 import { getPullRequestLabels } from '../../lib/get-pull-request-label.ts';
-import { defaultPrLogConfig as defaultPrLogConfigValue } from '../../lib/pr-log-config.ts';
+import {
+    defaultPrLogConfig as defaultPrLogConfigValue,
+    type CollapseRule as CollapseRuleValue,
+    type PrLogConfig as PrLogConfigValue
+} from '../../lib/pr-log-config.ts';
 import { defaultValidLabels as defaultValidLabelsValue } from '../../lib/valid-labels.ts';
-import { createPrLogEngineWithDependencies } from '../../core/pr-log-engine.ts';
-import { createGitHubClient } from './github-client.ts';
-
-type GitHubClientOptions = {
-    readonly githubToken: string | undefined;
-    readonly githubApiBaseUrl?: string | undefined;
-};
-
-type VersionBumpLevel = 'major' | 'minor' | 'patch';
-type VersionBumpConfig = Readonly<Record<VersionBumpLevel, readonly string[]>>;
+import {
+    createPrLogEngineWithDependencies,
+    type ChangelogBaseRef as ChangelogBaseRefValue,
+    type CollectMergedPullRequestsOptions as CollectMergedPullRequestsOptionsValue,
+    type ChangelogEntryInput as ChangelogEntryInputValue,
+    type ExtractChangelogReleaseSectionInput as ExtractChangelogReleaseSectionInputValue,
+    type ExtractChangelogReleaseSectionResult as ExtractChangelogReleaseSectionResultValue,
+    type FilterPullRequestsByTargetFilesInput as FilterPullRequestsByTargetFilesInputValue,
+    type MissingChangelogBaseRefError as MissingChangelogBaseRefErrorValue,
+    type MissingChangelogBaseRefReason as MissingChangelogBaseRefReasonValue,
+    type PackageChangelogBaseRefInput as PackageChangelogBaseRefInputValue,
+    type LinklessChangelogEntry as LinklessChangelogEntryValue,
+    type PrLogEngine as PrLogEngineValue,
+    type PullRequest as PullRequestValue,
+    type PullRequestChangedFile as PullRequestChangedFileValue,
+    type PullRequestWithLabel as PullRequestWithLabelValue,
+    type ReadPullRequestChangedFilesOptions as ReadPullRequestChangedFilesOptionsValue,
+    type ReadPullRequestLabelsOptions as ReadPullRequestLabelsOptionsValue,
+    type RenderGroupedTargetChangelogMarkdownInput as RenderGroupedTargetChangelogMarkdownInputValue,
+    type RenderChangelogMarkdownInput as RenderChangelogMarkdownInputValue,
+    type RenderTargetChangelogMarkdownInput as RenderTargetChangelogMarkdownInputValue,
+    type ReleaseSectionNotFound as ReleaseSectionNotFoundValue,
+    type ResolveVersionNumberInput as ResolveVersionNumberInputValue,
+    type ResolvePullRequestLabelsOptions as ResolvePullRequestLabelsOptionsValue,
+    type TargetChangelogSection as TargetChangelogSectionValue,
+    type UpdateChangelogInput as UpdateChangelogInputValue
+} from '../../core/pr-log-engine.ts';
+import {
+    createGitHubClient,
+    type GitHubClientDependencies,
+    type GitHubClientOptions
+} from './github-client.ts';
 
 export type PrLogEngineOptions = GitHubClientOptions & {
     readonly workingDirectory: string;
-    readonly config: PrLogConfig;
-};
-
-export type CollapseRule = {
-    readonly label: string;
-    readonly pattern: RegExp;
-    readonly replace: string;
-    readonly keyGroup: string;
-    readonly fromGroup: string;
-    readonly toGroup: string;
-};
-
-export type PrLogConfig = {
-    readonly validLabels: ReadonlyMap<string, string>;
-    readonly ignoredLabels: readonly string[];
-    readonly versionBumps: VersionBumpConfig;
-    readonly dateFormat: string | undefined;
-    readonly collapseRules: readonly CollapseRule[];
-    readonly labelLookupIntervalMilliseconds: number;
-    readonly maximumRateLimitRetryCount: number;
-};
-
-export type ChangelogBaseRef = {
-    readonly ref: string;
-};
-
-export type MissingChangelogBaseRefReason = 'explicit-base-ref' | 'package-version-tag' | 'previous-git-head';
-
-export type MissingChangelogBaseRefError = Readonly<Error> & {
-    readonly name: 'MissingChangelogBaseRefError';
-    readonly packageName: string;
-    readonly ref: string | undefined;
-    readonly reason: MissingChangelogBaseRefReason;
-};
-
-export type PackageChangelogBaseRefInput = {
-    readonly packageName: string;
-    readonly previousVersion: string | undefined;
-    readonly previousGitHead: string | undefined;
-    readonly packageTagFormat: string | undefined;
-    readonly explicitBaseRef: string | undefined;
-};
-
-export type PullRequest = {
-    readonly id: number;
-    readonly title: string;
-};
-
-export type PullRequestChangedFile = {
-    readonly path: string;
-    readonly previousPath: string | undefined;
-    readonly status: string;
-    readonly additions: number;
-    readonly deletions: number;
-    readonly changes: number;
-};
-
-export type PullRequestWithLabel = PullRequest & {
-    readonly label: string;
-};
-
-export type FilterPullRequestsByTargetFilesInput = {
-    readonly targetName: string;
-    readonly targetSourceFiles: readonly string[];
-    readonly pullRequests: readonly PullRequest[];
-    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly PullRequestChangedFile[]>;
-    readonly ignoredAttributionPaths: readonly string[];
-};
-
-export type CollectMergedPullRequestsOptions = {
-    readonly githubRepo: string;
-    readonly baseRef: string;
-};
-
-export type ReadPullRequestChangedFilesOptions = {
-    readonly githubRepo: string;
-    readonly pullRequests: readonly PullRequest[];
-};
-
-export type ReadPullRequestLabelsOptions = {
-    readonly githubRepo: string;
-    readonly pullRequests: readonly PullRequest[];
-};
-
-export type ResolvePullRequestLabelsOptions = {
-    readonly githubRepo: string;
-    readonly config: PrLogConfig;
-    readonly pullRequests: readonly PullRequest[];
-    readonly targetName: string | undefined;
-    readonly targetScopedLabelPattern: string | undefined;
-};
-
-export type ResolveVersionNumberInput = {
-    readonly latestVersionTag: string;
-    readonly mergedPullRequests: readonly PullRequestWithLabel[];
-    readonly config: PrLogConfig;
-};
-
-export type LinklessChangelogEntry = {
-    readonly id: undefined;
-    readonly title: string;
-    readonly label: string;
-};
-
-export type ChangelogEntryInput = LinklessChangelogEntry | PullRequestWithLabel;
-
-type RenderChangelogMarkdownInputBase = {
-    readonly config: PrLogConfig;
-    readonly currentDate: Readonly<Date>;
-    readonly mergedPullRequests: readonly ChangelogEntryInput[];
-    readonly githubRepo: string;
-};
-
-type RenderReleasedChangelogMarkdownInput = RenderChangelogMarkdownInputBase & {
-    readonly unreleased: false;
-    readonly versionNumber: string;
-};
-
-type RenderUnreleasedChangelogMarkdownInput = RenderChangelogMarkdownInputBase & {
-    readonly unreleased: true;
-    readonly versionNumber: undefined;
-};
-
-export type RenderChangelogMarkdownInput =
-    | RenderReleasedChangelogMarkdownInput
-    | RenderUnreleasedChangelogMarkdownInput;
-
-type TargetChangelogSectionBase = {
-    readonly targetName: string;
-    readonly mergedPullRequests: readonly ChangelogEntryInput[];
-};
-
-type ReleasedTargetChangelogSection = TargetChangelogSectionBase & {
-    readonly unreleased: false;
-    readonly versionNumber: string;
-};
-
-type UnreleasedTargetChangelogSection = TargetChangelogSectionBase & {
-    readonly unreleased: true;
-    readonly versionNumber: undefined;
-};
-
-export type TargetChangelogSection = ReleasedTargetChangelogSection | UnreleasedTargetChangelogSection;
-
-export type RenderGroupedTargetChangelogMarkdownInput = {
-    readonly config: PrLogConfig;
-    readonly currentDate: Readonly<Date>;
-    readonly githubRepo: string;
-    readonly targets: readonly TargetChangelogSection[];
-};
-
-export type RenderTargetChangelogMarkdownInput = RenderChangelogMarkdownInputBase & TargetChangelogSection;
-
-export type UpdateChangelogInput = {
-    readonly existingChangelogMarkdown: string;
-    readonly generatedChangelogMarkdown: string;
-};
-
-export type ExtractChangelogReleaseSectionInput = {
-    readonly changelogMarkdown: string;
-    readonly targetName: string | undefined;
-    readonly versionNumber: string;
-};
-
-export type ReleaseSectionNotFound = {
-    readonly reason: 'release-section-not-found';
-    readonly targetName: string | undefined;
-    readonly versionNumber: string;
-};
-
-type SuccessfulResult<Value> = {
-    readonly isOk: true;
-    readonly isErr: false;
-    readonly value: Value;
-};
-
-type FailedResult<ErrorValue> = {
-    readonly isOk: false;
-    readonly isErr: true;
-    readonly error: ErrorValue;
-};
-
-export type ExtractChangelogReleaseSectionResult =
-    | FailedResult<ReleaseSectionNotFound>
-    | SuccessfulResult<string>;
-
-export type PrLogEngine = {
-    resolveLatestSemverChangelogBaseRef: () => Promise<ChangelogBaseRef>;
-    resolveChangelogBaseRef: (input: PackageChangelogBaseRefInput) => Promise<ChangelogBaseRef>;
-    collectMergedPullRequests: (input: CollectMergedPullRequestsOptions) => Promise<readonly PullRequest[]>;
-    readPullRequestChangedFiles: (
-        input: ReadPullRequestChangedFilesOptions
-    ) => Promise<ReadonlyMap<number, readonly PullRequestChangedFile[]>>;
-    readPullRequestLabels: (input: ReadPullRequestLabelsOptions) => Promise<ReadonlyMap<number, readonly string[]>>;
-    filterPullRequestsByTargetFiles: (input: FilterPullRequestsByTargetFilesInput) => readonly PullRequest[];
-    resolvePullRequestLabels: (input: ResolvePullRequestLabelsOptions) => Promise<readonly PullRequestWithLabel[]>;
-    resolveVersionNumber: (input: ResolveVersionNumberInput) => string;
-    extractChangelogReleaseSection: (
-        input: ExtractChangelogReleaseSectionInput
-    ) => ExtractChangelogReleaseSectionResult;
-    renderChangelog: (input: RenderChangelogMarkdownInput) => string;
-    renderTargetChangelog: (input: RenderTargetChangelogMarkdownInput) => string;
-    renderGroupedTargetChangelog: (input: RenderGroupedTargetChangelogMarkdownInput) => string;
-    updateChangelog: (input: UpdateChangelogInput) => string;
+    readonly config: PrLogConfigValue;
 };
 
 function createCurrentDate(): Readonly<Date> {
     return new Date();
 }
 
-const gitHubClientDependencies = { Octokit };
+const gitHubClientDependencies: GitHubClientDependencies = { Octokit };
 
-export function createPrLogEngine(options: Readonly<PrLogEngineOptions>): PrLogEngine {
+export function createPrLogEngine(options: Readonly<PrLogEngineOptions>): PrLogEngineValue {
     const githubClient = createGitHubClient(gitHubClientDependencies, options);
     const execute = createCommandStringExecutor({ executeFile: execa, workingDirectory: options.workingDirectory });
     const gitCommandRunner = createGitCommandRunner({ execute });
@@ -248,4 +71,31 @@ export function createPrLogEngine(options: Readonly<PrLogEngineOptions>): PrLogE
 }
 
 export const defaultValidLabels: ReadonlyMap<string, string> = new Map(defaultValidLabelsValue);
-export const defaultPrLogConfig: PrLogConfig = defaultPrLogConfigValue;
+export const defaultPrLogConfig: PrLogConfigValue = defaultPrLogConfigValue;
+
+export type ChangelogBaseRef = ChangelogBaseRefValue;
+export type ChangelogEntryInput = ChangelogEntryInputValue;
+export type CollapseRule = CollapseRuleValue;
+export type CollectMergedPullRequestsOptions = CollectMergedPullRequestsOptionsValue;
+export type ExtractChangelogReleaseSectionInput = ExtractChangelogReleaseSectionInputValue;
+export type ExtractChangelogReleaseSectionResult = ExtractChangelogReleaseSectionResultValue;
+export type FilterPullRequestsByTargetFilesInput = FilterPullRequestsByTargetFilesInputValue;
+export type MissingChangelogBaseRefError = MissingChangelogBaseRefErrorValue;
+export type MissingChangelogBaseRefReason = MissingChangelogBaseRefReasonValue;
+export type PackageChangelogBaseRefInput = PackageChangelogBaseRefInputValue;
+export type LinklessChangelogEntry = LinklessChangelogEntryValue;
+export type PrLogEngine = PrLogEngineValue;
+export type PrLogConfig = PrLogConfigValue;
+export type PullRequest = PullRequestValue;
+export type PullRequestChangedFile = PullRequestChangedFileValue;
+export type PullRequestWithLabel = PullRequestWithLabelValue;
+export type ReadPullRequestChangedFilesOptions = ReadPullRequestChangedFilesOptionsValue;
+export type ReadPullRequestLabelsOptions = ReadPullRequestLabelsOptionsValue;
+export type RenderGroupedTargetChangelogMarkdownInput = RenderGroupedTargetChangelogMarkdownInputValue;
+export type RenderChangelogMarkdownInput = RenderChangelogMarkdownInputValue;
+export type RenderTargetChangelogMarkdownInput = RenderTargetChangelogMarkdownInputValue;
+export type ReleaseSectionNotFound = ReleaseSectionNotFoundValue;
+export type ResolvePullRequestLabelsOptions = ResolvePullRequestLabelsOptionsValue;
+export type ResolveVersionNumberInput = ResolveVersionNumberInputValue;
+export type TargetChangelogSection = TargetChangelogSectionValue;
+export type UpdateChangelogInput = UpdateChangelogInputValue;


### PR DESCRIPTION
Reverts the source-level declaration workarounds from the Packtory update. The dependency bump and strict `typeScriptIntegrity` config remain in place now that Packtory handles the generated declaration graph.